### PR TITLE
[frontend] styles: invert button styles (#199)

### DIFF
--- a/portal-front/src/components/service/[slug]/service-slug.tsx
+++ b/portal-front/src/components/service/[slug]/service-slug.tsx
@@ -193,22 +193,6 @@ const ServiceSlug: FunctionComponent<ServiceSlugProps> = ({
       </div>
       <div className="flex gap-s flex-wrap">
         <DataTableHeadBarOptions />
-        {dataOrganizationsTab.length > 0 && (
-          <ServiceSlugFormSheet
-            open={openSheet}
-            setOpen={setOpenSheet}
-            userService={currentUser}
-            connectionId={queryData.serviceByIdWithSubscriptions?.__id ?? ''}
-            dataOrganizationsTab={dataOrganizationsTab}
-            subscription={selectedSubscription}
-            trigger={
-              <TriggerButton
-                onClick={() => setCurrentUser({})}
-                label={t('Service.InviteUser')}
-              />
-            }
-          />
-        )}
 
         {useAdminPath() && (
           <ServiceSlugAddOrgaFormSheet
@@ -222,11 +206,27 @@ const ServiceSlug: FunctionComponent<ServiceSlugProps> = ({
             serviceId={serviceId}
             trigger={
               <Button
-                className="text-nowrap"
                 variant="outline"
                 aria-label={t('Service.SubscribeOrganization')}>
                 {t('Service.SubscribeOrganization')}
               </Button>
+            }
+          />
+        )}
+
+        {dataOrganizationsTab.length > 0 && (
+          <ServiceSlugFormSheet
+            open={openSheet}
+            setOpen={setOpenSheet}
+            userService={currentUser}
+            connectionId={queryData.serviceByIdWithSubscriptions?.__id ?? ''}
+            dataOrganizationsTab={dataOrganizationsTab}
+            subscription={selectedSubscription}
+            trigger={
+              <TriggerButton
+                onClick={() => setCurrentUser({})}
+                label={t('Service.InviteUser')}
+              />
             }
           />
         )}

--- a/portal-front/src/components/service/vault/[slug]/document-list.tsx
+++ b/portal-front/src/components/service/vault/[slug]/document-list.tsx
@@ -1,13 +1,22 @@
+import GuardCapacityComponent from '@/components/admin-guard';
+import { ServiceById } from '@/components/service/service.graphql';
+import DeleteDocument from '@/components/service/vault/delete-document';
 import { documentListLocalStorage } from '@/components/service/vault/document-list-localstorage';
 import {
   DocumentsListQuery,
   documentsFragment,
 } from '@/components/service/vault/document.graphql';
+import DownloadDocument from '@/components/service/vault/download-document';
+import EditDocument from '@/components/service/vault/edit-document';
 import { VaultForm } from '@/components/service/vault/vault-form';
 import {
   mapToSortingTableValue,
   transformSortingValueToParams,
 } from '@/components/ui/handle-sorting.utils';
+import { IconActions } from '@/components/ui/icon-actions';
+import useDecodedParams from '@/hooks/useDecodedParams';
+import { RESTRICTION } from '@/utils/constant';
+import { FormatDate } from '@/utils/date';
 import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
 import {
@@ -20,24 +29,15 @@ import {
 } from 'filigran-ui/clients';
 import { Button, Input } from 'filigran-ui/servers';
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 import * as React from 'react';
 import { useState } from 'react';
-import { commitLocalUpdate, useRelayEnvironment } from 'react-relay';
-
-import GuardCapacityComponent from '@/components/admin-guard';
-import { ServiceById } from '@/components/service/service.graphql';
-import DeleteDocument from '@/components/service/vault/delete-document';
-import DownloadDocument from '@/components/service/vault/download-document';
-import EditDocument from '@/components/service/vault/edit-document';
-import { IconActions } from '@/components/ui/icon-actions';
-import useDecodedParams from '@/hooks/useDecodedParams';
-import { RESTRICTION } from '@/utils/constant';
-import { FormatDate } from '@/utils/date';
-import Link from 'next/link';
 import {
   PreloadedQuery,
+  commitLocalUpdate,
   usePreloadedQuery,
   useRefetchableFragment,
+  useRelayEnvironment,
 } from 'react-relay';
 import { documentItem_fragment$data } from '../../../../../__generated__/documentItem_fragment.graphql';
 import { documentsList$key } from '../../../../../__generated__/documentsList.graphql';
@@ -266,7 +266,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
             />
             <div className="justify-between flex w-full sm:w-auto items-center gap-s">
               <DataTableHeadBarOptions />
-              <VaultForm connectionId={data?.documents?.__id} />
+
               {canManageService && (
                 <Button
                   asChild
@@ -276,6 +276,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
                   </Link>
                 </Button>
               )}
+              <VaultForm connectionId={data?.documents?.__id} />
             </div>
           </div>
         }

--- a/portal-front/src/components/service/vault/vault-form.tsx
+++ b/portal-front/src/components/service/vault/vault-form.tsx
@@ -5,13 +5,13 @@ import {
   newDocumentSchema,
   VaultNewFileFormSheet,
 } from '@/components/service/vault/vault-new-file-form-sheet';
-import TriggerButton from '@/components/ui/trigger-button';
 import { RESTRICTION } from '@/utils/constant';
 import { useToast } from 'filigran-ui/clients';
 import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import { useState } from 'react';
 
+import TriggerButton from '@/components/ui/trigger-button';
 import useDecodedParams from '@/hooks/useDecodedParams';
 import { useMutation } from 'react-relay';
 import { UploadableMap } from 'relay-runtime';


### PR DESCRIPTION
# Context : 

The primary button should be the one that is the most on the right. 
We have 2 buttons only on the management service page. We have shift outline and primary button. 

# How to test : 
Go on a service admin page. 
Admire the buttons : 
![image](https://github.com/user-attachments/assets/993922ee-0edd-4e6c-b723-efee9638117a)

Go on a Vault page with admin rights. 
Admire the buttons: 
![image](https://github.com/user-attachments/assets/48e23286-0c75-4ef5-90a0-65c8c1f68d9b)


The primary should be on the right. 

close #199 