### PR TITLE
[frontend] fix: set header as sticky in public pages

### DIFF
--- a/portal-front/app/(public)/layout.tsx
+++ b/portal-front/app/(public)/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
 }) {
   return (
     <div className="flex flex-col min-h-screen">
-      <header className="flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between">
+      <header className="flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between sticky top-0 z-[20]">
         <Link href={`/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}`}>
           <LogoXTMDark className="text-primary mr-2 w-[10rem] h-auto py-l" />
           <span className="sr-only">XTM Hub by Filigran</span>


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

The header disappear from the screen when we scroll on public pages. It must be sticky and not scroll.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- go to public pages (`/cybersecurity-solutions`)
- scroll on the page
- check that the header is sticky and nothing is displayed aboved it (in terms of z-index)
- do the same for csv feed list and detail pages
- do the same for custom OCTI dashboard list and detail pages

https://github.com/user-attachments/assets/952e9f91-d2e6-4616-b999-c2fac2fc5cf8

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Feature branch: https://dev-pr-601.hub.staging.filigran.io/

Related #591 