### PR TITLE
[front/back] - (Service): Add pictures in service #337

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -199,6 +199,7 @@ export type Mutation = {
   addLabel: Label;
   addOrganization?: Maybe<Organization>;
   addServiceInstance?: Maybe<Subscription>;
+  addServicePicture?: Maybe<ServiceInstance>;
   addSubscription?: Maybe<ServiceInstance>;
   addSubscriptionInService?: Maybe<ServiceInstance>;
   addUser?: Maybe<User>;
@@ -250,6 +251,13 @@ export type MutationAddOrganizationArgs = {
 
 export type MutationAddServiceInstanceArgs = {
   input?: InputMaybe<AddServiceInput>;
+};
+
+
+export type MutationAddServicePictureArgs = {
+  document?: InputMaybe<Scalars['Upload']['input']>;
+  isLogo?: InputMaybe<Scalars['Boolean']['input']>;
+  serviceId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -1186,6 +1194,7 @@ export type MutationResolvers<ContextType = PortalContext, ParentType extends Re
   addLabel?: Resolver<ResolversTypes['Label'], ParentType, ContextType, RequireFields<MutationAddLabelArgs, 'input'>>;
   addOrganization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<MutationAddOrganizationArgs, 'input'>>;
   addServiceInstance?: Resolver<Maybe<ResolversTypes['Subscription']>, ParentType, ContextType, Partial<MutationAddServiceInstanceArgs>>;
+  addServicePicture?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddServicePictureArgs>>;
   addSubscription?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddSubscriptionArgs>>;
   addSubscriptionInService?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddSubscriptionInServiceArgs>>;
   addUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAddUserArgs, 'input'>>;

--- a/portal-api/src/modules/services/service-instance.graphql
+++ b/portal-api/src/modules/services/service-instance.graphql
@@ -49,6 +49,11 @@ type Mutation {
     @auth(requires: [BCK_MANAGE_SERVICES])
   deleteServiceInstance(id: ID!): ServiceInstance
     @auth(requires: [BCK_MANAGE_SERVICES])
+  addServicePicture(
+    serviceId: ID
+    document: Upload
+    isLogo: Boolean
+  ): ServiceInstance @auth(requires: [BCK_MANAGE_SERVICES])
 }
 
 type Query {

--- a/portal-front/app/(application)/(admin)/admin/service/page.tsx
+++ b/portal-front/app/(application)/(admin)/admin/service/page.tsx
@@ -1,20 +1,14 @@
 'use client';
+import AdminServiceTab from '@/components/service/admin-service-tab';
 import {
   ServiceListQuery,
   servicesListFragment,
 } from '@/components/service/service.graphql';
 import { BreadcrumbNav } from '@/components/ui/breadcrumb-nav';
-import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
-import useGoToServiceLink from '@/hooks/useGoToServiceLink';
-import { i18nKey } from '@/utils/datatable';
 import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
 import { serviceQuery } from '@generated/serviceQuery.graphql';
 import { servicesList_services$key } from '@generated/servicesList_services.graphql';
-import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
-import { MoreVertIcon } from 'filigran-icon';
-import { DataTable } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
 import { useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 
 const breadcrumbValue = [
@@ -27,62 +21,7 @@ const breadcrumbValue = [
 ];
 
 const Page = () => {
-  const router = useRouter();
   const t = useTranslations();
-  const goToServiceLink = useGoToServiceLink();
-
-  const columns: ColumnDef<serviceList_fragment$data>[] = [
-    {
-      accessorKey: 'name',
-      id: 'name',
-      header: t('Service.Name'),
-    },
-    {
-      accessorKey: 'description',
-      id: 'description',
-      header: t('Service.Description'),
-    },
-    {
-      accessorKey: 'creation_status',
-      id: 'creation_status',
-      header: t('Service.CreationStatus'),
-    },
-    {
-      id: 'actions',
-      cell: ({ row }) => {
-        return (
-          <div className="flex items-center justify-end">
-            <IconActions
-              icon={
-                <>
-                  <MoreVertIcon
-                    aria-hidden={true}
-                    focusable={false}
-                    className="h-4 w-4 text-primary"
-                  />
-                  <span className="sr-only">{t('Utils.OpenMenu')}</span>
-                </>
-              }>
-              {row.original.service_definition?.identifier !== 'link' && (
-                <IconActionsButton
-                  aria-label={t('Service.GoToAdminLabel')}
-                  onClick={() => {
-                    router.push(`/admin/service/${row.id}`);
-                  }}>
-                  {t('Service.GoToAdminLabel')}
-                </IconActionsButton>
-              )}
-              <IconActionsButton
-                aria-label={t('Service.GoTo')}
-                onClick={() => goToServiceLink(row.original, row.id)}>
-                {t('Service.GoToLabel')}
-              </IconActionsButton>
-            </IconActions>
-          </div>
-        );
-      },
-    },
-  ];
 
   const queryData = useLazyLoadQuery<serviceQuery>(ServiceListQuery, {
     count: 50,
@@ -100,14 +39,7 @@ const Page = () => {
     <>
       <BreadcrumbNav value={breadcrumbValue} />
       <h1>{t('MenuLinks.Services')}</h1>
-      <DataTable
-        columns={columns}
-        i18nKey={i18nKey(t)}
-        data={serviceData}
-        tableOptions={{
-          getSortedRowModel: getSortedRowModel(),
-        }}
-      />
+      <AdminServiceTab serviceData={serviceData} />
     </>
   );
 };

--- a/portal-front/messages/en.json
+++ b/portal-front/messages/en.json
@@ -335,6 +335,13 @@
       "DuplicateName": "An organization with this name already exists"
     }
   },
+  "ServiceForm": {
+    "EditService": "Edit service's pictures",
+    "UpdatePictures": "Pictures",
+    "PictureUpdated": "Pictures updated for service: {serviceName}",
+    "Illustration": "Service's illustration",
+    "Logo": "Service's logo"
+  },
   "UserListPage": {
     "Title": "Users list",
     "Email": "Email",

--- a/portal-front/messages/fr.json
+++ b/portal-front/messages/fr.json
@@ -336,6 +336,13 @@
       "DuplicateName": "Une organisation portant ce nom existe déjà"
     }
   },
+  "ServiceForm": {
+    "EditService": "Editer les illustrations d'un service",
+    "UpdatePictures": "Illustrations",
+    "PictureUpdated": "Illustrations mises à jour pour le service : {serviceName}",
+    "Illustration": "Illustration du service",
+    "Logo": "Logo du service"
+  },
   "UserListPage": {
     "Title": "Liste des utilisateurs",
     "Email": "Email",

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -28,6 +28,7 @@ type Mutation {
   editServiceInstance(id: ID!, name: String!): ServiceInstance
   addServiceInstance(input: AddServiceInput): Subscription
   deleteServiceInstance(id: ID!): ServiceInstance
+  addServicePicture(serviceId: ID, document: Upload, isLogo: Boolean): ServiceInstance
   addLabel(input: AddLabelInput!): Label!
   editLabel(id: ID!, input: EditLabelInput!): Label!
   deleteLabel(id: ID!): Label!

--- a/portal-front/src/components/service/admin-service-tab.tsx
+++ b/portal-front/src/components/service/admin-service-tab.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { EditService } from '@/components/service/edit-service';
+import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
+import useGoToServiceLink from '@/hooks/useGoToServiceLink';
+import { i18nKey } from '@/utils/datatable';
+import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
+import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
+import { MoreVertIcon } from 'filigran-icon';
+import { DataTable } from 'filigran-ui';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+interface AdminServiceTabProps {
+  serviceData: serviceList_fragment$data[];
+}
+
+const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
+  const t = useTranslations();
+  const goToServiceLink = useGoToServiceLink();
+  const router = useRouter();
+
+  const columns: ColumnDef<serviceList_fragment$data>[] = [
+    {
+      accessorKey: 'name',
+      id: 'name',
+      header: t('Service.Name'),
+    },
+    {
+      accessorKey: 'description',
+      id: 'description',
+      header: t('Service.Description'),
+    },
+    {
+      accessorKey: 'creation_status',
+      id: 'creation_status',
+      header: t('Service.CreationStatus'),
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => {
+        return (
+          <div className="flex items-center justify-end">
+            <IconActions
+              icon={
+                <>
+                  <MoreVertIcon
+                    aria-hidden={true}
+                    focusable={false}
+                    className="h-4 w-4 text-primary"
+                  />
+                  <span className="sr-only">{t('Utils.OpenMenu')}</span>
+                </>
+              }>
+              {row.original.service_definition?.identifier !== 'link' && (
+                <IconActionsButton
+                  aria-label={t('Service.GoToAdminLabel')}
+                  onClick={() => {
+                    router.push(`/admin/service/${row.id}`);
+                  }}>
+                  {t('Service.GoToAdminLabel')}
+                </IconActionsButton>
+              )}
+              <IconActionsButton
+                aria-label={t('Service.GoTo')}
+                onClick={() => goToServiceLink(row.original, row.id)}>
+                {t('Service.GoToLabel')}
+              </IconActionsButton>
+
+              <EditService service={row.original} />
+            </IconActions>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      i18nKey={i18nKey(t)}
+      data={serviceData}
+      tableOptions={{
+        getSortedRowModel: getSortedRowModel(),
+      }}
+    />
+  );
+};
+export default AdminServiceTab;

--- a/portal-front/src/components/service/edit-service.tsx
+++ b/portal-front/src/components/service/edit-service.tsx
@@ -1,0 +1,82 @@
+import {
+  newPicturesSchema,
+  ServiceForm,
+} from '@/components/service/service-form';
+import { ServiceAddPicture } from '@/components/service/service.graphql';
+import { IconActionContext } from '@/components/ui/icon-actions';
+import { fileListToUploadableMap } from '@/relay/environment/fetchFormData';
+import { serviceAddPictureMutation } from '@generated/serviceAddPictureMutation.graphql';
+import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
+import { Button, useToast } from 'filigran-ui';
+import { useTranslations } from 'next-intl';
+import { FunctionComponent, useContext, useEffect, useState } from 'react';
+import { useMutation } from 'react-relay';
+import { z } from 'zod';
+import { SheetWithPreventingDialog } from '../ui/sheet-with-preventing-dialog';
+
+interface EditServiceProps {
+  service: serviceList_fragment$data;
+}
+
+export const EditService: FunctionComponent<EditServiceProps> = ({
+  service,
+}) => {
+  const t = useTranslations();
+  const { toast } = useToast();
+  const [openSheet, setOpenSheet] = useState<boolean | null>(null);
+  const { setMenuOpen } = useContext(IconActionContext);
+
+  useEffect(() => {
+    if (!openSheet && openSheet !== null) setMenuOpen(false);
+  }, [openSheet]);
+
+  const [servicePictureMutation] =
+    useMutation<serviceAddPictureMutation>(ServiceAddPicture);
+
+  const pictureMutation = (document: FileList, isLogo: boolean) => {
+    servicePictureMutation({
+      variables: {
+        serviceId: service.id,
+        document: document,
+        isLogo: isLogo,
+      },
+      uploadables: fileListToUploadableMap(document),
+      onCompleted: (response) => {
+        setOpenSheet(false);
+        toast({
+          title: t('Utils.Success'),
+          description: t('ServiceForm.PictureUpdated', {
+            serviceName: response.addServicePicture?.name,
+          }),
+        });
+      },
+      onError: (error) => {
+        toast({
+          variant: 'destructive',
+          title: t('Utils.Error'),
+          description: t(`Error.Server.${error.message}`),
+        });
+      },
+    });
+  };
+  const handleSubmit = (values: z.infer<typeof newPicturesSchema>) => {
+    pictureMutation(values.logo_document, true);
+    pictureMutation(values.illustration_document, false);
+  };
+  return (
+    <SheetWithPreventingDialog
+      open={openSheet ?? false}
+      setOpen={setOpenSheet}
+      trigger={
+        <Button
+          variant="ghost"
+          className="w-full justify-start normal-case"
+          aria-label={t('ServiceForm.EditService')}>
+          {t('ServiceForm.UpdatePictures')}
+        </Button>
+      }
+      title={t('ServiceForm.EditService')}>
+      <ServiceForm handleSubmit={handleSubmit} />
+    </SheetWithPreventingDialog>
+  );
+};

--- a/portal-front/src/components/service/service-form.tsx
+++ b/portal-front/src/components/service/service-form.tsx
@@ -1,0 +1,120 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { useDialogContext } from '@/components/ui/sheet-with-preventing-dialog';
+import {
+  Button,
+  FileInput,
+  FileInputDropZone,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  SheetFooter,
+} from 'filigran-ui';
+import { useTranslations } from 'next-intl';
+import { FunctionComponent } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+export const newPicturesSchema = z.object({
+  illustration_document: z.custom<FileList>(),
+  logo_document: z.custom<FileList>(),
+});
+
+interface ServiceFormProps {
+  handleSubmit: (values: z.infer<typeof newPicturesSchema>) => void;
+}
+
+export const ServiceForm: FunctionComponent<ServiceFormProps> = ({
+  handleSubmit,
+}) => {
+  const t = useTranslations();
+  const { handleCloseSheet } = useDialogContext();
+  const form = useForm<z.infer<typeof newPicturesSchema>>({
+    resolver: zodResolver(newPicturesSchema),
+    defaultValues: {
+      illustration_document: undefined,
+      logo_document: undefined,
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof newPicturesSchema>) => {
+    handleSubmit({
+      ...values,
+    });
+    form.reset();
+  };
+
+  return (
+    <FileInputDropZone className="absolute inset-0 p-xl pt-[5rem]">
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="w-full space-y-xl">
+          <FormField
+            control={form.control}
+            name="illustration_document"
+            render={({ field }) => {
+              return (
+                <FormItem>
+                  <FormLabel>{t('ServiceForm.Illustration')}</FormLabel>
+                  <FormControl>
+                    <FileInput
+                      {...field}
+                      texts={{
+                        selectFile: t('Service.Vault.FileForm.SelectDocument'),
+                        noFile: t('Service.Vault.FileForm.NoDocument'),
+                        dropFiles: t('Service.Vault.FileForm.DropDocuments'),
+                      }}
+                      allowedTypes={
+                        'image/jpeg, image/gif, image/png, image/svg'
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+          <FormField
+            control={form.control}
+            name="logo_document"
+            render={({ field }) => {
+              return (
+                <FormItem>
+                  <FormLabel>{t('ServiceForm.Logo')}</FormLabel>
+                  <FormControl>
+                    <FileInput
+                      {...field}
+                      texts={{
+                        selectFile: t('Service.Vault.FileForm.SelectDocument'),
+                        noFile: t('Service.Vault.FileForm.NoDocument'),
+                        dropFiles: t('Service.Vault.FileForm.DropDocuments'),
+                      }}
+                      allowedTypes={
+                        'image/jpeg, image/gif, image/png, image/svg'
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+
+          <SheetFooter className="pt-2">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={(e) => handleCloseSheet(e)}>
+              {t('Utils.Cancel')}
+            </Button>
+            <Button type="submit">{t('Utils.Validate')}</Button>
+          </SheetFooter>
+        </form>
+      </Form>
+    </FileInputDropZone>
+  );
+};

--- a/portal-front/src/components/service/service.graphql.ts
+++ b/portal-front/src/components/service/service.graphql.ts
@@ -12,6 +12,23 @@ export const ServiceListCreateMutation = graphql`
   }
 `;
 
+export const ServiceAddPicture = graphql`
+  mutation serviceAddPictureMutation(
+    $serviceId: ID
+    $document: Upload
+    $isLogo: Boolean
+  ) {
+    addServicePicture(
+      serviceId: $serviceId
+      document: $document
+      isLogo: $isLogo
+    ) {
+      id
+      name
+    }
+  }
+`;
+
 export const ServiceById = graphql`
   query serviceByIdQuery($service_instance_id: ID) {
     serviceInstanceById(service_instance_id: $service_instance_id) {


### PR DESCRIPTION
# Context: 
> This PR is a simple drawer to add pictures in the service (to see a beautiful homepage with logo & pictures)

# How to test:  
Connect as ADMIN Platform. 
Go to Settings > Services
Click on the three dots menu, then "Pictures". 
On the new tray, upload a picture to illustrate the service, and a logo picture. 
Go on the homepage. You should see your new pictures ! :) 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information: 
This PR follows the #273 
![image](https://github.com/user-attachments/assets/435ce95c-3cc6-4d6a-814d-475c0772ccc5)

Close #337 
