### PR TITLE
[backend] - new user is admin_orga if alone - issue 181

### DIFF
--- a/portal-api/src/modules/users/users.helper.ts
+++ b/portal-api/src/modules/users/users.helper.ts
@@ -154,7 +154,24 @@ export const insertUserIntoOrganization = async (
       user_id: user.id,
       organizations_id: [organization.id],
     });
+    const shouldBeAdminOrga = await isFirstInOrganization(
+      context,
+      organization.id
+    );
+    if (shouldBeAdminOrga) {
+      await addRolesToUser(user.id, ['ADMIN_ORGA']);
+    }
   }
+};
+
+export const isFirstInOrganization = async (
+  context: PortalContext,
+  organizationId: OrganizationId
+) => {
+  const userOrganization = await loadUserOrganization(context, {
+    organization_id: organizationId,
+  });
+  return userOrganization.length === 1;
 };
 
 export const mapUserToGraphqlUser = (


### PR DESCRIPTION
# Context : 
When I invite the first user on a service, if it is the first user of an organization, he should be admin_orga. 

# How to test
Connect as admin_ptf
Create a new organization
Go to a manage/service page
Add the newly created organization into the subscription. 
Invite a new user. This new user should be admin_orga. 
Invite another user. It should be a simple user. 

Test ok on local : 
![image](https://github.com/user-attachments/assets/82a1e96e-767a-4305-a861-f04257f039e5)


close #181 