### PR TITLE
[frontend] - (fix)(Sheet) : fix closing sheet on form's cancel button #264

### DIFF
--- a/portal-front/src/components/admin/user/user-form.tsx
+++ b/portal-front/src/components/admin/user/user-form.tsx
@@ -202,6 +202,7 @@ export const UserForm: FunctionComponent<UserFormProps> = ({
         <SheetFooter className="pt-2">
           <Button
             variant="outline"
+            type="button"
             onClick={(e) => handleCloseSheet(e)}>
             {t('Utils.Cancel')}
           </Button>

--- a/portal-front/src/components/organization/organization-form.tsx
+++ b/portal-front/src/components/organization/organization-form.tsx
@@ -40,6 +40,7 @@ export const OrganizationForm: FunctionComponent<
     },
   });
   setIsDirty(form.formState.isDirty);
+
   const onSubmit = (values: z.infer<typeof organizationFormSchema>) => {
     handleSubmit({
       ...values,
@@ -133,6 +134,7 @@ export const OrganizationForm: FunctionComponent<
         <SheetFooter className="pt-2">
           <Button
             variant="outline"
+            type="button"
             onClick={(e) => handleCloseSheet(e)}>
             {t('Utils.Cancel')}
           </Button>

--- a/portal-front/src/components/service/[slug]/service-slug-add-orga-form.tsx
+++ b/portal-front/src/components/service/[slug]/service-slug-add-orga-form.tsx
@@ -144,6 +144,7 @@ export const ServiceSlugAddOrgaForm: FunctionComponent<
         <SheetFooter className="pt-2">
           <Button
             variant="outline"
+            type="button"
             onClick={(e) => handleCloseSheet(e)}>
             {t('Utils.Cancel')}
           </Button>

--- a/portal-front/src/components/ui/sheet-with-preventing-dialog.tsx
+++ b/portal-front/src/components/ui/sheet-with-preventing-dialog.tsx
@@ -53,6 +53,8 @@ export const SheetWithPreventingDialog: FunctionComponent<
     if (isDirty) {
       e.preventDefault();
       setOpenDialog(true);
+    } else {
+      setOpen(false);
     }
   };
 


### PR DESCRIPTION
# Context: 
This PR allow user to close sheet with the cancel button if the form is not dirty. It also adds type="button" on Cancel button to avoid form submission. 

# How to test:  
Connect as an administrator. 
Go to a page with sheet (add user, add organization...) 
Open the sheet with the trigger. 
Click on cancel : the sheet should close directly.  

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests -> Done but on issue/160/e2E
- [X] Local tests

# Additional information: 
https://www.loom.com/share/7f317234fb314f978ccf2898e1ee4aaa?sid=6d0ab96a-40f9-47cd-92ab-a94102de0167

Close #264
