### PR TITLE
[frontend] fix dashboard fields that should be required #459

### DIFF
--- a/portal-e2e-tests/tests/model/dashboard.pageModel.ts
+++ b/portal-e2e-tests/tests/model/dashboard.pageModel.ts
@@ -38,10 +38,12 @@ export default class DashboardPage {
     name,
     shortDescription,
     version,
+    description,
   }: {
     name: string;
     shortDescription: string;
     version: string;
+    description: string;
   }) {
     await this.page.getByLabel('Add new dashboard').click();
     await this.page.getByPlaceholder('Dashboard name').fill(name);
@@ -49,6 +51,9 @@ export default class DashboardPage {
       .getByPlaceholder('This is some catchphrases to')
       .fill(shortDescription);
     await this.page.getByPlaceholder('1.0.0').fill(version);
+    await this.page
+      .getByRole('textbox', { name: 'This is a paragraph to' })
+      .fill(description);
     await this.page.getByLabel('Publish').click();
     await this.uploadJsonDocument(TEST_JSON_FILE.path);
     await this.uploadImageDocument(TEST_IMAGE_FILE.path);

--- a/portal-e2e-tests/tests/tests_files/custom-dashboard.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/custom-dashboard.spec.ts
@@ -6,6 +6,7 @@ const DASHBOARD_TEST = {
   name: 'e2e dashboard name',
   shortDescription: 'This is a short description',
   version: '1.0.0',
+  description: 'This is a dashboard description markdown',
 };
 
 test.describe.serial('Custom dashboard', () => {

--- a/portal-front/src/components/service/custom-dashboards/custom-dashboard-form.tsx
+++ b/portal-front/src/components/service/custom-dashboards/custom-dashboard-form.tsx
@@ -26,9 +26,9 @@ import { z } from 'zod';
 const fileListCheck = (file: FileList | undefined) => file && file.length > 0;
 
 export const newCustomDashboardSchema = z.object({
-  name: z.string().nonempty(),
-  shortDescription: z.string().max(255),
-  description: z.string().optional(),
+  name: z.string().min(1, 'Required'),
+  shortDescription: z.string().max(255).min(1, 'Required'),
+  description: z.string().min(1, 'Required'),
   productVersion: z.string().regex(/^\d+\.\d+\.\d+$/, {
     message: 'Product version must be X.Y.Z',
   }),
@@ -38,7 +38,7 @@ export const newCustomDashboardSchema = z.object({
   images: z.custom<FileList>(fileListCheck),
   active: z.boolean().optional(),
   labels: z.array(z.string()).optional(),
-  slug: z.string(),
+  slug: z.string().min(1, 'Required'),
 });
 
 export type CustomDashboardFormValues = z.infer<

--- a/portal-front/src/components/service/custom-dashboards/custom-dashboard-update-form.tsx
+++ b/portal-front/src/components/service/custom-dashboards/custom-dashboard-update-form.tsx
@@ -34,16 +34,16 @@ import { z } from 'zod';
 const fileListCheck = (file: FileList | undefined) => file && file.length > 0;
 
 export const updateCustomDashboardSchema = z.object({
-  name: z.string().nonempty(),
-  shortDescription: z.string().max(255).optional(),
+  name: z.string().min(1, 'Required'),
+  shortDescription: z.string().max(255).min(1, 'Required'),
   productVersion: z.string().regex(/^\d+\.\d+\.\d+$/, {
     message: 'Product version must be X.Y.Z',
   }),
-  description: z.string().optional(),
+  description: z.string().min(1, 'Required'),
   labels: z.array(z.string()).optional(),
   active: z.boolean().optional(),
   images: z.custom<FileList>(fileListCheck).optional(),
-  slug: z.string().optional(),
+  slug: z.string().min(1, 'Required'),
 });
 
 interface CustomDashboardFormProps {


### PR DESCRIPTION
# Context: 
We can create dashboard without short description. We should not.
![image](https://github.com/user-attachments/assets/e7e9d541-37e3-4f15-9746-762f5310d985)

# How to test:  
Try to create or update a dashboard without short description, you should not be able to do that.

# What tests has been made: 
- [ ] Integration tests
- [x] E2E tests
- [x] Local tests

# Additional information: 


Close #459 
