### PR TITLE
chore(config): fix minio port for local docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Editor config
 .idea
+*.iml
 .zed
+
+# System files
 *~
 .DS_Store

--- a/xtm-hub-dev/docker-compose.yml
+++ b/xtm-hub-dev/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       MINIO_ROOT_PASSWORD: changeme
     ports:
       - "9002:9000"
-      - "8902:8900"
+      - "8902:8902"
     volumes:
       - "minio:/data/minio"
     command: 'minio server /data/minio --console-address ":8902"'


### PR DESCRIPTION
# Context:

I was unable to connect to MinIO portal.

# How to test:

Launch containers
Go to http://localhost:8902
You should see the MinIO portal

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

One IntelliJ file type was missing from `.gitignore` so I added it.