### PR TITLE
[backend] fix modifying user context on changeOrganization #271

### DIFF
--- a/portal-api/src/index.ts
+++ b/portal-api/src/index.ts
@@ -45,6 +45,7 @@ const sessionMiddleware = expressSession({
   saveUninitialized: true,
   proxy: true,
   rolling: true,
+  resave: false,
   cookie: {
     httpOnly: true,
     sameSite: 'lax',


### PR DESCRIPTION
# Context: 

**resave Setting Explanation**
The resave option determines whether the session is saved back to the session store even when it hasn’t been modified during the request. Depending on the type of store you are using, this behavior might be necessary. However, it can also lead to race conditions. For example, if a client sends two parallel requests to your server, changes made to the session in one request could be overwritten by the other request, even if the second request didn’t make any changes. This behavior varies based on the session store in use.

**Why I Set resave: false**

I set resave to false because I encountered issues with request racing. By disabling the forced session save, I was able to prevent one request from overwriting session changes made by another concurrent request. This adjustment resolved the issue and ensured that the session data remained consistent.


Close #271 
