### PR TITLE
service management : the user cant modify himself - issue 175

### DIFF
--- a/portal-front/src/components/service/[slug]/service-user-service-table.tsx
+++ b/portal-front/src/components/service/[slug]/service-user-service-table.tsx
@@ -1,3 +1,4 @@
+import { Portal, portalContext } from '@/components/portal-context';
 import { UserServiceDeleteMutation } from '@/components/service/user_service.graphql';
 import { AlertDialogComponent } from '@/components/ui/alert-dialog';
 import { IconActions } from '@/components/ui/icon-actions';
@@ -5,7 +6,13 @@ import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
 import { DataTable } from 'filigran-ui/clients';
 import { Badge, Button } from 'filigran-ui/servers';
-import { FunctionComponent, ReactNode, useMemo, useState } from 'react';
+import {
+  FunctionComponent,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import { useMutation } from 'react-relay';
 import { serviceWithSubscriptions_fragment$data } from '../../../../__generated__/serviceWithSubscriptions_fragment.graphql';
 import { userService_fragment$data } from '../../../../__generated__/userService_fragment.graphql';
@@ -26,6 +33,7 @@ const ServiceUserServiceSlug: FunctionComponent<ServiceUserServiceProps> = ({
   setCurrentUser,
   toolbar,
 }) => {
+  const { me } = useContext<Portal>(portalContext);
   const [commitUserServiceDeletingMutation] =
     useMutation<userServiceDeleteMutation>(UserServiceDeleteMutation);
 
@@ -91,6 +99,10 @@ const ServiceUserServiceSlug: FunctionComponent<ServiceUserServiceProps> = ({
         id: 'actions',
         size: 40,
         cell: ({ row }) => {
+          // The user should not be able to modify himself
+          if (row.original.user?.id === me?.id) {
+            return null;
+          }
           return (
             <div className="flex items-center justify-end">
               {row.original.service_capability?.some(


### PR DESCRIPTION
# Context : 
A user can not modify its own access to a service. 

# How to test 
Connect on a manage/service page with the MANAGE_ACCESS capabilities. 
You should see yourself on the list, but can't have access to you own. 

![image](https://github.com/user-attachments/assets/ff603d5b-fe96-4957-baf2-2c63539903cb)

close #175 