### PR TITLE
[frontend/backend]: (CSVFeed) Share improvements #448

### DIFF
--- a/portal-api/src/modules/services/document/csv-feed/csv-feed.resolver.ts
+++ b/portal-api/src/modules/services/document/csv-feed/csv-feed.resolver.ts
@@ -9,6 +9,7 @@ import { logApp } from '../../../../utils/app-logger.util';
 import { UnknownError } from '../../../../utils/error.util';
 import { extractId } from '../../../../utils/utils';
 import { loadSubscription } from '../../../subcription/subscription.domain';
+import { getServiceInstance } from '../../service-instance.domain';
 import {
   getChildrenDocuments,
   getLabels,
@@ -74,6 +75,9 @@ const resolvers: Resolvers = {
       getLabels(context, id, {
         unsecured: true,
       }),
+    service_instance: ({ service_instance_id }, _, context) => {
+      return getServiceInstance(context, service_instance_id);
+    },
     children_documents: ({ id }, _, context) =>
       getChildrenDocuments(context, id, {
         unsecured: true,


### PR DESCRIPTION
# Context: 
> Send service_instance when requesting a CSV_Feed to forge the share link properly

# How to test:  
Connect as user with access to CSV Feeds 
Go to a CSV Feed 
Click on download : you should download 
Click on share : it should copy a share link on public pages 
Go to this public pages without being connected 
Click on share : it should copy a share link on public pages 
Click on download : you should be redirected to login

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:


Related #448 