### PR TITLE
[backend] fix: editMeUser did not update context session #285

### DIFF
--- a/portal-api/src/modules/users/users.resolver.ts
+++ b/portal-api/src/modules/users/users.resolver.ts
@@ -188,7 +188,13 @@ const resolvers: Resolvers = {
         });
 
         await dispatch('User', 'edit', user);
+        context.req.session.user = {
+          ...context.user,
+          ...user,
+        };
+
         await trx.commit();
+
         return user;
       } catch (error) {
         await trx.rollback();


### PR DESCRIPTION
# Context: 

The editMeUser function is working but does not update the user session in the backend. As a result, when the user reconnects to the service, meUser responds with the previous context.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information: 


Close #285 
