### PR TITLE
[workflow] chore: send mail on release (#207)

### DIFF
--- a/.github/workflows/release-email.yml
+++ b/.github/workflows/release-email.yml
@@ -4,9 +4,6 @@ on:
   release:
     types:
       - published
-  push:
-    branches:
-      - "issue/207/mail-on-release"
   workflow_dispatch:
 
 jobs:
@@ -28,6 +25,7 @@ jobs:
             core.setOutput("release_name", release.name);
             core.setOutput("release_tag", release.tag_name);
             core.setOutput("release_body", release.body);
+            core.setOutput("release_url", release.html_url);
       - name: Send Email
         uses: dawidd6/action-send-mail@v4
         with:
@@ -36,18 +34,21 @@ jobs:
           username: ${{ secrets.SMTP_USERNAME }}
           password: ${{ secrets.SMTP_PASSWORD }}
           subject: "[XTM Hub] Version: ${{ steps.last_release.outputs.release_tag }}"
-          to: "tiffaine.hervy@filigran.io" #TODO Modify with all-employees@filigran.io but not now...
-          from: "automation@filigran.io"
+          to: "all-employees@filigran.io"
+          from: "XTM Hub Team"
           convert_markdown: true
           html_body:
            🔔 DING DING 🔔
-
+            </br> </br>
            Dear Filigran team,
-           The Engineering team is glad to inform you that XTM Hub ${{ steps.last_release.outputs.release_tag }} has been released 🥳!
-           Release Node
-           
+            </br> </br>
+           The Engineering team is glad to inform you that <a href=${{steps.last_release.outputs.release_url}} target="_blank"> XTM Hub ${{ steps.last_release.outputs.release_tag }}</a> has been released 🥳!
+           </br> </br>
+           <h2>Release Note</h2>
+            
            ${{ steps.last_release.outputs.release_body }}
             
-            Don't hesitate to reach the product management team to get more information 🚀
-  
+            </br></br>
+            Don't hesitate to reach the <a href="mailto:engineering-product-management@filigran.io">product management team</a> to get more information 🚀
+            </br></br>
            Thank you all for your efforts in serving our community and our customers 🎀


### PR DESCRIPTION
# Context 

This new github action send an email on each release : 
![image](https://github.com/user-attachments/assets/79fbced7-69f8-48d9-b9dd-c303226fa292)

The email takes the release body and display it (without interpretation). 

What's left : 

When we'll be ready, change my email address for all-employees