### PR TITLE
[frontend] - fix(middleware): redirect to login on unauthenticated error (#217)

### DIFF
--- a/portal-front/messages/en.json
+++ b/portal-front/messages/en.json
@@ -5,7 +5,7 @@
   },
   "Error": {
     "YouAreNotAuthorized": "You are not authorized to get this page.",
-    "Disconnected": "You have been disconnected"
+    "Disconnected": "Your session have expired"
   },
   "HomePage": {
     "AvailableServices": "Available services",

--- a/portal-front/messages/fr.json
+++ b/portal-front/messages/fr.json
@@ -5,7 +5,7 @@
   },
   "Error": {
     "YouAreNotAuthorized": "Vous n'êtes pas autorisé à accéder à cette page.",
-    "Disconnected": "Vous avez été déconnecté"
+    "Disconnected": "Votre session a expiré"
   },
   "HomePage": {
     "AvailableServices": "Services disponibles",

--- a/portal-front/src/components/login/login-form.tsx
+++ b/portal-front/src/components/login/login-form.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { LoginFormMutation } from '@/components/login/login.graphql';
-import useDecodedQuery from '@/hooks/useDecodedQuery';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Form,
@@ -9,12 +8,10 @@ import {
   FormField,
   FormItem,
   FormLabel,
-  useToast,
 } from 'filigran-ui/clients';
 import { Button, Input } from 'filigran-ui/servers';
 import { useTranslations } from 'next-intl';
-import { usePathname, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-relay';
 import { z } from 'zod';
@@ -35,31 +32,11 @@ const LoginForm = () => {
       password: '',
     },
   });
-
   const [commitLoginFormMutation] = useMutation(LoginFormMutation);
-  const { toast } = useToast();
-
-  const { redirect } = useDecodedQuery();
-  const currentPath = usePathname();
-
-  useEffect(() => {
-    if (redirect) {
-      router.push(atob(redirect));
-      toast({
-        variant: 'destructive',
-        title: t('Utils.Error'),
-        description: t('Error.Disconnected'),
-      });
-    }
-  }, [currentPath]);
-
   const onSubmit = (variables: z.infer<typeof formSchema>) => {
     commitLoginFormMutation({
       variables,
       onCompleted() {
-        if (redirect) {
-          router.push(redirect);
-        }
         // If login succeed, refresh the page
         router.refresh();
       },

--- a/portal-front/src/components/login/login-layout.tsx
+++ b/portal-front/src/components/login/login-layout.tsx
@@ -3,10 +3,13 @@ import LoginMessage from '@/components/login/login-message';
 import LoginTitleForm from '@/components/login/login-title';
 import { PlatformProviderButton } from '@/components/login/platform-provider-button';
 import { SettingsQuery } from '@/components/login/settings.graphql';
-import { FunctionComponent } from 'react';
+import useDecodedQuery from '@/hooks/useDecodedQuery';
+import { useToast } from 'filigran-ui/clients';
+import { useTranslations } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
+import { FunctionComponent, useEffect } from 'react';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { settingsQuery } from '../../../__generated__/settingsQuery.graphql';
-
 interface LoginLayoutProps {
   queryRef: PreloadedQuery<settingsQuery>;
 }
@@ -15,6 +18,22 @@ export const LoginLayout: FunctionComponent<LoginLayoutProps> = ({
   queryRef,
 }) => {
   const data = usePreloadedQuery<settingsQuery>(SettingsQuery, queryRef);
+  const router = useRouter();
+  const { redirect } = useDecodedQuery();
+  const currentPath = usePathname();
+  const { toast } = useToast();
+  const t = useTranslations();
+  useEffect(() => {
+    if (redirect) {
+      router.push(atob(redirect));
+
+      toast({
+        variant: 'destructive',
+        title: t('Utils.Error'),
+        description: t('Error.Disconnected'),
+      });
+    }
+  }, [currentPath]);
   return (
     <main className="absolute inset-0 z-0 m-auto flex max-w-[450px] flex-col justify-center">
       <div className="flex flex-col items-center p-xl sm:p-0">

--- a/portal-front/src/components/login/platform-provider-button.tsx
+++ b/portal-front/src/components/login/platform-provider-button.tsx
@@ -1,10 +1,6 @@
-import useDecodedQuery from '@/hooks/useDecodedQuery';
-import { useToast } from 'filigran-ui/clients';
 import { Button } from 'filigran-ui/servers';
-import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent } from 'react';
 
 interface LoginButtonProviderProps {
   platformProvider: {
@@ -17,23 +13,6 @@ interface LoginButtonProviderProps {
 export const PlatformProviderButton: FunctionComponent<
   LoginButtonProviderProps
 > = ({ platformProvider }) => {
-  const router = useRouter();
-  const { redirect } = useDecodedQuery();
-  const currentPath = usePathname();
-  const { toast } = useToast();
-  const t = useTranslations();
-  useEffect(() => {
-    if (redirect) {
-      router.push(atob(redirect));
-
-      toast({
-        variant: 'destructive',
-        title: t('Utils.Error'),
-        description: t('Error.Disconnected'),
-      });
-    }
-  }, [currentPath]);
-
   return (
     <Button
       key={platformProvider.provider}


### PR DESCRIPTION
# Context 
We should improve user experience on the XTMH. 
Before this dev, when the user was logout (not by the UI) he just had a ugly error : 
Not authenticated. 

![Capture d'écran 2024-12-30 114031](https://github.com/user-attachments/assets/8c040a0f-2903-4136-8891-f771d2137611)



Now, he is redirected to the login page. 



# How to test 
Connect as any king of user. 
On local, cut your API server. Then relaunch it. 
Wait for the complete relaunch. 
On UI, try go navigate to a page > You should see a redirection to login page. 

close #217   