### PR TITLE
chore(open-source): update LICENSE (#340) 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-# Filigran Source-Available License v1.0
-
-This software is not open source.
-
-We publish this code to ensure transparency, foster collaboration, and allow the community to explore how we build internal tools at Filigran. However, this software is not intended for public or commercial use outside of Filigran.
-
 ## 1. Purpose
 
 The source code is made available **for transparency and learning purposes only**. It is part of an internal tool developed and used exclusively by Filigran.
@@ -31,7 +25,7 @@ This software is provided “as is” without warranty of any kind. Use it at yo
 
 ## 5. Contact
 
-To request commercial use, licensing, or extended access, please contact us at [contact@filigran.io](mailto:contact@filigran.io).
+For any question, please contact us at [contact@filigran.io](mailto:contact@filigran.io).
 
 ---
 


### PR DESCRIPTION
# Context: 
This pull request updates the licensing terms for the project by replacing the previous copyright notice with the Business Source License 1.1. 
The new license introduces specific terms for non-production use and outlines conditions for transitioning to a private license.

### Licensing changes:
* `LICENSE`: Replaced the previous copyright notice with the Business Source License 1.1, which specifies:
  - Non-production use is allowed for internal development, testing, or evaluation purposes.
  - A transition to a private license on the specified change date or four years after the first public distribution.
  - Prohibits production use without purchasing a commercial license.
  - Disclaims all warranties and limits liability.

Related #340 