### PR TITLE
[frontend] - Add optimistic count on downloading document - issue174

### DIFF
--- a/portal-front/src/components/service/vault/download-document.tsx
+++ b/portal-front/src/components/service/vault/download-document.tsx
@@ -3,23 +3,25 @@ import useDecodedParams from '@/hooks/useDecodedParams';
 import { cn } from '@/lib/utils';
 import { buttonVariants } from 'filigran-ui/servers';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
 import { FunctionComponent, useContext } from 'react';
 import { documentItem_fragment$data } from '../../../../__generated__/documentItem_fragment.graphql';
 interface DownloadDocumentProps {
   documentData: documentItem_fragment$data;
+  downloadClicked: (documentId: string) => void;
 }
 
 export const DownloadDocument: FunctionComponent<DownloadDocumentProps> = ({
   documentData,
+  downloadClicked,
 }) => {
   const { setMenuOpen } = useContext(IconActionContext);
   const t = useTranslations();
   const { slug } = useDecodedParams();
   return (
-    <Link
+    <a
       href={`/document/get/${slug}/${documentData.id}`}
       onClick={(e) => {
+        downloadClicked(documentData.id);
         e.stopPropagation();
         setMenuOpen(false);
       }}
@@ -32,7 +34,7 @@ export const DownloadDocument: FunctionComponent<DownloadDocumentProps> = ({
         })
       )}>
       {t('Utils.Download')}
-    </Link>
+    </a>
   );
 };
 


### PR DESCRIPTION
# Context 
On the Vault partner, when you download a document, the download number was not automatically updated, you needed to refresh. 
On the Vault parnter, if you clicked on the Download button, the download number was incremented twice. 

# How to test 
Go on a vault partner. 
Download a document (with the row link and the button)
Check the download number has increased once each time (directly, and stay the same number if you refresh). 


Close #174 