### PR TITLE
[frontend] feat: add Intercom script #511

### DIFF
--- a/portal-front/app/(application)/layout.tsx
+++ b/portal-front/app/(application)/layout.tsx
@@ -8,6 +8,7 @@ import serverPortalApiFetch from '@/relay/serverPortalApiFetch';
 import { AdminCallout } from '@/components/admin/admin-callout';
 import AppContext from '@/components/app-context';
 import { ContentLayout } from '@/components/content-layout';
+import Intercom from '@/components/external/intercom';
 import HeaderComponent from '@/components/header';
 import Login from '@/components/login/login';
 import Menu from '@/components/menu/menu';
@@ -63,6 +64,7 @@ const RootLayout: React.FunctionComponent<RootLayoutProps> = async ({
                 </div>
               </div>
             </div>
+            <Intercom />
           </PageLoader>
         </AppContext>
       </I18nContext>

--- a/portal-front/src/components/external/intercom.tsx
+++ b/portal-front/src/components/external/intercom.tsx
@@ -1,0 +1,59 @@
+'use client';
+import Script from 'next/script';
+import { useContext, useEffect } from 'react';
+import { PortalContext } from '../me/app-portal-context';
+
+interface CustomWindow extends Window {
+  intercomSettings?: Record<string, string>;
+  Intercom?: (args: string, data?: Record<string, string>) => void;
+}
+
+export default function Intercom() {
+  const { me } = useContext(PortalContext);
+  useEffect(() => {
+    const w = window as CustomWindow;
+    const intercomSettings: Record<string, string> = {
+      api_base: 'https://api-iam.intercom.io',
+      app_id: 'mjwhgrbh',
+    };
+    if (me) {
+      intercomSettings.user_id = me.id;
+      intercomSettings.email = me.email;
+      intercomSettings.name = `${me.first_name} ${me.last_name}`;
+    }
+    w.intercomSettings = intercomSettings;
+    w.Intercom && w.Intercom('update', intercomSettings);
+  }, [me]);
+
+  return (
+    <Script
+      id="intercom-script"
+      strategy="lazyOnload"
+      dangerouslySetInnerHTML={{
+        __html: `
+        (function(){
+          var w=window;var ic=w.Intercom;
+          if(typeof ic==="function"){
+            ic('reattach_activator');ic('update',w.intercomSettings);
+          } else {
+            var d=document;var i=function(){i.c(arguments);};
+            i.q=[];i.c=function(args){i.q.push(args);};
+            w.Intercom=i;
+            var l=function(){
+              var s=d.createElement('script');
+              s.type='text/javascript';
+              s.async=true;
+              s.src='https://widget.intercom.io/widget/mjwhgrbh';
+              var x=d.getElementsByTagName('script')[0];
+              x.parentNode.insertBefore(s,x);
+            };
+            if(document.readyState==='complete'){l();}
+            else if(w.attachEvent){w.attachEvent('onload',l);}
+            else{w.addEventListener('load',l,false);}
+          }
+        })();
+        `,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
# Context: 
This pull request introduces the integration of Intercom into the application layout.

Integration of Intercom:

* [`portal-front/app/(application)/layout.tsx`](diffhunk://#diff-0116eaac84d5ed53e7a9efbce5f6b8c288314e024b787511a8d3e0eb459c8b8fR11): Added import statement for the `Intercom` component and included `<Intercom />` within the `RootLayout` component to ensure it is rendered. [[1]](diffhunk://#diff-0116eaac84d5ed53e7a9efbce5f6b8c288314e024b787511a8d3e0eb459c8b8fR11) [[2]](diffhunk://#diff-0116eaac84d5ed53e7a9efbce5f6b8c288314e024b787511a8d3e0eb459c8b8fR67)

Definition of Intercom component:

* [`portal-front/src/components/external/intercom.tsx`](diffhunk://#diff-0a127059b986c26c9df1a16795cb3d0fd5da5643585c892297715923778cb56bR1-R59): Created a new `Intercom` component that uses the `next/script` module and `useEffect` hook to load and configure the Intercom script based on user context.


# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #511 