### PR TITLE
[frontend] fix: remove breadcumb and allow full name menu click

### DIFF
--- a/portal-front/app/(application)/(user)/profile/page-loader.tsx
+++ b/portal-front/app/(application)/(user)/profile/page-loader.tsx
@@ -11,7 +11,6 @@ const breadcrumbValue = [
   },
   {
     label: 'MenuLinks.Profile',
-    href: '/profile',
   },
 ];
 

--- a/portal-front/src/components/header.tsx
+++ b/portal-front/src/components/header.tsx
@@ -62,9 +62,9 @@ const HeaderComponent: React.FunctionComponent<HeaderComponentProps> = ({
       />
 
       <div className="mobile:hidden flex items-center gap-s">
-        <User />
         <IconActions
           className="rounded-full"
+          label={<User />}
           icon={
             <>
               <div className="my-auto size-10">
@@ -109,7 +109,8 @@ const HeaderComponent: React.FunctionComponent<HeaderComponentProps> = ({
             </SheetHeader>
             <div className="flex flex-1 flex-col h-full justify-between">
               <NavigationApp open={true} />
-              <div className="pb-xl text-center">
+              <div className="pb-xl flex flex-col text-center">
+                <ProfileMenuButton className="w-full" />
                 <Logout />
               </div>
             </div>

--- a/portal-front/src/components/ui/icon-actions.tsx
+++ b/portal-front/src/components/ui/icon-actions.tsx
@@ -18,6 +18,7 @@ import React, {
 interface IconActionsProps {
   children: ReactNode;
   icon: ReactNode;
+  label?: ReactNode;
   className?: string;
 }
 
@@ -30,6 +31,7 @@ export const IconActionContext = createContext<IconActionContextProps>({
 });
 export const IconActions: FunctionComponent<IconActionsProps> = ({
   children,
+  label,
   icon,
   className,
 }) => {
@@ -40,14 +42,14 @@ export const IconActions: FunctionComponent<IconActionsProps> = ({
       open={menuOpen}
       onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          className={cn(
-            'flex h-8 w-8 p-0 data-[state=open]:bg-hover',
-            className
-          )}>
-          {icon}
-        </Button>
+        <div className="flex items-center gap-s cursor-pointer">
+          {label}
+          <Button
+            variant="ghost"
+            className={cn('h-8 w-8 p-0 data-[state=open]:bg-hover', className)}>
+            {icon}
+          </Button>
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

- remove breadcump in profile to avoid confusion
- allow full name click on menu
- add profile link on mobile

https://github.com/user-attachments/assets/ae10e7fc-4c63-4866-bcab-9fbab196e779


# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- click on your name, it should open the menu
- go to the profile page
- check that the profile breadcrumb is not clickable
- reduce the size of your window
- check that there's a profile link above logout

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Feature branch

https://dev-pr-615.hub.staging.filigran.io/

# Additional information:

Related #606