### PR TITLE
[backend] fix(getSubscriptions): with user's subscription (#162)

### DIFF
--- a/portal-e2e-tests/tests/tests_files/service-management.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-management.spec.ts
@@ -16,7 +16,6 @@ test.afterAll('Remove subscription', async () => {
 test('should confirm service management is ok', async ({ page }) => {
   await removeSubscription('681fb117-e2c3-46d3-945a-0e921b5d4b6c');
 
-  await page.reload();
   const loginPage = new LoginPage(page);
   await loginPage.login();
 
@@ -82,8 +81,8 @@ test('should confirm service management is ok', async ({ page }) => {
   await expect(page.getByText('ACCESS_SERVICE').first()).toBeVisible();
 
   // Unsubscribe organization
-  // await page.getByLabel('Delete Organization from the').click();
-  // await page.getByRole('button', { name: 'Remove' }).click();
-  // await page.getByRole('main').getByText('Internal', { exact: true }).click();
-  // await expect(page.getByRole('option', { name: 'Thales' })).not.toBeVisible();
+  await page.getByLabel('Delete Organization from the').click();
+  await page.getByRole('button', { name: 'Remove' }).click();
+  await page.getByRole('main').getByText('Filigran', { exact: true }).click();
+  await expect(page.getByRole('option', { name: 'Thales' })).not.toBeVisible();
 });


### PR DESCRIPTION
# Context 
This PR is about the manage/service page. 

It allows subscriptions to have the user's subscription as the first element of the list. Thanks to that, we don't have problems if the user is allowed to see its own subscription only : the combobox is well selected. 

# How to test 
Connect as an ADMIN_PTF 
Go to the manage service page. 
You user's organization should be the default organization selected in the combobox. 
![image](https://github.com/user-attachments/assets/8eddc09d-daba-49f1-9247-98762d9fe23c)

close #162 