### PR TITLE
[frontend] feat: As a user with an orga with no sub, I can visit the Hub !

### DIFF
--- a/portal-front/app/(application)/layout.tsx
+++ b/portal-front/app/(application)/layout.tsx
@@ -19,10 +19,6 @@ import meLoaderQueryNode, {
   meLoaderQuery,
   meLoaderQuery$data,
 } from '../../__generated__/meLoaderQuery.graphql';
-import meUserHasOrganizationWithSubscriptionNode, {
-  meUserHasOrganizationWithSubscription,
-  meUserHasOrganizationWithSubscription$data,
-} from '../../__generated__/meUserHasOrganizationWithSubscription.graphql';
 import PageLoader from './page-loader';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -52,17 +48,6 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
   const me = meData.me as unknown as meContext_fragment$data;
 
   if (me) {
-    // @ts-ignore
-    const { data }: { data: meUserHasOrganizationWithSubscription$data } =
-      await serverPortalApiFetch<
-        typeof meUserHasOrganizationWithSubscriptionNode,
-        meUserHasOrganizationWithSubscription
-      >(meUserHasOrganizationWithSubscriptionNode, {});
-
-    const userHasBypassCapability = me.capabilities.some(
-      (capability) => capability.name === 'BYPASS'
-    );
-
     return (
       <I18nContext>
         <AppContext>


### PR DESCRIPTION
# Context: 
Remove the redirection to the landing page and redirects everyone to the XTM Hub homepage.
The source of truth will be the homepage for any user interested in Filigran’s offering/solutions.

# How to test:  
Create a simple user linked to an organisation without a subscription to a service and verify that you can stay on the app.

# What tests has been made: 
- [ ] Integration tests
- [x] E2E tests
- [X] Local tests

# Additional information: 


Close #242 
