### PR TITLE
[frontend] fix(services): homepage service list now refreshed on subscription & service card rendering issues

### DIFF
--- a/portal-front/app/(application)/page.tsx
+++ b/portal-front/app/(application)/page.tsx
@@ -28,17 +28,6 @@ const Page: React.FunctionComponent = () => {
     useQueryLoader<userServiceOwnedQuery>(UserServiceOwnedQuery);
   useMountingLoader(loadQueryUserServiceOwned, { count, orderBy, orderMode });
 
-  const handleUpdate = useCallback(() => {
-    loadQueryUserServiceOwned(
-      {
-        count,
-        orderBy: 'service_name',
-        orderMode: 'asc',
-      },
-      { fetchPolicy: 'network-only' }
-    );
-  }, []);
-
   // Public services
   const [countServiceList] = useLocalStorage('countServiceList', 50);
   const [orderModeServiceList] = useLocalStorage<OrderingMode>(
@@ -58,6 +47,25 @@ const Page: React.FunctionComponent = () => {
     orderBy: orderByServiceList,
     orderMode: orderModeServiceList,
   });
+
+  const handleUpdate = useCallback(() => {
+    loadQueryUserServiceOwned(
+      {
+        count,
+        orderBy: 'service_name',
+        orderMode: 'asc',
+      },
+      { fetchPolicy: 'network-only' }
+    );
+    loadQueryPublicServiceList(
+      {
+        count,
+        orderBy: 'name',
+        orderMode: 'asc',
+      },
+      { fetchPolicy: 'network-only' }
+    );
+  }, []);
 
   if (!queryRefUserServiceOwned || !queryRefPublicServiceList)
     return <Loader />;

--- a/portal-front/src/components/service/service-instance-card.tsx
+++ b/portal-front/src/components/service/service-instance-card.tsx
@@ -17,24 +17,25 @@ const ServiceInstanceCard: React.FunctionComponent<
   const isLinkService =
     serviceInstance?.service_definition?.identifier ===
     SERVICE_DEFINITION_IDENTIFIER.LINK;
-  const isPending =
-    serviceInstance?.creation_status === SERVICE_CREATION_STATUS.PENDING;
+  const isDisabled =
+    serviceInstance?.creation_status === SERVICE_CREATION_STATUS.PENDING ||
+    rightAction !== undefined;
+
+  let serviceHref: string | undefined;
+  let serviceTarget: string | undefined;
+  if (!isDisabled) {
+    serviceHref =
+      isLinkService && serviceInstance.links?.[0]?.url
+        ? serviceInstance.links?.[0]?.url
+        : `/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}`;
+    serviceTarget = serviceInstance.links?.[0]?.url?.startsWith('http')
+      ? '_blank'
+      : '_self';
+  }
 
   return (
     <li className="relative">
-      <a
-        href={
-          isLinkService && serviceInstance.links?.[0]?.url
-            ? serviceInstance.links?.[0]?.url
-            : `/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}`
-        }
-        target={
-          serviceInstance.links?.[0]?.url?.startsWith('http')
-            ? '_blank'
-            : '_self'
-        }
-        className="flex justify-center items-center flex-col gap-l bg-blue-900 h-48 w-full box-border pl-s cursor-pointer aria-disabled:opacity-60 aria-disabled:cursor-not-allowed"
-        aria-disabled={isPending}>
+      <div className="flex justify-center items-center flex-col gap-l bg-blue-900 h-48 w-full box-border pl-s">
         <LogoFiligranIcon className="absolute inset-0 text-white opacity-10 z-0 size-64 rotate-45 blur" />
         <div className="mt-s flex items-center h-12 w-full">
           <div
@@ -44,7 +45,15 @@ const ServiceInstanceCard: React.FunctionComponent<
               backgroundSize: 'cover',
             }}
           />
-          <h3 className="m-l text-white">{serviceInstance.name}</h3>
+          <h3 className="m-l text-white position-relative z-10">
+            <a
+              href={serviceHref}
+              target={serviceTarget}
+              className="after:content-[''] after:absolute after:inset-0 aria-disabled:opacity-60 aria-disabled:after:hidden"
+              aria-disabled={isDisabled}>
+              {serviceInstance.name}
+            </a>
+          </h3>
         </div>
 
         <div
@@ -56,18 +65,8 @@ const ServiceInstanceCard: React.FunctionComponent<
             paddingLeft: '20px',
           }}
         />
-      </a>
-      <div
-        className="h-40 border-light flex flex-col relative border bg-page-background p-l gap-xs cursor-pointer aria-disabled:opacity-60 aria-disabled:cursor-not-allowed"
-        onClick={() => {
-          const url = isLinkService
-            ? serviceInstance.links?.[0]?.url
-            : `/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}`;
-          if (url) {
-            window.open(url, url.startsWith('http') ? '_blank' : '_self');
-          }
-        }}
-        aria-disabled={isPending}>
+      </div>
+      <div className="h-40 border-light flex flex-col relative border bg-page-background p-l gap-xs">
         <div className="mt-s flex items-center h-12 w-full">
           <h3 className="">{serviceInstance.name}</h3>
           <div


### PR DESCRIPTION
# Context: 
This PR fixes two issues related to the homepage service list and service cards:

1. Service list refresh:
    - Previously, when subscribing to a service, the homepage service list was not updating properly.
    - Now, the list refreshes correctly, ensuring that newly subscribed services are immediately reflected.
2. Service card rendering fix:
    - Recent changes introduced a regression affecting the display of service cards.
    - This PR resolves the rendering issues to ensure consistency and proper UI behavior.

# How to test:  
1. Go to the homepage and check the list of available services.
3. Subscribe to a service and you're not redirected to the service page (as the bug does).
4. Verify that the service list updates correctly without requiring a manual refresh.

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information: 


Close #330
