### PR TITLE
[frontend/backend] - Remove service_capa admin_subscription

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -533,7 +533,6 @@ export type ServicePrice = Node & {
 
 export enum ServiceRestriction {
   AccessUser = 'ACCESS_USER',
-  AdminSubscription = 'ADMIN_SUBSCRIPTION',
   ManageAccess = 'MANAGE_ACCESS'
 }
 

--- a/portal-api/src/modules/services/services.graphql
+++ b/portal-api/src/modules/services/services.graphql
@@ -65,8 +65,8 @@ type Query {
   ): ServiceConnection! @auth(requires: [BYPASS])
   serviceById(service_id: ID): Service @auth
   serviceByIdWithSubscriptions(service_id: ID): Service
-    @auth
-    @service_capa(requires: [MANAGE_ACCESS, ADMIN_SUBSCRIPTION])
+  @auth
+  @service_capa(requires: [MANAGE_ACCESS])
 }
 
 type ServiceSubscription {

--- a/portal-api/src/modules/services/services.helper.ts
+++ b/portal-api/src/modules/services/services.helper.ts
@@ -32,7 +32,7 @@ export const loadUnsecureAllUserFromServiceForAWX = async (
       'User.email',
       dbRaw(`
       CASE 
-        WHEN array_agg("Service_Capability".service_capability_name) @> ARRAY['MANAGE_ACCESS', 'ADMIN_SUBSCRIPTION'] 
+        WHEN array_agg("Service_Capability".service_capability_name) @> ARRAY['MANAGE_ACCESS'] 
         THEN true 
         ELSE false 
       END as admin

--- a/portal-api/src/modules/subcription/subscription.graphql
+++ b/portal-api/src/modules/subcription/subscription.graphql
@@ -38,5 +38,5 @@ type Mutation {
     @auth(requires: [BYPASS])
   deleteSubscription(subscription_id: ID!): Service
     @auth(requires: [BCK_MANAGE_SERVICES])
-    @service_capa(requires: [MANAGE_ACCESS, ADMIN_SUBSCRIPTION])
+    @service_capa(requires: [MANAGE_ACCESS])
 }

--- a/portal-api/src/modules/subcription/subscription.resolver.ts
+++ b/portal-api/src/modules/subcription/subscription.resolver.ts
@@ -77,11 +77,7 @@ const resolvers: Resolvers = {
         return {
           ...filledSubscription.service,
           subscribed: true,
-          capabilities: [
-            'ACCESS_SERVICE',
-            'MANAGE_ACCESS',
-            'ADMIN_SUBSCRIPTION',
-          ],
+          capabilities: ['ACCESS_SERVICE', 'MANAGE_ACCESS'],
         };
       } catch (error) {
         await trx.rollback();

--- a/portal-api/src/modules/user_service/user_service.domain.ts
+++ b/portal-api/src/modules/user_service/user_service.domain.ts
@@ -228,11 +228,7 @@ export const addAdminAccess = async (
     subscription_id: subscriptionId,
   };
   const [userService] = await insertUserService(context, dataUserService);
-  const capabilities = [
-    'ACCESS_SERVICE',
-    'MANAGE_ACCESS',
-    'ADMIN_SUBSCRIPTION',
-  ];
+  const capabilities = ['ACCESS_SERVICE', 'MANAGE_ACCESS'];
   const dataCapabilities = capabilities.map((capability) => ({
     id: uuidv4() as ServiceCapabilityId,
     user_service_id: userService.id,

--- a/portal-api/src/nodes/node.graphql
+++ b/portal-api/src/nodes/node.graphql
@@ -19,7 +19,6 @@ directive @service_capa(
 
 enum ServiceRestriction {
   ACCESS_USER
-  ADMIN_SUBSCRIPTION
   MANAGE_ACCESS
 }
 

--- a/portal-api/tests/seeds/02-insert-services-community.js
+++ b/portal-api/tests/seeds/02-insert-services-community.js
@@ -65,11 +65,6 @@ export async function seed(knex) {
   await knex('Service_Capability')
     .insert([
       {
-        id: '706c2468-581e-4739-8d25-082c0a3f328d',
-        user_service_id: '4055e8a2-5ee2-4438-b422-62ff2e6c027f',
-        service_capability_name: 'ADMIN_SUBSCRIPTION',
-      },
-      {
         id: '51491107-5dc5-4aee-bca6-e07410844477',
         user_service_id: '4055e8a2-5ee2-4438-b422-62ff2e6c027f',
         service_capability_name: 'MANAGE_ACCESS',

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -385,7 +385,6 @@ enum Restriction {
 
 enum ServiceRestriction {
   ACCESS_USER
-  ADMIN_SUBSCRIPTION
   MANAGE_ACCESS
 }
 

--- a/portal-front/src/components/service/[slug]/service-slug-form-sheet.tsx
+++ b/portal-front/src/components/service/[slug]/service-slug-form-sheet.tsx
@@ -2,6 +2,7 @@ import { Portal, portalContext } from '@/components/portal-context';
 import { ServiceCapabilityCreateMutation } from '@/components/service/[slug]/capabilities/service-capability.graphql';
 import { UserServiceCreateMutation } from '@/components/service/user_service.graphql';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { UnknownIcon } from 'filigran-icon';
 import {
   Form,
   FormControl,
@@ -66,14 +67,6 @@ export const ServiceSlugFormSheet: FunctionComponent<
       label: 'ACCESS_SERVICE',
       value: 'ACCESS_SERVICE',
     },
-    ...(me?.capabilities.some((capability) => capability?.name === 'BYPASS')
-      ? [
-          {
-            label: 'ADMIN_SUBSCRIPTION',
-            value: 'ADMIN_SUBSCRIPTION',
-          },
-        ]
-      : []),
   ];
 
   const form = useForm<z.infer<ZodSchema>>({
@@ -184,7 +177,6 @@ export const ServiceSlugFormSheet: FunctionComponent<
                 )}
               />
             )}
-
             <FormField
               control={form.control}
               name="capabilities"
@@ -204,7 +196,6 @@ export const ServiceSlugFormSheet: FunctionComponent<
                 </FormItem>
               )}
             />
-
             <SheetFooter className="pt-2">
               <SheetClose asChild>
                 <Button variant="outline">Cancel</Button>
@@ -215,6 +206,20 @@ export const ServiceSlugFormSheet: FunctionComponent<
                 Validate
               </Button>
             </SheetFooter>
+            <div className="flex flex-row">
+              <div className="font-bold">Manage access</div>{' '}
+              <div className="flex items-center">
+                <UnknownIcon className="h-4 w-4 ml-s" />{' '}
+              </div>
+            </div>
+            You can access the service and invite users to this service
+            <div className="flex flex-row">
+              <div className="font-bold">Access service</div>
+              <div className="flex items-center">
+                <UnknownIcon className="h-4 w-4 ml-s" />
+              </div>
+            </div>
+            You just have access to a service
           </form>
         </Form>
       </SheetContent>

--- a/portal-front/src/components/service/[slug]/service-user-service-table.tsx
+++ b/portal-front/src/components/service/[slug]/service-user-service-table.tsx
@@ -93,7 +93,7 @@ const ServiceUserServiceSlug: FunctionComponent<ServiceUserServiceProps> = ({
             <>
               {row.original.service_capability?.some(
                 (serv_capa) =>
-                  serv_capa?.service_capability_name !== 'ADMIN_SUBSCRIPTION'
+                  serv_capa?.service_capability_name !== 'MANAGE_ACCESS'
               ) && (
                 <IconActions
                   icon={


### PR DESCRIPTION
# Context 
Should remove the service_capa admin_subscription since it is not usefull for now. 

Add more information on this service_capa usages : 

![image](https://github.com/user-attachments/assets/8ccc5f4a-0edb-4c87-8578-db0019244da5)


N.B : @EllynBsc  ok avec ce design
 
 Closes  #105