### PR TITLE
[frontend] fix: remove countryData production build warnings

### DIFF
--- a/portal-front/src/components/ui/country/combobox.tsx
+++ b/portal-front/src/components/ui/country/combobox.tsx
@@ -1,7 +1,7 @@
 import { Combobox } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
 import React, { useMemo } from 'react';
-import * as countryData from './data.json';
+import countryData from './data.json';
 
 interface CountryComboboxProps {
   value?: { name: string } | undefined;
@@ -13,9 +13,10 @@ export const CountryCombobox: React.FC<CountryComboboxProps> = ({
   onValueChange,
 }) => {
   const t = useTranslations();
+  const { countries } = countryData;
   const dataTab = useMemo(() => {
-    return countryData.countries.sort((a, b) => a.name.localeCompare(b.name));
-  }, [countryData]);
+    return countries.sort((a, b) => a.name.localeCompare(b.name));
+  }, [countries]);
 
   return (
     <Combobox


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

- remove warnings in production build due to import of json file

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- launch `yarn build` in `portal-front`
- check that the `countryData` related warnings are removed

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests