### PR TITLE
[frontend/backend] fix: not authenticated message on not logged in user

### DIFF
--- a/portal-api/src/modules/users/users.graphql
+++ b/portal-api/src/modules/users/users.graphql
@@ -37,7 +37,7 @@ input UserFilter {
 }
 
 type Query {
-  me: User @auth
+  me: User
   user(id: ID!): User @auth
   users(
     first: Int!

--- a/portal-api/src/modules/users/users.resolver.ts
+++ b/portal-api/src/modules/users/users.resolver.ts
@@ -43,6 +43,10 @@ const validPassword = (user: UserLoadUserBy, password: string): boolean => {
 const resolvers: Resolvers = {
   Query: {
     me: async (_, __, context) => {
+      // User is not logged in
+      if (!context.user) {
+        return null;
+      }
       return mapUserToGraphqlUser(context.user);
     },
     user: async (_, { id }) => {

--- a/portal-front/app/(application)/layout.tsx
+++ b/portal-front/app/(application)/layout.tsx
@@ -42,13 +42,16 @@ interface RootLayoutProps {
 const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
   children,
 }) => {
-  try {
-    // @ts-ignore
-    const { data: meData }: { data: meLoaderQuery$data } =
-      await serverPortalApiFetch<typeof meLoaderQueryNode, meLoaderQuery>(
-        meLoaderQueryNode,
-        {}
-      );
+  // @ts-ignore
+  const { data: meData }: { data: meLoaderQuery$data } =
+    await serverPortalApiFetch<typeof meLoaderQueryNode, meLoaderQuery>(
+      meLoaderQueryNode,
+      {}
+    );
+
+  const me = meData.me as unknown as meContext_fragment$data;
+
+  if (me) {
     // @ts-ignore
     const { data }: { data: meUserHasSomeSubscription$data } =
       await serverPortalApiFetch<
@@ -56,10 +59,10 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
         meUserHasSomeSubscription
       >(meUserHasSomeSubscriptionNode, {});
 
-    const me = meData.me as unknown as meContext_fragment$data;
     const userHasBypassCapability = me.capabilities.some(
       (capability) => capability.name === 'BYPASS'
     );
+
     return (
       <I18nContext>
         <AppContext>
@@ -82,7 +85,7 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
         </AppContext>
       </I18nContext>
     );
-  } catch (e) {
+  } else {
     return (
       <I18nContext>
         <AppContext>


### PR DESCRIPTION
Modify the behavior when queryring `me`.
I removed `@auth` for the endpoint and add a check to see if the user is logged i.e. `!context.user` returning null to the front.