### PR TITLE
[backend]: (AddServicePicture) pass serviceInstanceId in context #625

### DIFF
--- a/portal-api/src/__generated__/resolvers-types.ts
+++ b/portal-api/src/__generated__/resolvers-types.ts
@@ -390,7 +390,7 @@ export type MutationAddServiceInstanceArgs = {
 export type MutationAddServicePictureArgs = {
   document?: InputMaybe<Scalars['Upload']['input']>;
   isLogo?: InputMaybe<Scalars['Boolean']['input']>;
-  serviceId?: InputMaybe<Scalars['ID']['input']>;
+  serviceInstanceId: Scalars['ID']['input'];
 };
 
 
@@ -1700,7 +1700,7 @@ export type MutationResolvers<ContextType = PortalContext, ParentType extends Re
   addLabel?: Resolver<ResolversTypes['Label'], ParentType, ContextType, RequireFields<MutationAddLabelArgs, 'input'>>;
   addOrganization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<MutationAddOrganizationArgs, 'input'>>;
   addServiceInstance?: Resolver<Maybe<ResolversTypes['SubscriptionModel']>, ParentType, ContextType, Partial<MutationAddServiceInstanceArgs>>;
-  addServicePicture?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddServicePictureArgs>>;
+  addServicePicture?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, RequireFields<MutationAddServicePictureArgs, 'serviceInstanceId'>>;
   addSubscription?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddSubscriptionArgs>>;
   addSubscriptionInService?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddSubscriptionInServiceArgs>>;
   addUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAddUserArgs, 'input'>>;

--- a/portal-api/src/modules/services/document/document.helper.ts
+++ b/portal-api/src/modules/services/document/document.helper.ts
@@ -89,11 +89,7 @@ export const loadUnsecureDocumentsBy = async (
   return dbUnsecure<Document[]>('Document').where(field).select('*');
 };
 
-export const uploadNewFile = async (
-  context: PortalContext,
-  document,
-  serviceInstanceId: ServiceInstanceId
-) => {
+export const uploadNewFile = async (context: PortalContext, document) => {
   if (!document || !document.file) {
     return;
   }
@@ -101,12 +97,12 @@ export const uploadNewFile = async (
     document.file,
     document.file.name,
     context.user.id,
-    serviceInstanceId
+    context.serviceInstanceId as ServiceInstanceId
   );
 
   const data: FullDocumentMutator = {
     uploader_id: context.user.id,
-    name: serviceInstanceId,
+    name: context.serviceInstanceId,
     minio_name: minioName,
     file_name: document.file.name,
     service_instance_id: null,
@@ -115,8 +111,7 @@ export const uploadNewFile = async (
     type: 'service_picture',
   };
 
-  const addedDocument = await createDocument(context, data);
-  return addedDocument;
+  return createDocument(context, data);
 };
 
 export const deleteDocuments = async () => {

--- a/portal-api/src/modules/services/service-instance.graphql
+++ b/portal-api/src/modules/services/service-instance.graphql
@@ -68,7 +68,7 @@ type Mutation {
   deleteServiceInstance(id: ID!): ServiceInstance
     @auth(requires: [MANAGE_SUBSCRIPTION])
   addServicePicture(
-    serviceId: ID
+    serviceInstanceId: ID!
     document: Upload
     isLogo: Boolean
   ): ServiceInstance @auth(requires: [MANAGE_SUBSCRIPTION])

--- a/portal-api/src/modules/services/services.resolver.ts
+++ b/portal-api/src/modules/services/services.resolver.ts
@@ -146,11 +146,7 @@ const resolvers: Resolvers = {
       return deletedServiceInstance;
     },
     addServicePicture: async (_, payload, context) => {
-      const document = await uploadNewFile(
-        context,
-        payload.document,
-        fromGlobalId(payload.serviceId).id as ServiceInstanceId
-      );
+      const document = await uploadNewFile(context, payload.document);
       const update = payload.isLogo
         ? {
             logo_document_id: document.id,
@@ -162,7 +158,7 @@ const resolvers: Resolvers = {
         context,
         'ServiceInstance'
       )
-        .where({ id: fromGlobalId(payload.serviceId).id })
+        .where({ id: extractId<ServiceInstanceId>(payload.serviceInstanceId) })
         .update(update)
         .returning('*');
       await dispatch('ServiceInstance', 'edit', updatedServiceInstance);

--- a/portal-e2e-tests/tests/model/service.pageModel.ts
+++ b/portal-e2e-tests/tests/model/service.pageModel.ts
@@ -8,7 +8,9 @@ export default class ServicePage {
     await this.page.getByRole('button', { name: 'Settings' }).click();
     await this.page.getByRole('link', { name: 'Services' }).click();
     await this.page.getByText('Name', { exact: true }).click();
+  }
 
+  async navigateToServiceItemAdmin() {
     await clickRowAction(
       this.page,
       this.page.getByRole('row', { name: 'Vault' }),
@@ -83,5 +85,27 @@ export default class ServicePage {
     await clickRowAction(this.page, row, 'Delete');
     // Wait for the dialog to appear and animation to finish
     await this.page.getByRole('button', { name: 'Remove access' }).click();
+  }
+
+  async addPictureService(
+    firstPathName: string,
+    secondPathName: string,
+    serviceName: string = 'Filigran Academy'
+  ) {
+    await this.page
+      .getByRole('row', { name: serviceName })
+      .getByRole('button')
+      .click();
+    await this.page
+      .getByRole('button', { name: "Edit service's pictures" })
+      .click();
+    const fileInputIllustration = this.page
+      .locator('input[type="file"]')
+      .nth(0);
+
+    await fileInputIllustration.setInputFiles(firstPathName);
+    const fileInputLogo = this.page.locator('input[type="file"]').nth(1);
+    await fileInputLogo.setInputFiles(secondPathName);
+    await this.page.getByRole('button', { name: 'Validate' }).click();
   }
 }

--- a/portal-e2e-tests/tests/tests_files/capabilities.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/capabilities.spec.ts
@@ -69,6 +69,7 @@ test.describe('Capabilities', () => {
   test('Should add subscription with capabilities', async ({ page }) => {
     await test.step("Add orga's sub + user with manage access", async () => {
       await servicePage.navigateToServiceListAdmin();
+      await servicePage.navigateToServiceItemAdmin();
 
       await servicePage.addOrganizationIntoServiceWithCapabilities(
         TEST_CAPABILITY.organizationName

--- a/portal-e2e-tests/tests/tests_files/service-management.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-management.spec.ts
@@ -30,6 +30,7 @@ test.describe('Service Management', () => {
 
     await loginPage.login();
     await servicePage.navigateToServiceListAdmin();
+    await servicePage.navigateToServiceItemAdmin();
   });
 
   test('should be able to admin service', async ({ page }) => {

--- a/portal-e2e-tests/tests/tests_files/service-pictures.spec.ts
+++ b/portal-e2e-tests/tests/tests_files/service-pictures.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '../fixtures/baseFixtures.js';
+import LoginPage from '../model/login.pageModel';
+import ServicePage from '../model/service.pageModel';
+export const PICTURE_1_FILE = {
+  path: './tests/tests_files/assets/test.png',
+  name: 'test.png',
+  description: 'Test picture service',
+};
+export const PICTURE_2_FILE = {
+  path: './tests/tests_files/assets/test2.png',
+  name: 'test2.png',
+  description: 'Test picture service',
+};
+test.describe('Service Management', () => {
+  let loginPage: LoginPage;
+  let servicePage: ServicePage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    servicePage = new ServicePage(page);
+
+    await loginPage.login();
+    await servicePage.navigateToServiceListAdmin();
+  });
+
+  test('should be able to add pictures to a service', async ({ page }) => {
+    await test.step('Add picture to a service', async () => {
+      await servicePage.addPictureService(
+        PICTURE_1_FILE.path,
+        PICTURE_2_FILE.path
+      );
+      await expect(
+        page.getByText('Pictures updated for service: Filigran Academy').first()
+      ).toBeVisible();
+
+      await expect(page.getByText('Success', { exact: true })).toBeVisible();
+    });
+  });
+});

--- a/portal-front/schema.graphql
+++ b/portal-front/schema.graphql
@@ -40,7 +40,7 @@ type Mutation {
   editServiceInstance(id: ID!, name: String!): ServiceInstance
   addServiceInstance(input: AddServiceInput): SubscriptionModel
   deleteServiceInstance(id: ID!): ServiceInstance
-  addServicePicture(serviceId: ID, document: Upload, isLogo: Boolean): ServiceInstance
+  addServicePicture(serviceInstanceId: ID!, document: Upload, isLogo: Boolean): ServiceInstance
   addLabel(input: AddLabelInput!): Label!
   editLabel(id: ID!, input: EditLabelInput!): Label!
   deleteLabel(id: ID!): Label!

--- a/portal-front/src/components/service/edit-service.tsx
+++ b/portal-front/src/components/service/edit-service.tsx
@@ -39,7 +39,7 @@ export const EditService: FunctionComponent<EditServiceProps> = ({
     }
     servicePictureMutation({
       variables: {
-        serviceId: service.id,
+        serviceInstanceId: service.id,
         document: document,
         isLogo: isLogo,
       },

--- a/portal-front/src/components/service/service.graphql.ts
+++ b/portal-front/src/components/service/service.graphql.ts
@@ -14,12 +14,12 @@ export const ServiceListCreateMutation = graphql`
 
 export const ServiceAddPicture = graphql`
   mutation serviceAddPictureMutation(
-    $serviceId: ID
+    $serviceInstanceId: ID!
     $document: Upload
     $isLogo: Boolean
   ) {
     addServicePicture(
-      serviceId: $serviceId
+      serviceInstanceId: $serviceInstanceId
       document: $document
       isLogo: $isLogo
     ) {


### PR DESCRIPTION
# Context: 
> The mutation AddServicePicture uses the function createDocument that uses context with serviceInstanceId. We should then pass the serviceInstanceId. 

# How to test:  
Add a picture to a service. You should be able to see your nw picture and have no errors. 

# What tests has been made: 
- [ ] Integration tests
- [X] E2E tests
- [X] Local tests


Related #617 