### PR TITLE
[frontend/backend] - User can access XTMH if its organization has subscription #183

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -354,7 +354,7 @@ export type Query = {
   services: ServiceConnection;
   settings: Settings;
   user?: Maybe<User>;
-  userHasSomeSubscription: Scalars['Boolean']['output'];
+  userHasOrganizationWithSubscription: Scalars['Boolean']['output'];
   userServiceOwned?: Maybe<UserServiceConnection>;
   users: UserConnection;
 };
@@ -1055,7 +1055,7 @@ export type QueryResolvers<ContextType = PortalContext, ParentType extends Resol
   services?: Resolver<ResolversTypes['ServiceConnection'], ParentType, ContextType, RequireFields<QueryServicesArgs, 'first' | 'orderBy' | 'orderMode'>>;
   settings?: Resolver<ResolversTypes['Settings'], ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
-  userHasSomeSubscription?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  userHasOrganizationWithSubscription?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   userServiceOwned?: Resolver<Maybe<ResolversTypes['UserServiceConnection']>, ParentType, ContextType, RequireFields<QueryUserServiceOwnedArgs, 'first' | 'orderBy' | 'orderMode'>>;
   users?: Resolver<ResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<QueryUsersArgs, 'first' | 'orderBy' | 'orderMode'>>;
 }>;

--- a/portal-api/src/modules/subcription/subscription.helper.ts
+++ b/portal-api/src/modules/subcription/subscription.helper.ts
@@ -6,9 +6,11 @@ import Subscription, {
 } from '../../model/kanel/public/Subscription';
 import { PortalContext } from '../../model/portal-context';
 
-export const deleteSubscriptionUnsecure = async (serviceId: string) => {
+export const deleteSubscriptionUnsecure = async (
+  field: SubscriptionMutator
+) => {
   return dbUnsecure<Subscription>('Subscription')
-    .where('Subscription.service_id', '=', serviceId)
+    .where(field)
     .delete('*')
     .returning('*');
 };
@@ -38,6 +40,12 @@ export const insertSubscription = async (
   dataSubscription
 ) => {
   return db<Subscription>(context, 'Subscription')
+    .insert(dataSubscription)
+    .returning('*');
+};
+
+export const insertUnsecureSubscription = async (dataSubscription) => {
+  return dbUnsecure<Subscription>('Subscription')
     .insert(dataSubscription)
     .returning('*');
 };

--- a/portal-api/src/modules/subcription/subscription.resolver.test.ts
+++ b/portal-api/src/modules/subcription/subscription.resolver.test.ts
@@ -1,6 +1,7 @@
 import { toGlobalId } from 'graphql-relay/node/node';
 import { afterAll, describe, expect, it } from 'vitest';
 import { contextAdminUser } from '../../../tests/tests.const';
+import { ServiceId } from '../../model/kanel/public/Service';
 import { deleteSubscriptionUnsecure } from './subscription.helper';
 import subscriptionResolver from './subscription.resolver';
 
@@ -22,7 +23,9 @@ describe('Subscription mutation resolver', () => {
       expect(response.name).toEqual('Malware analysis');
     });
     afterAll(async () => {
-      await deleteSubscriptionUnsecure('234a5d21-8a1f-4d3f-8f57-7fd21c321bd4');
+      await deleteSubscriptionUnsecure({
+        service_id: '234a5d21-8a1f-4d3f-8f57-7fd21c321bd4' as ServiceId,
+      });
     });
   });
 });

--- a/portal-api/src/modules/users/users.domain.ts
+++ b/portal-api/src/modules/users/users.domain.ts
@@ -5,6 +5,7 @@ import {
   AddUserInput,
   EditUserInput,
   QueryUsersArgs,
+  Subscription,
   UserConnection,
   UserFilter,
   User as UserGenerated,
@@ -427,12 +428,18 @@ export const loadUserDetails = async (
     .first();
 };
 
-export const userHasSomeSubscription = async (context: PortalContext) => {
-  const exists = await dbUnsecure('User_Service')
-    .where({ user_id: context.user.id })
-    .first(); // Fetch only the first matching record
-
-  return !!exists;
+export const userHasOrganizationWithSubscription = async (
+  context: PortalContext
+) => {
+  const organizationIds = context.user.organizations.map((org) => org.id);
+  if (organizationIds.length === 0) {
+    return false;
+  }
+  const subscriptions: Subscription[] = await db<Subscription>(
+    context,
+    'Subscription'
+  ).whereIn('organization_id', organizationIds);
+  return subscriptions.length !== 0;
 };
 
 /**

--- a/portal-api/src/modules/users/users.graphql
+++ b/portal-api/src/modules/users/users.graphql
@@ -46,7 +46,7 @@ type Query {
     orderMode: OrderingMode!
     filter: UserFilter
   ): UserConnection! @auth
-  userHasSomeSubscription: Boolean! @auth
+  userHasOrganizationWithSubscription: Boolean! @auth
 }
 
 input EditUserInput {

--- a/portal-api/src/modules/users/users.resolver.test.ts
+++ b/portal-api/src/modules/users/users.resolver.test.ts
@@ -1,6 +1,6 @@
 import { toGlobalId } from 'graphql-relay/node/node';
 import { v4 as uuidv4 } from 'uuid';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   contextAdminOrgaThales,
   contextAdminUser,
@@ -9,14 +9,61 @@ import {
   AddUserInput,
   EditUserInput,
 } from '../../__generated__/resolvers-types';
+import { SubscriptionId } from '../../model/kanel/public/Subscription';
 import { UserId } from '../../model/kanel/public/User';
 import {
   ADMIN_UUID,
   PLATFORM_ORGANIZATION_UUID,
   ROLE_USER,
 } from '../../portal.const';
+import {
+  deleteSubscriptionUnsecure,
+  insertUnsecureSubscription,
+} from '../subcription/subscription.helper';
 import { deleteUserById, loadUserBy } from './users.domain';
 import usersResolver from './users.resolver';
+
+describe('User query resolver', () => {
+  describe('userHasOrganizationWithSubscription', () => {
+    beforeEach(async () => {
+      await insertUnsecureSubscription({
+        id: '7c6e887e-9553-439b-aeaf-a81911c399d2',
+        organization_id: '681fb117-e2c3-46d3-945a-0e921b5d4b6c',
+        service_id: 'e88e8f80-ba9e-480b-ab27-8613a1565eff',
+      });
+    });
+    it.each`
+      expected | organizations                                                                                                       | description
+      ${true}  | ${[{ id: '681fb117-e2c3-46d3-945a-0e921b5d4b6c', name: 'Thales', personal_space: false, domains: ['thales.com'] }]} | ${'organization has subscription'}
+      ${false} | ${[]}                                                                                                               | ${'has no organization'}
+      ${false} | ${[{ id: '681fb117-e2c3-46d3-945a-0e921b5d4b6d', name: 'Thales', personal_space: false, domains: ['thales.com'] }]} | ${'no organization has subscription'}
+    `(
+      'Should return $expected if $description',
+      async ({ expected, organizations }) => {
+        const currentContext = {
+          ...contextAdminOrgaThales,
+          user: {
+            ...contextAdminOrgaThales.user,
+            organizations: organizations,
+          },
+        };
+        const response =
+          await usersResolver.Query.userHasOrganizationWithSubscription(
+            undefined,
+            {},
+            currentContext
+          );
+
+        expect(response).toStrictEqual(expected);
+      }
+    );
+    afterEach(async () => {
+      await deleteSubscriptionUnsecure({
+        id: '7c6e887e-9553-439b-aeaf-a81911c399d2' as SubscriptionId,
+      });
+    });
+  });
+});
 
 describe('Query resolver', () => {
   it('should fetch User', async () => {

--- a/portal-api/src/modules/users/users.resolver.ts
+++ b/portal-api/src/modules/users/users.resolver.ts
@@ -26,7 +26,7 @@ import {
   selectOrganizationAtLogin,
   updateSelectedOrganization,
   updateUser,
-  userHasSomeSubscription,
+  userHasOrganizationWithSubscription,
 } from './users.domain';
 import {
   addNewUserWithRoles,
@@ -58,8 +58,8 @@ const resolvers: Resolvers = {
     users: async (_, { first, after, orderMode, orderBy, filter }, context) => {
       return loadUsers(context, { first, after, orderMode, orderBy }, filter);
     },
-    userHasSomeSubscription: async (_, __, context) => {
-      return userHasSomeSubscription(context);
+    userHasOrganizationWithSubscription: async (_, __, context) => {
+      return userHasOrganizationWithSubscription(context);
     },
   },
   Mutation: {

--- a/portal-front/app/(application)/layout.tsx
+++ b/portal-front/app/(application)/layout.tsx
@@ -19,10 +19,10 @@ import meLoaderQueryNode, {
   meLoaderQuery,
   meLoaderQuery$data,
 } from '../../__generated__/meLoaderQuery.graphql';
-import meUserHasSomeSubscriptionNode, {
-  meUserHasSomeSubscription,
-  meUserHasSomeSubscription$data,
-} from '../../__generated__/meUserHasSomeSubscription.graphql';
+import meUserHasOrganizationWithSubscriptionNode, {
+  meUserHasOrganizationWithSubscription,
+  meUserHasOrganizationWithSubscription$data,
+} from '../../__generated__/meUserHasOrganizationWithSubscription.graphql';
 import PageLoader from './page-loader';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -53,11 +53,11 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
 
   if (me) {
     // @ts-ignore
-    const { data }: { data: meUserHasSomeSubscription$data } =
+    const { data }: { data: meUserHasOrganizationWithSubscription$data } =
       await serverPortalApiFetch<
-        typeof meUserHasSomeSubscriptionNode,
-        meUserHasSomeSubscription
-      >(meUserHasSomeSubscriptionNode, {});
+        typeof meUserHasOrganizationWithSubscriptionNode,
+        meUserHasOrganizationWithSubscription
+      >(meUserHasOrganizationWithSubscriptionNode, {});
 
     const userHasBypassCapability = me.capabilities.some(
       (capability) => capability.name === 'BYPASS'
@@ -66,7 +66,8 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
     return (
       <I18nContext>
         <AppContext>
-          {data.userHasSomeSubscription || userHasBypassCapability ? (
+          {data.userHasOrganizationWithSubscription ||
+          userHasBypassCapability ? (
             <PageLoader>
               <Menu />
               <div className="w-full overflow-auto h-screen">

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -75,7 +75,7 @@ type Query {
   me: User
   user(id: ID!): User
   users(first: Int!, after: ID, orderBy: UserOrdering!, orderMode: OrderingMode!, filter: UserFilter): UserConnection!
-  userHasSomeSubscription: Boolean!
+  userHasOrganizationWithSubscription: Boolean!
   node(id: ID!): Node
 }
 

--- a/portal-front/src/components/me.graphql.ts
+++ b/portal-front/src/components/me.graphql.ts
@@ -30,8 +30,8 @@ export const MeQuery = graphql`
   }
 `;
 
-export const meUserHasSomeSubscription = graphql`
-  query meUserHasSomeSubscription {
-    userHasSomeSubscription
+export const meUserHasOrganizationWithSubscription = graphql`
+  query meUserHasOrganizationWithSubscription {
+    userHasOrganizationWithSubscription
   }
 `;


### PR DESCRIPTION
# Context: 
Now, if the user has no userService access, he is redirected to the filigran.io 
We want the user to be redirected only if he has no organization with subscription. 

# How to test:  
Create an organization without any subscription. Add a user in this organization. 
Connect as the user newly created. You should be redirected. 
Connect as ADMIN_PTF, add a subscription to the newly created organization (but not the user !) 
Connect as the user newly created. Now, he should not be redirected. (ok) 

# What tests has been made: 
- [X] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information: 
Vidéo of the local tests : 
https://www.loom.com/share/5fcdbe090c8044aab9809bddefbcfd4a?sid=6c62709e-46a7-4140-8744-f19f5a9f84a6


Close #183 
