### PR TITLE
[frontend] fix(users): Disable sorting on column organnizations in users list

### DIFF
--- a/portal-front/src/components/admin/user/user-list.tsx
+++ b/portal-front/src/components/admin/user/user-list.tsx
@@ -184,6 +184,7 @@ const UserList: FunctionComponent<UserListProps> = ({ organization }) => {
             accessorKey: 'organizations',
             id: 'organizations',
             header: t('UserListPage.Organizations'),
+            enableSorting: false,
             cell: ({ row }: { row: Row<userList_fragment$data> }) => {
               return (
                 <div className="flex gap-xs">


### PR DESCRIPTION
# Context: 
This pull request includes a small change to the `portal-front/src/components/admin/user/user-list.tsx` file. 
The change disables sorting for the `organizations` column in the `UserList` component.

* [`portal-front/src/components/admin/user/user-list.tsx`](diffhunk://#diff-4d8180be3d00de46120f71b0effc070a4b6a1155447a9cf4772c1b83e902c987R187): Disabled sorting for the `organizations` column by setting `enableSorting` to `false`.

# How to test:  
1. Go to Settings > Security, you shouldn't be able to sort the table on the col Organizations.

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information: 

Related to #487
