### PR TITLE
[Frontend] - (subscriptionSlug) Add default value in edit-user-service #548

### DIFF
--- a/portal-e2e-tests/tests/model/service.pageModel.ts
+++ b/portal-e2e-tests/tests/model/service.pageModel.ts
@@ -74,7 +74,7 @@ export default class ServicePage {
     await clickRowAction(
       this.page,
       this.page.getByRole('row', { name: userEmail }),
-      'Edit user rights'
+      'Update'
     );
     await this.page.getByLabel(newCapability).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();

--- a/portal-e2e-tests/tests/tests_files/service-management.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-management.spec.ts
@@ -17,6 +17,7 @@ const TEST_SUBSCRIPTION = {
 
 export const GENERIC_CAPABILITY = {
   manageAccess: 'MANAGE_ACCESS',
+  access: 'ACCESS',
 };
 test.describe('Service Management', () => {
   let loginPage: LoginPage;
@@ -63,9 +64,7 @@ test.describe('Service Management', () => {
       await servicePage.editUsersRightsForService(
         TEST_SUBSCRIPTION.userInOrgaEmail
       );
-      await expect(
-        page.getByText(GENERIC_CAPABILITY.manageAccess)
-      ).toBeVisible();
+      await expect(page.getByText(GENERIC_CAPABILITY.access)).toBeVisible();
     });
 
     await test.step('Add user that is not in organization', async () => {

--- a/portal-front/src/components/service/[slug]/userservice-form.tsx
+++ b/portal-front/src/components/service/[slug]/userservice-form.tsx
@@ -12,8 +12,10 @@ import { ServiceCapabilityCreateMutation } from '@/components/service/[slug]/cap
 import { UserServiceCreateMutation } from '@/components/service/user_service.graphql';
 import { useDialogContext } from '@/components/ui/sheet-with-preventing-dialog';
 import { emailRegex } from '@/lib/regexs';
+import { cn } from '@/lib/utils';
 import { DEBOUNCE_TIME } from '@/utils/constant';
 import { serviceCapabilityMutation } from '@generated/serviceCapabilityMutation.graphql';
+import { subscriptionByIdQuery$data } from '@generated/subscriptionByIdQuery.graphql';
 import { userList_fragment$key } from '@generated/userList_fragment.graphql';
 import { userList_users$key } from '@generated/userList_users.graphql';
 import { userListQuery } from '@generated/userListQuery.graphql';
@@ -49,27 +51,17 @@ import {
 } from 'react-relay';
 import { useDebounceCallback } from 'usehooks-ts';
 import { z } from 'zod';
-import { subscriptionWithUserService_fragment$data } from '@generated/subscriptionWithUserService_fragment.graphql';
-import { serviceCapability_fragment$data } from '@generated/serviceCapability_fragment.graphql';
 
 interface UserServiceFormProps {
   connectionId: string;
   userService?: userServices_fragment$data;
-  subscription: subscriptionWithUserService_fragment$data;
-  serviceName: string;
-  serviceId: string;
-  serviceCapabilities: serviceCapability_fragment$data[];
-  organizationId: string;
+  subscription: subscriptionByIdQuery$data;
 }
 
 export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
   connectionId,
   userService,
   subscription,
-  serviceName,
-  serviceId,
-  serviceCapabilities,
-  organizationId,
 }) => {
   const { handleCloseSheet, setIsDirty, setOpenSheet } = useDialogContext();
   const { me } = useContext(PortalContext);
@@ -82,6 +74,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
   const { toast } = useToast();
   const t = useTranslations();
 
+  const organizationId = subscription.subscriptionById?.organization?.id;
   const genericCapabilities = [
     {
       id: GenericCapabilityName.ManageAccess as string,
@@ -90,7 +83,11 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
     },
   ];
 
-  const capabilitiesData = [...serviceCapabilities, ...genericCapabilities];
+  const capabilitiesData = [
+    ...(subscription.subscriptionById?.service_instance?.service_definition
+      ?.service_capability ?? []),
+    ...genericCapabilities,
+  ];
 
   const capabilitiesFormSchema = z.object({
     capabilities: z.array(z.string()),
@@ -119,6 +116,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
         .filter((id) => id !== undefined);
     return currentCapabilities ?? [];
   };
+
   const form = useForm({
     resolver: zodResolver(
       userService?.id ? capabilitiesFormSchema : extendedSchema
@@ -126,7 +124,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
     defaultValues: {
       email: [{ id: '', text: '' }],
       capabilities: getCurrentCapabilities(),
-      organizationId: subscription.subscriptionById?.organization?.id,
+      organizationId: organizationId,
     },
   });
   useEffect(() => {
@@ -134,20 +132,12 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
   }, [form.formState.isDirty]);
 
   useEffect(() => {
-    if (userService?.id) {
-      form.reset({
-        email: [{ id: '', text: '' }],
-        capabilities: getCurrentCapabilities(),
-        organizationId: subscription.subscriptionById?.organization?.id,
-      });
-    } else {
-      // For creating user
-      form.reset({
-        email: [{ id: '', text: '' }],
-        capabilities: [],
-        organizationId: subscription.subscriptionById?.organization?.id,
-      });
-    }
+    const isUserCreation = !userService?.id;
+    form.reset({
+      email: [{ id: '', text: '' }],
+      capabilities: isUserCreation ? [] : getCurrentCapabilities(),
+      organizationId: organizationId,
+    });
   }, [subscription.subscriptionById]);
 
   const onSubmitCapabilitiesSchema = (
@@ -163,7 +153,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
 
           ...editCapaValues,
         },
-        serviceInstanceId: serviceId,
+        serviceInstanceId: subscription.subscriptionById?.service_instance?.id,
       },
       onCompleted() {
         toast({
@@ -191,7 +181,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
         input: {
           email: values.email.map(({ text }) => text),
           capabilities: values.capabilities,
-          subscriptionId: subscription.id,
+          subscriptionId: subscription.subscriptionById?.id ?? '',
         },
       },
       onCompleted() {
@@ -199,7 +189,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
           title: t('Utils.Success'),
           description: t('ServiceActions.UserServiceAdded', {
             email: values.email.map((item) => item.text).join(', '),
-            serviceName: serviceName,
+            serviceName: subscription.subscriptionById?.service_instance?.name,
           }),
         });
         setOpenSheet(false);
@@ -234,7 +224,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
       ...prevFilter,
       organization: organizationId,
     }));
-  }, [organizationId]);
+  }, [subscription.subscriptionById]);
 
   const handleInputChange = (inputValue: string) => {
     setFilter((prevFilter) => ({
@@ -268,7 +258,7 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
       return false;
     }
 
-    return !subscription?.subscription_capability?.some(
+    return !subscription.subscriptionById?.subscription_capability?.some(
       (subscriptionCapa) => id === subscriptionCapa?.service_capability?.id
     );
   };
@@ -341,25 +331,31 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
           <p className="txt-sub-content italic">
             {t('InviteUserServiceForm.Description')}
           </p>
-          {capabilitiesData.map(({ id, name, description }) => (
+          {capabilitiesData.map((capability) => (
             <FormField
-              key={id}
+              key={capability!.id}
               control={form.control}
               name="capabilities"
               render={({ field }) => (
                 <FormItem className="flex items-center space-x-2">
                   <FormControl>
                     <Checkbox
-                      disabled={isCapabilityDisabled(id)}
+                      disabled={isCapabilityDisabled(capability!.id)}
                       className="mt-xs"
-                      checked={(field.value as string[]).includes(id)}
+                      checked={(field.value as string[]).includes(
+                        capability!.id
+                      )}
                       onCheckedChange={(checked) => {
                         const newValue = checked
-                          ? Array.from(new Set([...(field.value || []), id]))
-                          : (field.value || []).filter((value) => value !== id);
+                          ? Array.from(
+                              new Set([...(field.value || []), capability!.id])
+                            )
+                          : (field.value || []).filter(
+                              (value) => value !== capability!.id
+                            );
                         field.onChange(newValue);
                       }}
-                      id={id}
+                      id={capability!.id}
                     />
                   </FormControl>
 
@@ -367,17 +363,24 @@ export const UserServiceForm: FunctionComponent<UserServiceFormProps> = ({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <label
-                          htmlFor={id}
-                          className={`txt-sub-content ${!isCapabilityDisabled(id) ? 'cursor-pointer' : 'cursor-not-allowed'}`}>
-                          {name === GenericCapabilityName.ManageAccess
+                          htmlFor={capability!.id}
+                          aria-disabled={isCapabilityDisabled(capability!.id)}
+                          className={cn(
+                            'txt-sub-content',
+                            isCapabilityDisabled(capability!.id)
+                              ? 'cursor-not-allowed'
+                              : 'cursor-pointer'
+                          )}>
+                          {capability!.name ===
+                          GenericCapabilityName.ManageAccess
                             ? 'Manage access: The user can invite other users from his/her organization to this service'
-                            : `${name} access: ${description}`}
-                          {isCapabilityDisabled(id)}
+                            : `${capability!.name} access: ${capability!.description}`}
+                          {isCapabilityDisabled(capability!.id)}
                         </label>
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>
-                          {isCapabilityDisabled(id)
+                          {isCapabilityDisabled(capability!.id)
                             ? t('InviteUserServiceForm.DisabledCapability')
                             : t('InviteUserServiceForm.GrantCapability')}
                         </p>

--- a/portal-front/src/components/subcription/[slug]/edit-user-service.tsx
+++ b/portal-front/src/components/subcription/[slug]/edit-user-service.tsx
@@ -34,8 +34,7 @@ export const EditUserService: FunctionComponent<EditUserServiceProps> = ({
       trigger={
         <Button
           variant="ghost"
-          className="w-full justify-start normal-case"
-          aria-label={'edit'}>
+          className="w-full justify-start normal-case">
           {t('Utils.Update')}
         </Button>
       }

--- a/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
+++ b/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
@@ -8,8 +8,6 @@ import {
 import BadgeOverflowCounter, {
   BadgeOverflow,
 } from '@/components/ui/badge-overflow-counter';
-import { serviceCapability_fragment$data } from '@generated/serviceCapability_fragment.graphql';
-import { subscriptionWithUserService_fragment$data } from '@generated/subscriptionWithUserService_fragment.graphql';
 import { userServiceFromSubscription$key } from '@generated/userServiceFromSubscription.graphql';
 import {
   userServices_fragment$data,
@@ -296,25 +294,7 @@ const SubscriptionSlug: FunctionComponent<SubscriptionSlugProps> = ({
           })}>
           <UserServiceForm
             connectionId={userServices.userServiceFromSubscription?.__id ?? ''}
-            serviceCapabilities={
-              (queryDataSubscription.subscriptionById?.service_instance
-                ?.service_definition?.service_capability ??
-                []) as serviceCapability_fragment$data[]
-            }
-            serviceName={
-              queryDataSubscription.subscriptionById?.service_instance?.name ??
-              ''
-            }
-            serviceId={
-              queryDataSubscription.subscriptionById?.service_instance?.id ?? ''
-            }
-            subscription={
-              (queryDataSubscription.subscriptionById ??
-                {}) as subscriptionWithUserService_fragment$data
-            }
-            organizationId={
-              queryDataSubscription.subscriptionById?.organization?.id ?? ''
-            }
+            subscription={queryDataSubscription}
           />
         </SheetWithPreventingDialog>
         <DataTableHeadBarOptions />


### PR DESCRIPTION
# Context: 
> This PR add default values for the current user modifier in the subscription-slug. 

# How to test:  
Connect as ADMIN BYPASS 
Go to a subscription-slug and edit a user.
The user's capabilities should be pre-checked :) 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
https://www.loom.com/share/e6bed8ea459646c5bd4ca7b03bcb5bee?sid=52339829-fa16-4e05-b891-d51ece9a6b0e

Related #548 