### PR TITLE
[frontend] bug ui header is transparent #454

### DIFF
--- a/portal-front/src/components/header.tsx
+++ b/portal-front/src/components/header.tsx
@@ -50,7 +50,7 @@ const HeaderComponent: React.FunctionComponent<HeaderComponentProps> = ({
   return (
     <header
       className={cn(
-        'sticky top-0 z-100 flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between',
+        'sticky top-0 z-[100] flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between',
         displayLogo ? '' : 'sm:justify-end'
       )}>
       <DisplayLogo


### PR DESCRIPTION
# Context: 
The content page was over the header. Tailwind class z-100 did not work.
![image](https://github.com/user-attachments/assets/82ff967d-f2ba-425c-a7eb-85d2707cee46)
![image](https://github.com/user-attachments/assets/de91ced7-d9b1-4c1b-87d6-97c6c4449bda)


# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information: 


Close #454 
