### PR TITLE
[backend] add command to use tsx instead of esbuild for dev environment

### DIFF
--- a/portal-api/builder/dev/watch-graphql.js
+++ b/portal-api/builder/dev/watch-graphql.js
@@ -1,0 +1,31 @@
+import { exec } from 'child_process';
+import chokidar from 'chokidar';
+
+const watcher = chokidar.watch('src/**/*.graphql', {
+  ignored: ['node_modules', 'dist'],
+  persistent: true,
+});
+
+let timeout;
+const debounceTime = 100; // Adjust debounce time as needed
+
+const runCodegen = () => {
+  clearTimeout(timeout);
+  timeout = setTimeout(() => {
+    console.log('GraphQL file changed, running codegen...');
+    exec('yarn generate:ts', (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing generate:ts: ${error.message}`);
+        return;
+      }
+      if (stderr) {
+        console.error(`stderr: ${stderr}`);
+      }
+      console.log(`stdout: ${stdout}`);
+    });
+  }, debounceTime);
+};
+
+watcher.on('change', runCodegen);
+watcher.on('add', runCodegen);
+watcher.on('unlink', runCodegen);

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -21,10 +21,12 @@
     "generate-pg-to-ts": "NODE_OPTIONS='--import tsx' kanel",
     "build": "yarn copy && node builder/prod/prod.js",
     "start": "node dist/index.js",
+    "start-tsx": "tsx --watch src/index.ts",
     "dev:tsc": "tsc --watch --preserveWatchOutput",
     "dev:node": "node --watch dist/index.js",
     "dev:esbuild": "yarn copy && node builder/dev/dev.js",
     "start-dev": "concurrently \"yarn dev:tsc\" \"yarn dev:esbuild\" \"yarn dev:node\"",
+    "start-dev-tsx": "concurrently \"yarn dev:tsc\" \"yarn start-tsx\" \"yarn watch:graphql\"",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "format:check": "prettier --check .",
@@ -38,7 +40,8 @@
     "test:w": "VITEST_MODE=true && vitest",
     "init-db-test": "VITEST_MODE=true tsx tests/script/create-database.ts",
     "clean-db-test": "VITEST_MODE=true tsx tests/script/clean-database.ts",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "watch:graphql": "node builder/dev/watch-graphql.js"
   },
   "dependencies": {
     "@apollo/server": "4.11.0",


### PR DESCRIPTION
# Context: 
Since we use esbuild in our local development setup, finding buggy lines can be a hassle. With tsx, there's no minification, allowing us to pinpoint exactly where the code is breaking.

# How to test:  
use `yarn start-dev-tsx`

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information: 


Close #issueNumber 
