### PR TITLE
[frontend] styles: some UI tweaks

### DIFF
--- a/portal-e2e-tests/tests/tests_files/service-management.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-management.spec.ts
@@ -25,7 +25,7 @@ test('should confirm service management is ok', async ({ page }) => {
     .getByRole('row', { name: 'Partner Vault This service' })
     .getByRole('button')
     .click();
-  await page.getByText('Manage').click();
+  await page.getByLabel('Service.GoToAdmin').click();
 
   // Add organization
   await page.getByLabel('Subscribe organization').click();

--- a/portal-front/app/(application)/(admin)/admin/service/page.tsx
+++ b/portal-front/app/(application)/(admin)/admin/service/page.tsx
@@ -4,11 +4,10 @@ import {
   servicesListFragment,
 } from '@/components/service/service.graphql';
 import { BreadcrumbNav } from '@/components/ui/breadcrumb-nav';
-import { IconActions } from '@/components/ui/icon-actions';
+import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
 import { UseTranslationsProps } from '@/i18n/config';
 import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
-import { Button } from 'filigran-ui';
 import { DataTable } from 'filigran-ui/clients';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
@@ -53,26 +52,22 @@ const Page = () => {
             <IconActions
               icon={
                 <>
-                  <MoreVertIcon className="h-4 w-4" />
+                  <MoreVertIcon className="h-4 w-4 text-primary" />
                   <span className="sr-only">Open menu</span>
                 </>
               }>
-              <Button
-                variant={'ghost'}
-                className="w-full justify-start"
-                aria-label={t('Service.GoToManagement')}
+              <IconActionsButton
+                aria-label={t('Service.GoToAdmin')}
                 onClick={() => {
                   router.push(`/admin/service/${row.id}`);
                 }}>
-                Manage
-              </Button>
-              <Button
-                variant={'ghost'}
-                className="w-full justify-start"
-                aria-label={t('Service.GoToManagement')}
+                {t('Service.GoToAdminLabel')}
+              </IconActionsButton>
+              <IconActionsButton
+                aria-label={t('Service.GoTo')}
                 onClick={() => router.push(`/service/vault/${row.id}`)}>
-                Go to
-              </Button>
+                {t('Service.GoToLabel')}
+              </IconActionsButton>
             </IconActions>
           </div>
         );

--- a/portal-front/messages/en.json
+++ b/portal-front/messages/en.json
@@ -41,7 +41,9 @@
     "SubscribeService": "Subscribe service",
     "SubscribeOrganization": "Subscribe organization",
     "GoTo": "Go to service page",
+    "GoToLabel": "Go to",
     "GoToManagement": "Go to service management",
+    "GoToAdminLabel": "Admin",
     "Capabilities": {
       "ManageAccessName": "Manage access",
       "ManageAccessDescription": "You can access the service and invite users to this service",
@@ -49,7 +51,7 @@
       "AccessServiceDescription": "You just have access to a service"
     },
     "Management": {
-      "Email": "EMAIL",
+      "Email": "Email",
       "OneUserMax": "Add 1 user max"
     },
     "SubscribeSuccessful": "You have successfully subscribed to the service. You can now find it in your subscribed services.",

--- a/portal-front/messages/fr.json
+++ b/portal-front/messages/fr.json
@@ -41,7 +41,9 @@
     "SubscribeService": "Souscrire au service",
     "SubscribeOrganization": "Souscrire une organisation",
     "GoTo": "Aller au service",
-    "GoToManagement": "Aller à la page de management du service",
+    "GoToLabel": "Consulter",
+    "GoToAdmin": "Aller à la page de management du service",
+    "GoToAdminLabel": "Administrer",
     "Capabilities": {
       "ManageAccessName": "Manage access",
       "ManageAccessDescription": "Vous pouvez accéder au service et inviter des utilisateurs à ce service",
@@ -49,7 +51,7 @@
       "AccessServiceDescription": "Vous avez uniquement accès à un service"
     },
     "Management": {
-      "Email": "EMAIL",
+      "Email": "Email",
       "OneUserMax": "1 utilisateur max"
     },
     "SubscribeSuccessful": "Vous avez souscrit au service. Vous pouvez maintenant le retrouver dans les services souscrits !",

--- a/portal-front/package.json
+++ b/portal-front/package.json
@@ -25,7 +25,7 @@
     "clsx": "2.1.1",
     "extract-files": "13.0.0",
     "filigran-icon": "0.9.0",
-    "filigran-ui": "0.24.2",
+    "filigran-ui": "0.24.4",
     "graphql": "16.9.0",
     "graphql-sse": "2.5.3",
     "next": "14.2.15",

--- a/portal-front/src/components/admin/user/delete-user-action.tsx
+++ b/portal-front/src/components/admin/user/delete-user-action.tsx
@@ -49,7 +49,9 @@ export const DeleteUserAction: FunctionComponent<DeleteUserActionsProps> = ({
   };
 
   const defaultTrigger = (
-    <IconActionsButton aria-label={t('UserActions.DeleteUser')}>
+    <IconActionsButton
+      className="normal-case"
+      aria-label={t('UserActions.DeleteUser')}>
       {t('MenuActions.Delete')}
     </IconActionsButton>
   );

--- a/portal-front/src/components/admin/user/remove-user-from-orga.tsx
+++ b/portal-front/src/components/admin/user/remove-user-from-orga.tsx
@@ -61,7 +61,9 @@ export const RemoveUserFromOrga: FunctionComponent<RemoveUserFromOrgaProps> = ({
   };
 
   const defaultTrigger = (
-    <IconActionsButton aria-label={t('UserActions.RemoveUser')}>
+    <IconActionsButton
+      className="normal-case"
+      aria-label={t('UserActions.RemoveUser')}>
       {t('MenuActions.Remove')}
     </IconActionsButton>
   );

--- a/portal-front/src/components/admin/user/user-form-sheet.tsx
+++ b/portal-front/src/components/admin/user/user-form-sheet.tsx
@@ -24,6 +24,7 @@ import {
   SheetTrigger,
 } from 'filigran-ui/clients';
 import { Button, Input, MultiSelectFormField } from 'filigran-ui/servers';
+import { useTranslations } from 'next-intl';
 import { FunctionComponent, ReactNode, useContext } from 'react';
 import { useForm } from 'react-hook-form';
 import { z, ZodSchema } from 'zod';
@@ -78,6 +79,7 @@ export const UserFormSheet: FunctionComponent<UserFormSheetProps> = ({
   validationSchema,
 }) => {
   const { me } = useContext<Portal>(portalContext);
+  const t = useTranslations();
   const currentRolesPortal = user?.roles_portal.map(
     (rolePortalData) => rolePortalData.id
   );
@@ -182,6 +184,7 @@ export const UserFormSheet: FunctionComponent<UserFormSheetProps> = ({
                   <FormLabel>Roles</FormLabel>
                   <FormControl>
                     <MultiSelectFormField
+                      noResultString={t('Utils.NotFound')}
                       options={rolePortalData}
                       defaultValue={field.value}
                       onValueChange={field.onChange}
@@ -204,6 +207,7 @@ export const UserFormSheet: FunctionComponent<UserFormSheetProps> = ({
                     <FormLabel>Organizations</FormLabel>
                     <FormControl>
                       <MultiSelectFormField
+                        noResultString={t('Utils.NotFound')}
                         options={orgData}
                         defaultValue={field.value}
                         onValueChange={field.onChange}

--- a/portal-front/src/components/admin/user/user-list.tsx
+++ b/portal-front/src/components/admin/user/user-list.tsx
@@ -197,14 +197,16 @@ const UserList: FunctionComponent<UserListProps> = ({ organization }) => {
             <IconActions
               icon={
                 <>
-                  <MoreVertIcon className="h-4 w-4" />
+                  <MoreVertIcon className="h-4 w-4 text-primary" />
                   <span className="sr-only">Open menu</span>
                 </>
               }>
               <EditUser
                 user={row.original}
                 trigger={
-                  <IconActionsButton aria-label={t('UserActions.UpdateUser')}>
+                  <IconActionsButton
+                    className="normal-case"
+                    aria-label={t('UserActions.UpdateUser')}>
                     {t('MenuActions.Update')}
                   </IconActionsButton>
                 }
@@ -219,6 +221,7 @@ const UserList: FunctionComponent<UserListProps> = ({ organization }) => {
               <GuardCapacityComponent
                 capacityRestriction={[RESTRICTION.CAPABILITY_BYPASS]}>
                 <IconActionsButton
+                  className="normal-case"
                   aria-label={t('UserActions.DetailsUser')}
                   onClick={() => router.push(`/admin/user/${row.original.id}`)}>
                   {t('MenuActions.Details')}

--- a/portal-front/src/components/organization/delete-organization.tsx
+++ b/portal-front/src/components/organization/delete-organization.tsx
@@ -53,7 +53,7 @@ export const DeleteOrganization: FunctionComponent<DeleteOrganizationProps> = ({
       triggerElement={
         <Button
           variant="ghost"
-          className="w-full justify-start"
+          className="w-full justify-start normal-case"
           aria-label="Delete Organization">
           Delete
         </Button>

--- a/portal-front/src/components/organization/edit-organization.tsx
+++ b/portal-front/src/components/organization/edit-organization.tsx
@@ -64,7 +64,7 @@ export const EditOrganization: FunctionComponent<EditOrganizationProps> = ({
       trigger={
         <Button
           variant="ghost"
-          className="w-full justify-start"
+          className="w-full justify-start normal-case"
           aria-label={t('OrganizationForm.EditOrganization')}>
           {t('Utils.Update')}
         </Button>

--- a/portal-front/src/components/organization/organization-list.tsx
+++ b/portal-front/src/components/organization/organization-list.tsx
@@ -62,7 +62,7 @@ const OrganizationList: FunctionComponent = () => {
           <IconActions
             icon={
               <>
-                <MoreVertIcon className="h-4 w-4" />
+                <MoreVertIcon className="h-4 w-4 text-primary" />
                 <span className="sr-only">Open menu</span>
               </>
             }>

--- a/portal-front/src/components/service/[slug]/service-slug-form-sheet.tsx
+++ b/portal-front/src/components/service/[slug]/service-slug-form-sheet.tsx
@@ -313,6 +313,7 @@ export const ServiceSlugFormSheet: FunctionComponent<
                   <FormLabel>Capabilities</FormLabel>
                   <FormControl>
                     <MultiSelectFormField
+                      noResultString={t('Utils.NotFound')}
                       options={capabilitiesData}
                       value={field.value}
                       onValueChange={field.onChange}

--- a/portal-front/src/components/service/[slug]/service-user-service-table.tsx
+++ b/portal-front/src/components/service/[slug]/service-user-service-table.tsx
@@ -1,7 +1,7 @@
 import { Portal, portalContext } from '@/components/portal-context';
 import { UserServiceDeleteMutation } from '@/components/service/user_service.graphql';
 import { AlertDialogComponent } from '@/components/ui/alert-dialog';
-import { IconActions } from '@/components/ui/icon-actions';
+import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
 import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
 import { DataTable } from 'filigran-ui/clients';
@@ -112,20 +112,18 @@ const ServiceUserServiceSlug: FunctionComponent<ServiceUserServiceProps> = ({
                 <IconActions
                   icon={
                     <>
-                      <MoreVertIcon className="h-4 w-4" />
+                      <MoreVertIcon className="h-4 w-4 text-primary" />
                       <span className="sr-only">Open menu</span>
                     </>
                   }>
-                  <Button
-                    variant={'ghost'}
-                    className="w-full justify-start"
+                  <IconActionsButton
                     aria-label="Edit user rights"
                     onClick={() => {
                       setCurrentUser(row.original);
                       setOpenSheet(true);
                     }}>
                     Edit
-                  </Button>
+                  </IconActionsButton>
                   <AlertDialogComponent
                     AlertTitle={'Remove access'}
                     actionButtonText={'Remove rights'}
@@ -133,7 +131,7 @@ const ServiceUserServiceSlug: FunctionComponent<ServiceUserServiceProps> = ({
                     triggerElement={
                       <Button
                         variant="ghost"
-                        className="w-full justify-start"
+                        className="w-full justify-start normal-case"
                         aria-label="Remove access">
                         Delete
                       </Button>

--- a/portal-front/src/components/service/vault/[slug]/document-list.tsx
+++ b/portal-front/src/components/service/vault/[slug]/document-list.tsx
@@ -144,7 +144,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
           <IconActions
             icon={
               <>
-                <MoreVertIcon className="text-primary h-4 w-4" />
+                <MoreVertIcon className="h-4 w-4 text-primary" />
                 <span className="sr-only">{t('Utils.OpenMenu')}</span>
               </>
             }>

--- a/portal-front/yarn.lock
+++ b/portal-front/yarn.lock
@@ -6817,9 +6817,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filigran-ui@npm:0.24.2":
-  version: 0.24.2
-  resolution: "filigran-ui@npm:0.24.2"
+"filigran-ui@npm:0.24.4":
+  version: 0.24.4
+  resolution: "filigran-ui@npm:0.24.4"
   dependencies:
     "@dnd-kit/core": 6.1.0
     "@dnd-kit/modifiers": 7.0.0
@@ -6851,7 +6851,7 @@ __metadata:
   peerDependencies:
     react: 18.2.0
     react-dom: 18.2.0
-  checksum: 0d432211fdf3ba70b93f729c2c6ae581206fe3d137a8cb0fa823de20b2ea55490decf64a2cecb581ad03364d3e2de4c8541d63d3d18f1ffd369197ac5cc704c1
+  checksum: 780bdf4d8eb8112c957fd59051b50d2b927022f9501793a4e3798a4afa498873edb72dd408de3ee93177028d513e504639ca989fa207b2bb3f0c7ddc96576a1e
   languageName: node
   linkType: hard
 
@@ -9549,7 +9549,7 @@ __metadata:
     eslint-config-prettier: 9.1.0
     extract-files: 13.0.0
     filigran-icon: 0.9.0
-    filigran-ui: 0.24.2
+    filigran-ui: 0.24.4
     graphql: 16.9.0
     graphql-sse: 2.5.3
     husky: 9.1.6


### PR DESCRIPTION
# Context 
For the V1, we should improve UI !

# How to test 
![image](https://github.com/user-attachments/assets/f3c41ab4-4af8-4d0b-9960-2c531727042b)

On the portal, the three dots menu are now color primary 
The three dots menu's dropdown should be normal-case
On the service page, the dropdown should be ADMIN and not MANAGE (#178 )


close #178 
close #63 