### PR TITLE
[backend] fix: force @types/express-serve-static-core resolution to 5.0.6 to avoid subdeps incompat

### DIFF
--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -78,6 +78,7 @@
     "@types/config": "3.3.5",
     "@types/cors": "2.8.17",
     "@types/express": "4.17.21",
+    "@types/express-serve-static-core": "5.0.6",
     "@types/express-session": "1.18.0",
     "@types/graphql-upload": "16.0.7",
     "@types/node": "22.5.5",
@@ -109,5 +110,8 @@
       "yarn format",
       "yarn lint:fix"
     ]
+  },
+  "resolutions": {
+    "@types/express-serve-static-core": "5.0.6"
   }
 }

--- a/portal-api/yarn.lock
+++ b/portal-api/yarn.lock
@@ -3847,19 +3847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.30, @types/express-serve-static-core@npm:^4.17.33":
-  version: 4.19.6
-  resolution: "@types/express-serve-static-core@npm:4.19.6"
-  dependencies:
-    "@types/node": "*"
-    "@types/qs": "*"
-    "@types/range-parser": "*"
-    "@types/send": "*"
-  checksum: b0576eddc2d25ccdf10e68ba09598b87a4d7b2ad04a81dc847cb39fe56beb0b6a5cc017b1e00aa0060cb3b38e700384ce96d291a116a0f1e54895564a104aae9
-  languageName: node
-  linkType: hard
-
-"@types/express-serve-static-core@npm:^5.0.0":
+"@types/express-serve-static-core@npm:5.0.6":
   version: 5.0.6
   resolution: "@types/express-serve-static-core@npm:5.0.6"
   dependencies:
@@ -8970,6 +8958,7 @@ __metadata:
     "@types/config": 3.3.5
     "@types/cors": 2.8.17
     "@types/express": 4.17.21
+    "@types/express-serve-static-core": 5.0.6
     "@types/express-session": 1.18.0
     "@types/graphql-upload": 16.0.7
     "@types/node": 22.5.5


### PR DESCRIPTION
# Context: 
Fix multiple TS errors at backend dev startup