### PR TITLE
feat: Deployment CD now done through calls to AWX

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -243,7 +243,7 @@ jobs:
             --conf.token ${{ secrets.AWX_TOKEN }} \
             -f human job_templates launch 'Deploy XTM Hub' \
             --inventory eu-west-production \
-            --extra_vars '{"env":"Production"}'
+            --extra_vars '{"env":"Production","xtmhub_version":"${{ github.ref_name }}"}'
       - name: Deploy on Staging
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
# Context: 

Update the `restart-deployment` job to call AWX to launch an actual deployment of XTM Hub.

# How to test:  

- Tested the AWX job directly on AWX, example: https://awx.filigran.io/#/jobs/playbook/65384/details
- Tested the GitHub action locally using act:
  - Create a secret file `my.secrets`:
    ```shell
    AWX_TOKEN=FOO
    ```
    - Create an event file `event.json`:
    ```json
    {
      "ref": "refs/heads/development"
    }
    ```
    - run act
    ```shell
    act -j restart-deployment -e event.json --secret-file my.secrets
    ```

:information_source:  I have not yet tested a deployment in production, might need to sync with the XTM Hub Team for that

# Additional information:

Will need to add a new repository secret named `AWX_TOKEN` but I don't have the rights to do it.
Might be able to get rid of the following repository secrets:
- `TEAMS_WEBHOOK_URL`
- `K8S_TOKEN_PROD`
- `K8S_TOKEN`
- `K8S_TOKEN_DEV`
