### PR TITLE
[frontend]: fix(A11Y) change redirection button to a link

### DIFF
--- a/portal-e2e-tests/tests/model/service.pageModel.ts
+++ b/portal-e2e-tests/tests/model/service.pageModel.ts
@@ -13,7 +13,7 @@ export default class ServicePage {
       .getByRole('row', { name: 'Vault' })
       .getByRole('button')
       .click();
-    await this.page.getByRole('button', { name: 'Manage' }).click();
+    await this.page.getByRole('link', { name: 'Manage' }).click();
   }
 
   async addOrganizationIntoService(organizationName: string) {

--- a/portal-e2e-tests/tests/tests_files/capabilities.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/capabilities.spec.ts
@@ -79,7 +79,7 @@ test.describe('Capabilities', () => {
         .getByRole('button')
         .click();
 
-      await page.getByRole('button', { name: 'Manage users' }).click();
+      await page.getByRole('link', { name: 'Manage users' }).click();
       await servicePage.addUserIntoService(TEST_CAPABILITY.adminThalesEmail);
 
       await loginPage.logout();

--- a/portal-e2e-tests/tests/tests_files/service-management.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-management.spec.ts
@@ -42,7 +42,7 @@ test.describe('Service Management', () => {
         .getByRole('row', { name: TEST_SUBSCRIPTION.organizationName })
         .getByRole('button')
         .click();
-      await page.getByRole('button', { name: 'Manage users' }).click();
+      await page.getByRole('link', { name: 'Manage users' }).click();
       await servicePage.addUserIntoService(TEST_SUBSCRIPTION.userInOrgaEmail);
 
       await expect(

--- a/portal-front/src/components/service/[slug]/service-slug.tsx
+++ b/portal-front/src/components/service/[slug]/service-slug.tsx
@@ -10,7 +10,7 @@ import {
   BreadcrumbNav,
   BreadcrumbNavLink,
 } from '@/components/ui/breadcrumb-nav';
-import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
+import { IconActions, IconActionsLink } from '@/components/ui/icon-actions';
 import { SheetWithPreventingDialog } from '@/components/ui/sheet-with-preventing-dialog';
 import useAdminPath from '@/hooks/useAdminPath';
 import { i18nKey } from '@/utils/datatable';
@@ -28,7 +28,6 @@ import {
   useToast,
 } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
 import { FunctionComponent, useState } from 'react';
 import { PreloadedQuery, useMutation, usePreloadedQuery } from 'react-relay';
 
@@ -45,7 +44,6 @@ const ServiceSlug: FunctionComponent<ServiceSlugProps> = ({
     ServiceByIdWithSubscriptions,
     queryRef
   );
-  const router = useRouter();
 
   const [commitSubscriptionMutation] = useMutation<subscriptionDeleteMutation>(
     SubscriptionDeleteMutation
@@ -116,12 +114,9 @@ const ServiceSlug: FunctionComponent<ServiceSlugProps> = ({
                   <span className="sr-only">{t('Utils.OpenMenu')}</span>
                 </>
               }>
-              <IconActionsButton
-                onClick={() => {
-                  router.push(`/admin/service/${row.id}/subscription`);
-                }}>
+              <IconActionsLink href={`/admin/service/${row.id}/subscription`}>
                 {t('Service.Management.ManageUsers')}
-              </IconActionsButton>
+              </IconActionsLink>
               <AlertDialogComponent
                 AlertTitle={t('Service.Management.RemoveAccess')}
                 actionButtonText={t('Service.Management.RemoveAccess')}

--- a/portal-front/src/components/service/admin-service-tab.tsx
+++ b/portal-front/src/components/service/admin-service-tab.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { EditService } from '@/components/service/edit-service';
-import { IconActions, IconActionsButton } from '@/components/ui/icon-actions';
+import { IconActions, IconActionsLink } from '@/components/ui/icon-actions';
 import { i18nKey } from '@/utils/datatable';
 import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
 import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
 import { DataTable } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
 
 interface AdminServiceTabProps {
   serviceData: serviceList_fragment$data[];
@@ -16,7 +15,6 @@ interface AdminServiceTabProps {
 
 const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
   const t = useTranslations();
-  const router = useRouter();
 
   const columns: ColumnDef<serviceList_fragment$data>[] = [
     {
@@ -51,13 +49,9 @@ const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
                 </>
               }>
               {row.original.service_definition?.identifier !== 'link' && (
-                <IconActionsButton
-                  aria-label={t('Service.GoToAdminLabel')}
-                  onClick={() => {
-                    router.push(`/admin/service/${row.id}`);
-                  }}>
+                <IconActionsLink href={`/admin/service/${row.id}`}>
                   {t('Service.GoToAdminLabel')}
-                </IconActionsButton>
+                </IconActionsLink>
               )}
               <EditService service={row.original} />
             </IconActions>

--- a/portal-front/src/components/ui/icon-actions.tsx
+++ b/portal-front/src/components/ui/icon-actions.tsx
@@ -6,7 +6,9 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from 'filigran-ui';
+import Link from 'next/link';
 import React, {
+  ComponentProps,
   createContext,
   FunctionComponent,
   ReactNode,
@@ -68,6 +70,24 @@ export const IconActionsButton: FunctionComponent<
       onClick={(e) => e.stopPropagation()}
       {...props}>
       {children}
+    </Button>
+  );
+};
+type IconActionsLinkProps = ComponentProps<typeof Link> & {
+  className?: string;
+};
+export const IconActionsLink: FunctionComponent<IconActionsLinkProps> = ({
+  children,
+  className,
+  ...props
+}) => {
+  return (
+    <Button
+      asChild
+      variant="ghost"
+      className={cn('w-full justify-start normal-case', className)}
+      onClick={(e) => e.stopPropagation()}>
+      <Link {...props}>{children}</Link>
     </Button>
   );
 };


### PR DESCRIPTION
# Context: 
> In the 'more' menu, if there is redirection (such as in Settings>Services) it should be a link instead of a button with router.push

# How to test:  
Connect as a BYPASS Admin
Go to Settings > Service
Click on a service you can admin, on the 'more' menu and then choose the  "inspect" tool of your browser console. 
Inspect the "Manage", it should be an "<a>" not a "<button>". 
Then, click on the "Manage". 
CLick on a subscirption 'more' menu and then  choose the "inspect" tool of your browser console. 
Inspect the "Manage users", it should be an "<a>" not a "<button>". 


# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
![image](https://github.com/user-attachments/assets/3b8fd12a-9fd8-4326-804c-d6a8341aa980)

Related #245 