### PR TITLE
[front] - Fix(UserManagement) : Display orga's name #502

### DIFF
--- a/portal-front/src/components/admin/user/admin-user-update-form.tsx
+++ b/portal-front/src/components/admin/user/admin-user-update-form.tsx
@@ -229,10 +229,11 @@ export const AdminUserUpdateForm: FunctionComponent<
                       <div className="grid gap-m items-center grid-cols-[1fr_4fr_3rem]">
                         <Label>
                           {
-                            organizations.find(
-                              (organization) =>
-                                organization.node.id === field.organization_id
-                            )?.node.name
+                            user.organization_capabilities?.find(
+                              (orgaCapa) =>
+                                orgaCapa.organization.id ===
+                                field.organization_id
+                            )?.organization.name
                           }
                         </Label>
                         <FormControl>


### PR DESCRIPTION
# Context: 
> It compare the oragnigazation name with the organizations that come back from the backend, not from the list limited to 50 organizations. 

# How to test:  
Add at least 51 organizations in your DB 
Choose a user part of the 51th
Click on Update 
You should see the organization name. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
![image](https://github.com/user-attachments/assets/c76f2ea7-427a-4907-a057-ea0291b19c36)


Related #502 