### PR TITLE
[front] - (CustomDashboard) : Add the author's organization

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -97,6 +97,7 @@ export type Document = Node & {
   updated_at?: Maybe<Scalars['Date']['output']>;
   updater_id?: Maybe<Scalars['String']['output']>;
   uploader?: Maybe<User>;
+  uploader_organization?: Maybe<Organization>;
 };
 
 export type DocumentConnection = {
@@ -127,6 +128,7 @@ export type EditDocumentInput = {
   product_version?: InputMaybe<Scalars['String']['input']>;
   short_description?: InputMaybe<Scalars['String']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
+  uploader_organization_id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EditLabelInput = {
@@ -1308,6 +1310,7 @@ export type DocumentResolvers<ContextType = PortalContext, ParentType extends Re
   updated_at?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   updater_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uploader?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  uploader_organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/portal-api/src/migrations/20250409120557_add_organization_information_on_document.js
+++ b/portal-api/src/migrations/20250409120557_add_organization_information_on_document.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table('Document', function (table) {
+    table.uuid('uploader_organization_id');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table('Document', function (table) {
+    table.dropColumn('uploader_organization_id');
+  });
+}

--- a/portal-api/src/model/kanel/public/Document.ts
+++ b/portal-api/src/model/kanel/public/Document.ts
@@ -45,6 +45,8 @@ export default interface Document {
   slug: string | null;
 
   share_number: number | null;
+
+  uploader_organization_id: string | null;
 }
 
 /** Represents the initializer for the table public.Document */
@@ -91,6 +93,8 @@ export interface DocumentInitializer {
 
   /** Default value: 0 */
   share_number?: number | null;
+
+  uploader_organization_id?: string | null;
 }
 
 /** Represents the mutator for the table public.Document */
@@ -132,4 +136,6 @@ export interface DocumentMutator {
   slug?: string | null;
 
   share_number?: number | null;
+
+  uploader_organization_id?: string | null;
 }

--- a/portal-api/src/modules/services/document/document.domain.ts
+++ b/portal-api/src/modules/services/document/document.domain.ts
@@ -2,6 +2,7 @@ import config from 'config';
 import { db, dbRaw, dbUnsecure, paginate } from '../../../../knexfile';
 import {
   DocumentConnection,
+  Organization,
   QueryDocumentsArgs,
 } from '../../../__generated__/resolvers-types';
 import {
@@ -234,6 +235,23 @@ export const getUploader = async (
       .limit(1)
       .returning('User.*')
   )[0];
+};
+
+export const getUploaderOrganization = async (
+  context,
+  documentId,
+  opts = {}
+): Promise<Organization> => {
+  const [organization] = await db<Organization>(context, 'Organization', opts)
+    .leftJoin(
+      'Document',
+      'Document.uploader_organization_id',
+      'Organization.id'
+    )
+    .where('Document.id', '=', documentId)
+    .select('Organization.*');
+
+  return organization;
 };
 
 export const getLabels = (context, documentId, opts = {}): Promise<Label[]> =>

--- a/portal-api/src/modules/services/document/document.graphql
+++ b/portal-api/src/modules/services/document/document.graphql
@@ -8,6 +8,7 @@ enum DocumentOrdering {
 type Document implements Node {
   id: ID!
   uploader: User
+  uploader_organization: Organization
   service_instance_id: String!
   name: String
   short_description: String
@@ -33,6 +34,7 @@ input EditDocumentInput {
   product_version: String
   labels: [String!]
   description: String
+  uploader_organization_id: String
   name: String
   active: Boolean
   slug: String

--- a/portal-api/src/modules/services/document/document.resolver.ts
+++ b/portal-api/src/modules/services/document/document.resolver.ts
@@ -4,6 +4,7 @@ import {
   DocumentId,
   DocumentMutator,
 } from '../../../model/kanel/public/Document';
+import { OrganizationId } from '../../../model/kanel/public/Organization';
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { UserId } from '../../../model/kanel/public/User';
 import { logApp } from '../../../utils/app-logger.util';
@@ -16,6 +17,7 @@ import {
   getChildrenDocuments,
   getLabels,
   getUploader,
+  getUploaderOrganization,
   incrementShareNumber,
   loadDocumentBy,
   loadDocuments,
@@ -58,6 +60,7 @@ const resolvers: Resolvers = {
           active: payload.active ?? true,
           labels: payload.labels,
           slug: payload.slug,
+          uploader_organization_id: context.user.selected_organization_id,
         };
 
         const [addedDocument] = await createDocument(data);
@@ -71,7 +74,14 @@ const resolvers: Resolvers = {
       try {
         const [document] = await updateDocumentDescription(
           context,
-          input,
+          input.uploader_organization_id
+            ? ({
+                ...input,
+                uploader_organization_id: extractId<OrganizationId>(
+                  input.uploader_organization_id
+                ),
+              } as DocumentMutator)
+            : input,
           fromGlobalId(documentId).id as DocumentId,
           context.serviceInstanceId as ServiceInstanceId
         );
@@ -110,6 +120,10 @@ const resolvers: Resolvers = {
       }),
     uploader: ({ id }, _, context) =>
       getUploader(context, id, {
+        unsecured: true,
+      }),
+    uploader_organization: ({ id }, _, context) =>
+      getUploaderOrganization(context, id, {
         unsecured: true,
       }),
     labels: ({ id }, _, context) =>

--- a/portal-api/src/modules/services/document/document.test.ts
+++ b/portal-api/src/modules/services/document/document.test.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { contextAdminUser } from '../../../../tests/tests.const';
 import { DocumentMutator } from '../../../model/kanel/public/Document';
+import { OrganizationId } from '../../../model/kanel/public/Organization';
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { PortalContext } from '../../../model/portal-context';
 import * as FileStorage from './document-storage';
@@ -115,6 +116,8 @@ describe('Should modify document', () => {
       description: 'description',
       minio_name: 'minioName',
       file_name: 'filename',
+      uploader_organization_id:
+        'ba091095-418f-4b4f-b150-6c9295e232c4' as OrganizationId,
       service_instance_id:
         'c6343882-f609-4a3f-abe0-a34f8cb11302' as ServiceInstanceId,
     });

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -165,6 +165,7 @@ enum DocumentOrdering {
 type Document implements Node {
   id: ID!
   uploader: User
+  uploader_organization: Organization
   service_instance_id: String!
   name: String
   short_description: String
@@ -190,6 +191,7 @@ input EditDocumentInput {
   product_version: String
   labels: [String!]
   description: String
+  uploader_organization_id: String
   name: String
   active: Boolean
   slug: String

--- a/portal-front/src/components/service/custom-dashboards/[details]/custom-dashboard-details.tsx
+++ b/portal-front/src/components/service/custom-dashboards/[details]/custom-dashboard-details.tsx
@@ -1,4 +1,5 @@
 import { formatDate } from '@/utils/date';
+import { LogoFiligranIcon } from 'filigran-icon';
 import * as React from 'react';
 
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
@@ -19,10 +20,24 @@ const DashboardDetails: React.FunctionComponent<DashboardDetailsProps> = ({
   const t = useTranslations();
   return (
     <div className="space-y-xl">
+      {!documentData.uploader_organization?.personal_space && (
+        <div>
+          <div>
+            <Label className="block pb-s">{'Organization'}</Label>
+            <div className="flex items-center gap-s mb-s">
+              <LogoFiligranIcon className="size-8" />
+              {/*By default, if the organization is undefined, we display Filigran*/}
+
+              {`${documentData.uploader_organization?.name ?? 'Filigran'}`}
+            </div>
+          </div>
+        </div>
+      )}
       <div>
-        <Label className="block pb-xs">
+        <Label className="block pb-s">
           {t('Service.CustomDashboards.Details.Author')}
         </Label>
+
         <div className="flex items-center gap-s">
           <div className="size-8">
             <Avatar src={documentData.uploader?.picture ?? ''} />
@@ -34,7 +49,7 @@ const DashboardDetails: React.FunctionComponent<DashboardDetailsProps> = ({
         </div>
       </div>
       <div>
-        <Label className="block pb-xs">
+        <Label className="block pb-s">
           {t('Service.CustomDashboards.Details.LastUpdatedAt')}
         </Label>
         <span>
@@ -45,19 +60,19 @@ const DashboardDetails: React.FunctionComponent<DashboardDetailsProps> = ({
         </span>
       </div>
       <div>
-        <Label className="block pb-xs">
+        <Label className="block pb-s">
           {t('Service.CustomDashboards.Details.OpenCTIVersion')}
         </Label>
         <span>{documentData.product_version}</span>
       </div>
       <div>
-        <Label className="block pb-xs">
+        <Label className="block pb-s">
           {t('Service.CustomDashboards.Details.Downloads')}
         </Label>
         <span>{roundToNearest(documentData.download_number ?? 0)}</span>
       </div>
       <div>
-        <Label className="block pb-xs">
+        <Label className="block pb-s">
           {t('Service.CustomDashboards.Details.Shares')}
         </Label>
         <span>{roundToNearest(documentData.share_number ?? 0)}</span>

--- a/portal-front/src/components/service/custom-dashboards/custom-dashboard-update-form.tsx
+++ b/portal-front/src/components/service/custom-dashboards/custom-dashboard-update-form.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { getLabels } from '@/components/admin/label/label.utils';
+import { PortalContext } from '@/components/me/app-portal-context';
 import { DocumentAddMutation } from '@/components/service/document/document.graphql';
 import { AlertDialogComponent } from '@/components/ui/alert-dialog';
 import MarkdownInput from '@/components/ui/MarkdownInput';
@@ -22,12 +23,17 @@ import {
   FormMessage,
   Input,
   MultiSelectFormField,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   SheetFooter,
   Textarea,
   toast,
 } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-relay';
 import slugify from 'slugify';
@@ -42,6 +48,7 @@ export const updateCustomDashboardSchema = z.object({
     message: 'Product version must be X.Y.Z',
   }),
   description: z.string().min(1, 'Required'),
+  uploader_organization_id: z.string().min(1, 'Required'),
   labels: z.array(z.string()).optional(),
   active: z.boolean().optional(),
   images: z.custom<FileList>(fileListCheck).optional(),
@@ -75,6 +82,8 @@ export const CustomDashboardUpdateForm = ({
   const t = useTranslations();
   const { handleCloseSheet, setIsDirty } = useDialogContext();
 
+  const { me } = useContext(PortalContext);
+
   const form = useForm<CustomDashboardUpdateFormValues>({
     resolver: zodResolver(updateCustomDashboardSchema),
     defaultValues: {
@@ -82,6 +91,7 @@ export const CustomDashboardUpdateForm = ({
       shortDescription: customDashboard.short_description ?? '',
       productVersion: customDashboard.product_version ?? '',
       description: customDashboard.description ?? '',
+      uploader_organization_id: customDashboard.uploader_organization?.id ?? '',
       active: customDashboard.active ?? false,
       labels: customDashboard.labels.map(({ id }) => id) ?? [],
       slug: customDashboard.slug ?? '',
@@ -266,6 +276,42 @@ export const CustomDashboardUpdateForm = ({
                         }
                       />
                     </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="uploader_organization_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t('OrganizationInServiceAction.Organization')}
+                    </FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue
+                            placeholder={t(
+                              'OrganizationInServiceAction.SelectOrganization'
+                            )}
+                          />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {me?.organizations.map((node) => {
+                          return (
+                            <SelectItem
+                              key={node?.id}
+                              value={node?.id}>
+                              {node?.name}
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/portal-front/src/components/service/custom-dashboards/custom-dashboard-update.tsx
+++ b/portal-front/src/components/service/custom-dashboards/custom-dashboard-update.tsx
@@ -78,6 +78,7 @@ const DashboardUpdate: React.FunctionComponent<DashboardUpdateProps> = ({
           labels: values.labels,
           active: values.active,
           slug: values.slug,
+          uploader_organization_id: values.uploader_organization_id,
         },
       },
       onCompleted: (response) => {

--- a/portal-front/src/components/service/document/document.graphql.ts
+++ b/portal-front/src/components/service/document/document.graphql.ts
@@ -131,6 +131,11 @@ export const documentItem = graphql`
       last_name
       picture
     }
+    uploader_organization {
+      id
+      name
+      personal_space
+    }
     children_documents {
       id
       file_name


### PR DESCRIPTION
# Context: 
> This PR  adds the organization in the detailed page. By default, the organization is Filigran. It is not displayed if the organization is a personal space. 

# How to test:  
Connect as an admnistrator and go on a dashboard details page
Check the organization by Default is "FIligran"
Update the dashboard to update the company with your personal space : you should see no organization (since the personal space should not be displayed) 
Update the dashboard to update the company with Filigran : you should see again FIligran. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
https://www.loom.com/share/ad11efa768fb4cf1a43fe073ee9d69fc?sid=9eef660f-6c90-4f13-8adb-4a988b49567a

Related #425 