### PR TITLE
[backend] fix: last login does not work #584

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -1035,6 +1035,7 @@ export enum UserOrdering {
   Disabled = 'disabled',
   Email = 'email',
   FirstName = 'first_name',
+  LastLogin = 'last_login',
   LastName = 'last_name'
 }
 

--- a/portal-api/src/modules/users/users.graphql
+++ b/portal-api/src/modules/users/users.graphql
@@ -4,6 +4,7 @@ enum UserOrdering {
   last_name
   disabled
   country
+  last_login
 }
 
 type Capability implements Node {

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -542,6 +542,7 @@ enum UserOrdering {
   last_name
   disabled
   country
+  last_login
 }
 
 type Capability implements Node {


### PR DESCRIPTION
# Context: 
Graphql api in ordering did not take account last_login param.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 
try to filter on last_login
# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:
Right now, the undefined value shows up at the top. Should we maybe tweak the default sorting so that undefined values go to the bottom instead?
@EllynBsc Personally, I see this more as an improvement than a bug fix, since the default sorting behavior generally works like this

Related #584 