### PR TITLE
[backend] fix(documents): make sure filtering list with requested document type (#649)

### DIFF
--- a/portal-api/src/modules/services/csv-feeds/csv-feeds.resolver.ts
+++ b/portal-api/src/modules/services/csv-feeds/csv-feeds.resolver.ts
@@ -101,7 +101,11 @@ const resolvers: Resolvers = {
   },
   Query: {
     csvFeeds: async (_, input, context) =>
-      loadParentDocumentsByServiceInstance<CsvFeedConnection>(context, input),
+      loadParentDocumentsByServiceInstance<CsvFeedConnection>(
+        'csv_feed',
+        context,
+        input
+      ),
     csvFeed: async (_, { id }, context) =>
       loadCsvFeedById(context, extractId<DocumentId>(id)),
     seoCsvFeedsByServiceSlug: async (_, { serviceSlug }) =>

--- a/portal-api/src/modules/services/custom-dashboards/custom-dashboards.resolver.ts
+++ b/portal-api/src/modules/services/custom-dashboards/custom-dashboards.resolver.ts
@@ -73,6 +73,7 @@ const resolvers: Resolvers = {
     },
     customDashboards: async (_, input, context) => {
       return loadParentDocumentsByServiceInstance<CustomDashboardConnection>(
+        'custom_dashboard',
         context,
         input,
         CUSTOM_DASHBOARD_METADATA

--- a/portal-api/src/modules/services/document/document.domain.ts
+++ b/portal-api/src/modules/services/document/document.domain.ts
@@ -392,6 +392,7 @@ export const passDocumentToInactive = async (
 export const loadParentDocumentsByServiceInstance = async <
   T = DocumentConnection | CsvFeedConnection | CustomDashboardConnection,
 >(
+  type: string,
   context: PortalContext,
   input: QueryDocumentsArgs,
   include_metadata?: string[]
@@ -407,6 +408,7 @@ export const loadParentDocumentsByServiceInstance = async <
       'Document.service_instance_id': extractId<ServiceInstanceId>(
         input.serviceInstanceId
       ),
+      'Document.type': type,
     },
     include_metadata
   );


### PR DESCRIPTION
# Context: 
This pull request updates the `loadParentDocumentsByServiceInstance` function to include a `type` parameter for filtering documents by type, and modifies the associated resolvers to pass the appropriate type values. These changes allow us to ensure that we only retrieve the requested documents.

### Updates to document querying:

* [`portal-api/src/modules/services/document/document.domain.ts`](diffhunk://#diff-ab4f14486202558c48be982d4a596d8f7055617426fe74358ede70e2af4679a4R395): Added a `type` parameter to the `loadParentDocumentsByServiceInstance` function and updated the query logic to filter documents by their type using the `Document.type` field. [[1]](diffhunk://#diff-ab4f14486202558c48be982d4a596d8f7055617426fe74358ede70e2af4679a4R395) [[2]](diffhunk://#diff-ab4f14486202558c48be982d4a596d8f7055617426fe74358ede70e2af4679a4R411)

### Resolver modifications to support the new `type` parameter:

* [`portal-api/src/modules/services/csv-feeds/csv-feeds.resolver.ts`](diffhunk://#diff-5c0f528378370bc0d9154859cae9f083db9aa67406e8809811d173f2234df91aL104-R108): Updated the `csvFeeds` resolver to pass `'csv_feed'` as the type parameter to `loadParentDocumentsByServiceInstance`.
* [`portal-api/src/modules/services/custom-dashboards/custom-dashboards.resolver.ts`](diffhunk://#diff-7e332a62f3bfc599d45ec879bf5f5eaea44118917017a20354e541a1056ef11fR76): Updated the `customDashboards` resolver to pass `'custom_dashboard'` as the type parameter to `loadParentDocumentsByServiceInstance`.

# What tests has been made: 
- [ ] Integration tests
- [X] E2E tests
- [X] Local tests

# Additional information:

Related #649