### PR TITLE
chore(ci): save CI service logs and push them in an artifact to debug

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -101,8 +101,60 @@ jobs:
           export IMAGE_TAGS="${{ needs.build-images-tests.outputs.docker-tags }}" \
            TEAMS_WEBHOOK_E2E="${{ secrets.TEAMS_WEBHOOK_E2E }}" \
            GITHUB_PR_TITLE="${{ github.event.pull_request.title }}" \
-           GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}"
+           GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}" \
+           GITHUB_RUN_ID="${{ github.run_id }}"
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run portal-e2e-tests
+
+      - name: Collect service logs on failure
+        if: failure()
+        run: |
+          echo "=== Collecting logs from all services ==="
+          echo ""
+          echo "=== Portal API Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-api || echo "Could not collect portal-api logs"
+          echo ""
+          echo "=== Portal API Test Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-api-test || echo "Could not collect portal-api-test logs"
+          echo ""
+          echo "=== Portal Front Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-front || echo "Could not collect portal-front logs"
+          echo ""
+          echo "=== Portal Front Test Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-front-test || echo "Could not collect portal-front-test logs"
+          echo ""
+          echo "=== PostgreSQL Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-postgres || echo "Could not collect portal-postgres logs"
+          echo ""
+          echo "=== MinIO Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-minio || echo "Could not collect portal-minio logs"
+          echo ""
+          echo "=== E2E Tests Logs ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-e2e-tests || echo "Could not collect portal-e2e-tests logs"
+          echo ""
+          echo "=== Docker container status ==="
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml ps -a || echo "Could not get container status"
+
+      - name: Save logs as artifacts
+        if: failure()
+        run: |
+          mkdir -p logs
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-api > logs/portal-api.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-api-test > logs/portal-api-test.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-front > logs/portal-front.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-front-test > logs/portal-front-test.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-postgres > logs/portal-postgres.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-minio > logs/portal-minio.log 2>&1 || true
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs portal-e2e-tests > logs/portal-e2e-tests.log 2>&1 || true
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30
+
+
 
   run-front-unit-tests:
     needs: build-images-tests

--- a/portal-e2e-tests/tests/webhooks/notification-webhook.js
+++ b/portal-e2e-tests/tests/webhooks/notification-webhook.js
@@ -95,6 +95,7 @@ export default async (reportData) => {
   console.log(facts);
 
   const prLink = `https://github.com/FiligranHQ/xtm-hub/pull/${process.env.GITHUB_PR_NUMBER}`;
+  const artifactLink = `https://github.com/FiligranHQ/xtm-hub/actions/runs/${process.env.GITHUB_RUN_ID}`;
   let description = ``;
   if (summary.passed.value === summary.tests.value) {
     description += '\\\n ✔ Congratulations! All tests passed.';
@@ -151,6 +152,11 @@ export default async (reportData) => {
             {
               type: 'TextBlock',
               text: `[${prLink}](${prLink})`,
+            },
+            {
+              type: 'TextBlock',
+              text: `[📋 Service Logs Artifact](${artifactLink})`,
+              weight: 'bolder',
             },
             {
               type: 'Image',

--- a/xtm-hub-dev/docker-compose-ci.yml
+++ b/xtm-hub-dev/docker-compose-ci.yml
@@ -2,6 +2,11 @@ version: "3.7"
 services:
   portal-front:
     container_name: portal-front
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     build:
       context: ../portal-front/.
       cache_from:
@@ -21,6 +26,11 @@ services:
 
   portal-front-test:
     container_name: portal-front-test
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     build:
       context: ../portal-front/.
       dockerfile: test.Dockerfile
@@ -33,6 +43,11 @@ services:
 
   portal-api-test:
     container_name: portal-api-test
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     build:
       context: ../portal-api/.
       dockerfile: test.Dockerfile
@@ -63,6 +78,11 @@ services:
 
   portal-api:
     container_name: portal-api
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     build:
       context: ../portal-api/.
       cache_from:
@@ -100,6 +120,11 @@ services:
 
   portal-postgres:
     container_name: portal-postgres
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     image: postgres:16.0
     environment:
       - POSTGRES_USER=portal
@@ -114,6 +139,11 @@ services:
 
   portal-minio:
     container_name: portal-minio
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     image: "minio/minio:RELEASE.2024-08-03T04-33-23Z"
     environment:
       MINIO_ROOT_USER: portal
@@ -126,6 +156,11 @@ services:
       retries: 10
 
   portal-e2e-tests:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     build:
       context: ../portal-e2e-tests/.
       cache_from:
@@ -151,3 +186,4 @@ services:
       - TEAMS_WEBHOOK_E2E=${TEAMS_WEBHOOK_E2E}
       - GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER}
       - GITHUB_PR_TITLE=${GITHUB_PR_TITLE}
+      - GITHUB_RUN_ID=${GITHUB_RUN_ID}


### PR DESCRIPTION
# Context: 
This pull request introduces several improvements to the CI pipeline and logging configuration. 
Key changes include adding support for collecting and uploading service logs on test failures, enhancing notification messages with links to log artifacts, and configuring logging limits for Docker containers to prevent excessive log growth.

### CI Pipeline Enhancements:
* [`.github/workflows/dockerbuild-ci.yml`](diffhunk://#diff-c1ea070a271ae1b7649194f23337685bad6caa3cd9d8412235abb25d74451409L104-R158): Added steps to collect service logs on failure, save them as artifacts, and upload them for easier debugging. These logs include outputs from services like `portal-api`, `portal-front`, `portal-postgres`, and others.

### Notification Improvements:
* [`portal-e2e-tests/tests/webhooks/notification-webhook.js`](diffhunk://#diff-9ee3724525898c58be31d7d29a9a8ca65fe9e2e51ac2c2130a562034fc334a22R98): Enhanced webhook notifications to include a link to the uploaded service logs artifact, making it easier to access logs directly from the notification. [[1]](diffhunk://#diff-9ee3724525898c58be31d7d29a9a8ca65fe9e2e51ac2c2130a562034fc334a22R98) [[2]](diffhunk://#diff-9ee3724525898c58be31d7d29a9a8ca65fe9e2e51ac2c2130a562034fc334a22R156-R160)

### Logging Configuration:
* [`xtm-hub-dev/docker-compose-ci.yml`](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR5-R9): Configured all services (`portal-front`, `portal-api`, `portal-postgres`, etc.) to use the `json-file` logging driver with limits on log size (`max-size: "10m"`) and file count (`max-file: "3"`). This prevents logs from growing indefinitely and consuming excessive disk space. [[1]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR5-R9) [[2]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR29-R33) [[3]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR46-R50) [[4]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR81-R85) [[5]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR123-R127) [[6]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR142-R146) [[7]](diffhunk://#diff-079e414734b4ccfd891bc0525c65f16323d41bdaea161d34acd7fc354bcbcbefR159-R163)

These changes collectively improve the reliability and maintainability of the CI pipeline and help streamline debugging processes.

# How to test:  
> Create a bug 😁  and check the CI logs

# What tests has been made: 
- [ ] Integration tests
- [X] E2E tests
- [X] Local tests