### PR TITLE
[backend] - send invite email on vault invite

### DIFF
--- a/portal-api/src/modules/services/services.domain.ts
+++ b/portal-api/src/modules/services/services.domain.ts
@@ -1,3 +1,5 @@
+import config from 'config';
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { db, dbRaw, dbUnsecure, paginate } from '../../../knexfile';
 import {
@@ -8,19 +10,21 @@ import { OrganizationId } from '../../model/kanel/public/Organization';
 import { ServiceMutator } from '../../model/kanel/public/Service';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
 import Subscription from '../../model/kanel/public/Subscription';
-import User, { UserId } from '../../model/kanel/public/User';
+import User, { UserId, UserMutator } from '../../model/kanel/public/User';
 import UserService, {
   UserServiceId,
 } from '../../model/kanel/public/UserService';
 import { PortalContext } from '../../model/portal-context';
 import { ROLE_ADMIN_ORGA } from '../../portal.const';
+import { sendMail } from '../../server/mail-service';
 import { formatRawObject } from '../../utils/queryRaw.util';
 import { loadSubscription } from '../subcription/subscription.domain';
+import { loadSubscriptionBy } from '../subcription/subscription.helper';
 import {
   addAdminAccess,
   insertUserService,
 } from '../user_service/user_service.domain';
-import { loadUsersByOrganization } from '../users/users.domain';
+import { loadUserBy, loadUsersByOrganization } from '../users/users.domain';
 import { insertServiceCapability } from './instances/service-capabilities/service_capabilities.helper';
 
 export const loadPublicServices = async (context: PortalContext, opts) => {
@@ -279,6 +283,23 @@ export const grantServiceAccess = async (
     context,
     dataUserServices
   )) as [UserService];
+
+  const [subscription] = await loadSubscriptionBy('id', subscriptionId);
+  for (const userId of usersId) {
+    const user = await loadUserBy({ 'User.id': userId } as UserMutator);
+
+    const service = await loadServiceBy(context, 'id', subscription.service_id);
+    await sendMail({
+      to: user.email,
+      template: 'partnerVault',
+      params: {
+        name: user.email,
+        partnerVaultLink: `${config.get('base_url_front')}/service/vault/${toGlobalId('Service', service.id)}`,
+        partnerVault: service.name,
+        contactEmail: 'xtm-hub-support@filigran.io',
+      },
+    });
+  }
 
   for (const capability of capabilities) {
     const dataServiceCapabilities = insertedUserServices.map(

--- a/portal-api/src/modules/user_service/user-service.helper.ts
+++ b/portal-api/src/modules/user_service/user-service.helper.ts
@@ -1,3 +1,5 @@
+import config from 'config';
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { db, dbRaw, dbUnsecure } from '../../../knexfile';
 import { OrganizationId } from '../../model/kanel/public/Organization';
@@ -12,11 +14,14 @@ import UserService, {
   UserServiceInitializer,
   UserServiceMutator,
 } from '../../model/kanel/public/UserService';
+import { sendMail } from '../../server/mail-service';
 import { loadUserOrganization } from '../common/user-organization.helper';
+import { loadServiceBy } from '../services/services.domain';
 import {
   insertSubscription,
   loadUnsecureSubscriptionBy,
 } from '../subcription/subscription.helper';
+import { loadUserBy } from '../users/users.domain';
 
 export const loadUnsecureUserServiceBy = (field: UserServiceMutator) => {
   return dbUnsecure<UserService>('User_Service')
@@ -98,6 +103,20 @@ export const createUserServiceAccess = async (
       user_service_id: addedUserService.id,
       service_capability_name: capability,
     };
+
+    const user = await loadUserBy({ 'User.id': user_id });
+
+    const service = await loadServiceBy(context, 'id', subscription.service_id);
+    await sendMail({
+      to: user.email,
+      template: 'partnerVault',
+      params: {
+        name: user.email,
+        partnerVaultLink: `${config.get('base_url_front')}/service/vault/${toGlobalId('Service', service.id)}`,
+        partnerVault: service.name,
+        contactEmail: 'contact@filigran.io',
+      },
+    });
 
     await db<ServiceCapability>(context, 'Service_Capability')
       .insert(service_capa)

--- a/portal-api/src/server/mail-template/partnerVault.html
+++ b/portal-api/src/server/mail-template/partnerVault.html
@@ -136,7 +136,7 @@
                       Dear {{ name }},
                     </h1>
                     <p style="margin: 0; line-height: 24px">
-                      Welcome to the {{ partnerVault }}! We're thrilled to have
+                      Welcome to the Partner Vault! We're thrilled to have
                       you onboard and look forward to collaborating closely with
                       you.
                       <br />


### PR DESCRIPTION
# Context : 

When we add a user to the vault partner, we should send an email to the user. 

# How to test : 

On https://internxt.com/temporary-email, you have email with same domain. 
Create an admin_orga and a user in the same domain (open a private tab to have another email address with the same domain). 

As an admin PTF, add a subscription to the newly created admin_orga. 
You should receive an email : 

EMAIL OK 👌 
![image](https://github.com/user-attachments/assets/b1fd45b3-78af-4faa-9573-67ff2f47c81c)


Then, grant the access to a "simple" user. 

EMAIL OK 👌 

![image](https://github.com/user-attachments/assets/44dcd1c1-7d00-45dd-9c52-03fd0b25733b)


close #46 