### PR TITLE
[backend]: issue(csvFeed): Fix resolver to send back subscription #539

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -88,6 +88,7 @@ export type CsvFeed = Node & {
   minio_name: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
   service_instance?: Maybe<ServiceInstance>;
+  service_instance_id: Scalars['String']['output'];
   share_number: Scalars['Int']['output'];
   short_description?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -1384,6 +1385,7 @@ export type CsvFeedResolvers<ContextType = PortalContext, ParentType extends Res
   minio_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   share_number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/portal-api/src/modules/services/document/csv-feed/csv-feed.graphql
+++ b/portal-api/src/modules/services/document/csv-feed/csv-feed.graphql
@@ -16,6 +16,7 @@ type CsvFeed implements Node {
   slug: String
   labels: [Label!]!
   service_instance: ServiceInstance
+  service_instance_id: String!
   subscription: SubscriptionModel
   children_documents: [Document!]
 }

--- a/portal-api/src/modules/services/document/csv-feed/csv-feed.resolver.ts
+++ b/portal-api/src/modules/services/document/csv-feed/csv-feed.resolver.ts
@@ -5,6 +5,7 @@ import { ServiceInstanceId } from '../../../../model/kanel/public/ServiceInstanc
 import { logApp } from '../../../../utils/app-logger.util';
 import { UnknownError } from '../../../../utils/error.util';
 import { extractId } from '../../../../utils/utils';
+import { loadSubscription } from '../../../subcription/subscription.domain';
 import {
   getChildrenDocuments,
   getLabels,
@@ -59,6 +60,9 @@ const resolvers: Resolvers = {
       getUploaderOrganization(context, id, {
         unsecured: true,
       }),
+    subscription: ({ service_instance_id }, _, context) => {
+      return loadSubscription(context, service_instance_id);
+    },
   },
   Query: {
     csvFeeds: async (

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -176,6 +176,7 @@ type CsvFeed implements Node {
   slug: String
   labels: [Label!]!
   service_instance: ServiceInstance
+  service_instance_id: String!
   subscription: SubscriptionModel
   children_documents: [Document!]
 }


### PR DESCRIPTION
# Context: 
> This PR send back the subscriptionId within the CsvFeed to make the "MANAGE_ACCESS" button works. 

# How to test:  
Connect as a user with the MANAGE_ACCESS capability on the service. 
Click on the button MANAGE ACCESS
You should be able to manage the access in your subscription. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
![image](https://github.com/user-attachments/assets/607deb39-00db-48fd-a78d-a8e73d281154)

Related #539 