### PR TITLE
[Frontend] - (ServicePicture): Changing only one picture is possible.

### DIFF
--- a/portal-front/src/components/service/edit-service.tsx
+++ b/portal-front/src/components/service/edit-service.tsx
@@ -33,7 +33,10 @@ export const EditService: FunctionComponent<EditServiceProps> = ({
   const [servicePictureMutation] =
     useMutation<serviceAddPictureMutation>(ServiceAddPicture);
 
-  const pictureMutation = (document: FileList, isLogo: boolean) => {
+  const pictureMutation = (document: FileList | undefined, isLogo: boolean) => {
+    if (!document) {
+      return;
+    }
     servicePictureMutation({
       variables: {
         serviceId: service.id,


### PR DESCRIPTION
# Context: 
Before, we had a bug : could not update just one service's picture. We had an error if one picture was undefined. Now, this case is handled :) 

# How to test:  
Connect as an administrator
Go to Settings > Service 
Choose a service and click "picture" to update its pictures. 
Update just one picture, it should be ok 
Update the two pictures, it should be ok. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information: 
https://www.loom.com/share/03edb082b9ac4283ba65b3f1b9ea27c7?sid=d7e7ce99-2b62-45d2-9dc1-18ee064734e8

Close #382 
