### PR TITLE
chore(config): update app subdomain and URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing to XTM Hub
 
-Thank you for reading this documentation and considering making your contribution to the project. Any contribution that helps us improve the platform is valuable and much appreciated. 
+Thank you for reading this documentation and considering making your contribution to the project. Any contribution that helps us improve the platform is valuable and much appreciated.
 
 In order to help you understand the project, where we are heading and how you can contribute, below are several resources and answers.
 
-Do not hesitate to shoot us an [email](mailto:contact@filigran.io) or join us on our [Slack channel](https://community.filigran.io). Most of the articles below are an introduction for our [detailed documentation](https://docs.xtmhub.filigran.io/latest/).
+Do not hesitate to shoot us an [email](mailto:contact@filigran.io) or join us on our [Slack channel](https://community.filigran.io). Most of the articles below are an introduction for our [detailed documentation](https://docs.hub.filigran.io/latest/).
 
 
 ## Why contribute?
 
 [XTM Hub](https://filigran.io/solutions/xtm-hub/) is the **unified entry point** for Filigran's ecosystem.
-It allows community members, prospects and customers to easily discover our offerings, access resources, and engage with one another (if you want to know more about XTM Hub, you can read the [detailed documentation](https://docs.xtmhub.filigran.io/latest/)).
+It allows community members, prospects and customers to easily discover our offerings, access resources, and engage with one another (if you want to know more about XTM Hub, you can read the [detailed documentation](https://docs.hub.filigran.io/latest/)).
 
 Whether you are an organisation or an individual working or studying in the field of cybersecurity and cyberdefense, or simply as an individual looking for a technical challenge, contributing to the XTM Hub project may represent a great opportunity for you.
 
@@ -34,7 +34,7 @@ For general suggestions or questions about the project or the documentation, you
 
 * You can look through opened issues and help triage them (ask for more information, suggest workarounds, suggest label, flag issues etc.)
 
-* If you are interested in contributing to the development of XTM Hub, please refer to the [detailed documentation](https://docs.xtmhub.filigran.io/latest/). You can either fix an issue that is meaningful to you or develop a feature requested by others.
+* If you are interested in contributing to the development of XTM Hub, please refer to the [detailed documentation](https://docs.hub.filigran.io/latest/). You can either fix an issue that is meaningful to you or develop a feature requested by others.
 
 * All commits messages must be formatted as: `[package] <type>(<scope>): Message (#issueNumber)`.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">
-  <a href="https://xtmhub.filigran.io"><img src="./.github/img/logo_xtm_hub.png" alt="XTMHub"></a>
+  <a href="https://hub.filigran.io"><img src="./.github/img/logo_xtm_hub.png" alt="XTMHub"></a>
 </h1>
 <p align="center">
-  <a href="https://xtmhub.filigran.io" alt="Website"><img src="https://img.shields.io/badge/website-xtmhub.filigran.io-blue.svg" /></a>
-  <a href="https://docs.xtmhub.filigran.io" alt="Documentation"><img src="https://img.shields.io/badge/documentation-latest-orange.svg" /></a>
+  <a href="https://hub.filigran.io" alt="Website"><img src="https://img.shields.io/badge/website-hub.filigran.io-blue.svg" /></a>
+  <a href="https://docs.hub.filigran.io" alt="Documentation"><img src="https://img.shields.io/badge/documentation-latest-orange.svg" /></a>
   <a href="https://community.filigran.io" alt="Slack"><img src="https://img.shields.io/badge/slack-3K%2B%20members-4A154B" /></a>
   <a href="https://github.com/FiligranHQ/xtm-hub/actions"><img src="https://github.com/FiligranHQ/xtm-hub/actions/workflows/dockerbuild-ci.yml/badge.svg?branch=main" /></a>
 </p>
@@ -25,7 +25,7 @@ The goal is simple: **grow the Filigran community** by boosting acquisition and 
 
 ## Documentation
 
-If you want to know more on XTH Hub, you can read the [documentation on the tool](https://docs.xtmhub.filigran.io).
+If you want to know more on XTH Hub, you can read the [documentation on the tool](https://docs.hub.filigran.io).
 
 ## Releases download
 
@@ -33,7 +33,7 @@ The releases are available on the [Github releases page](https://github.com/Fili
 
 ## Installation
 
-All you need to install the XTM Hub platform can be found in the [official documentation](https://docs.xtmhub.filigran.io).
+All you need to install the XTM Hub platform can be found in the [official documentation](https://docs.hub.filigran.io).
 
 ## Contributing
 

--- a/portal-api/config/production.json
+++ b/portal-api/config/production.json
@@ -7,7 +7,7 @@
       "provider": "oidc"
     }
   ],
-  "base_url_front": "https://xtmhub.filigran.io",
+  "base_url_front": "https://hub.filigran.io",
   "init_service_definitions": [],
   "init_services": [],
   "init_service_capabilities": []

--- a/portal-front/app/robots.txt
+++ b/portal-front/app/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Sitemap: https://xtmhub.filigran.io/sitemap.xml
+Sitemap: https://hub.filigran.io/sitemap.xml
 Disallow: /
 Allow: /$
 Allow: /cybersecurity-solutions

--- a/portal-front/src/components/admin/test-env-callout.tsx
+++ b/portal-front/src/components/admin/test-env-callout.tsx
@@ -21,7 +21,7 @@ export function TestEnvCallout() {
             environnement: settings?.environment,
           })}
           <Link
-            href="https://xtmhub.filigran.io/"
+            href="https://hub.filigran.io/"
             className="ml-xs underline">
             {t('GoToProd')}
           </Link>


### PR DESCRIPTION
# Context: 
This pull request updates the project to use the new subdomain `hub.filigran.io` instead of the old subdomain `xtmhub.filigran.io`. 
The changes span across documentation, configuration files, and code references to ensure consistency with the updated domain.

### Documentation Updates:
* Updated links in `CONTRIBUTING.md` to point to the new domain for the detailed documentation (`https://docs.hub.filigran.io/latest/`). [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L7-R13) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L37-R37)
* Updated links in `README.md` to reflect the new domain for the website and documentation (`https://hub.filigran.io` and `https://docs.hub.filigran.io`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R36)

### Configuration Updates:
* Changed the `base_url_front` in `portal-api/config/production.json` to use the new domain (`https://hub.filigran.io`).

### Code and Sitemap Updates:
* Updated the sitemap URL in `portal-front/app/robots.txt` to use the new domain (`https://hub.filigran.io/sitemap.xml`).
* Modified the link in `portal-front/src/components/admin/test-env-callout.tsx` to point to the new domain (`https://hub.filigran.io`).# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.