### PR TITLE
[frontend] email should take as much as space as possible #547

### DIFF
--- a/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
+++ b/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
@@ -156,12 +156,12 @@ const SubscriptionSlug: FunctionComponent<SubscriptionSlugProps> = ({
         accessorKey: 'user.email',
         id: 'email',
         header: 'Email',
+        size: -1,
       },
       {
-        accessorKey: 'name',
-        id: 'name',
+        id: 'capabilities',
+        size: 350,
         header: t('Service.Capabilities.CapabilitiesTitle'),
-        size: -1,
         enableSorting: false,
         cell: ({ row }) => {
           const capabilities = row.original?.user_service_capability ?? [];
@@ -195,6 +195,9 @@ const SubscriptionSlug: FunctionComponent<SubscriptionSlugProps> = ({
       },
       {
         id: 'actions',
+        enableHiding: false,
+        enableSorting: false,
+        enableResizing: false,
         size: 40,
         cell: ({ row }) => {
           return (


### PR DESCRIPTION
# Context: 
email should take as much as space as possible

# How to test:  
In Home > Settings > Services > [OpenCTI Custom Dashboards Library > Filigran

Make sure the email column take the most space as right now we do not see the full email when arriving on the page.

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #547