### PR TITLE
[backend]: (Metrics) expose counter of mutations and queries on /metrics #570

### DIFF
--- a/portal-api/src/index.ts
+++ b/portal-api/src/index.ts
@@ -23,6 +23,7 @@ import { UserLoadUserBy } from './model/user';
 import { documentDownloadEndpoint } from './modules/services/document/document-download-endpoint';
 import { documentVisualizeEndpoint } from './modules/services/document/visualize-document-endpoint';
 import { errorLoggingPlugin } from './server/apollo-plugins/log';
+import { operationMetricsPlugin } from './server/apollo-plugins/metrics';
 import { healthEndpoint } from './server/endpoints/health';
 import createSchema from './server/graphql-schema';
 import platformInit, { minioInit } from './server/initialize';
@@ -113,6 +114,7 @@ const server = new ApolloServer<PortalContext>({
       variables: {},
     }),
     errorLoggingPlugin(),
+    operationMetricsPlugin,
   ],
 });
 

--- a/portal-api/src/server/apollo-plugins/metrics.ts
+++ b/portal-api/src/server/apollo-plugins/metrics.ts
@@ -1,0 +1,40 @@
+import { ApolloServerPlugin } from '@apollo/server';
+import { Counter, Registry } from 'prom-client';
+
+export const registry = new Registry();
+
+export const graphqlMutationCounter = new Counter({
+  name: 'graphql_mutation_total',
+  help: 'Total number of GraphQL mutations called on XTM Hub',
+  labelNames: ['mutation'],
+});
+
+export const graphqlQueryCounter = new Counter({
+  name: 'graphql_query_total',
+  help: 'Total number of GraphQL queries called on XTM Hub',
+  labelNames: ['query'],
+});
+
+registry.registerMetric(graphqlMutationCounter);
+registry.registerMetric(graphqlQueryCounter);
+
+export const operationMetricsPlugin: ApolloServerPlugin = {
+  async requestDidStart() {
+    return {
+      async didResolveOperation({ request, document }) {
+        if (!request.operationName) {
+          return;
+        }
+        document.definitions.forEach((def) => {
+          if (def.kind === 'OperationDefinition') {
+            if (def.operation === 'mutation') {
+              graphqlMutationCounter.inc({ mutation: request.operationName });
+            } else if (def.operation === 'query') {
+              graphqlQueryCounter.inc({ query: request.operationName });
+            }
+          }
+        });
+      },
+    };
+  },
+};

--- a/portal-front/src/relay/environment/fetchFn.ts
+++ b/portal-front/src/relay/environment/fetchFn.ts
@@ -56,7 +56,11 @@ export async function networkFetch({
     credentials: 'same-origin',
     headers,
     cache,
-    body: JSON.stringify({ query: request.text, variables }),
+    body: JSON.stringify({
+      query: request.text,
+      variables,
+      operationName: request.name,
+    }),
     ...options,
   });
   const json = await resp.json();


### PR DESCRIPTION
# Context: 
> To exploit it in Grafana, we need to export a counter of mutations and query. 

# How to test:  
Start the platform. 
Go play with it (you can do mutations and queries) 
Go to your backend URL /metrics and see the countings :) 
That's it !!

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:
![image](https://github.com/user-attachments/assets/72b1842d-7d55-4850-baee-6c435b0c3a47)

Related #570