### PR TITLE
[frontend] - fix(userSlug) : Update user list on user deletion (#173)

### DIFF
--- a/portal-front/src/components/admin/user/user.graphql.ts
+++ b/portal-front/src/components/admin/user/user.graphql.ts
@@ -17,14 +17,6 @@ export const UserSlugEditMutation = graphql`
   }
 `;
 
-export const userSlugDeletion = graphql`
-  mutation userSlugDeletionMutation($id: ID!) {
-    deleteUser(id: $id) {
-      id
-    }
-  }
-`;
-
 export const userDeletion = graphql`
   mutation userDeletionMutation($connections: [ID!]!, $id: ID!) {
     deleteUser(id: $id) {

--- a/portal-front/src/hooks/useConnectionId.tsx
+++ b/portal-front/src/hooks/useConnectionId.tsx
@@ -1,0 +1,13 @@
+import { useRelayEnvironment } from 'react-relay';
+
+export const useConnectionId = (recordName: string) => {
+  const environment = useRelayEnvironment();
+  const store = environment.getStore();
+  const records = store.getSource().toJSON();
+  for (const [id, record] of Object.entries(records)) {
+    if (record?.__typename === recordName) {
+      return id;
+    }
+  }
+  return null;
+};

--- a/portal-front/src/lib/utils.ts
+++ b/portal-front/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { type ClassValue, clsx } from 'clsx';
 import { Children, isValidElement, ReactElement, ReactNode } from 'react';
-import { twMerge } from 'tailwind-merge';
 
+import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/portal-front/src/relay/environment/fetchFn.ts
+++ b/portal-front/src/relay/environment/fetchFn.ts
@@ -39,7 +39,6 @@ export async function networkFetch(
   if (portalCookie) {
     headers.cookie = portalCookie.name + '=' + portalCookie.value;
   }
-
   const resp = await fetch(apiUri, {
     method: 'POST',
     credentials: 'same-origin',
@@ -52,12 +51,10 @@ export async function networkFetch(
   // property of the response. If any exceptions occurred when processing the request,
   // throw an error to indicate to the developer what went wrong.
   if (Array.isArray(json.errors)) {
-    const containsAuthenticationFailure = json.errors.find(
-      (e: any) => e.message === 'Not authenticated.'
-    );
+    const containsAuthenticationFailure =
+      json.errors.find((e: any) => e.extensions.code === 'UNAUTHENTICATED') !==
+      undefined;
     if (containsAuthenticationFailure) {
-      // redirect to login page
-      window.location.href = '/';
       throw new Error('UNAUTHENTICATED');
     }
     throw new Error(json.errors[0].message);


### PR DESCRIPTION
# Context 
The list was not updated after a deletion in a user's details page. Now, with the connection id, it is 🌜 

# How to test
Connect as an ADMIN
Go on a user's detail page. 
Delete the user. 
You are automatically routed to the user list. The user should not be visible anymore. 

Loom video : https://www.loom.com/share/b65a77e152ea40629b6f46c1df72eff6?sid=e8e0b11f-709e-4a98-8751-260413e7ea41


close #173 