### PR TITLE
[frontend] fix: redirect user to login on download click in public pages

### DIFF
--- a/portal-front/app/(application)/layout.tsx
+++ b/portal-front/app/(application)/layout.tsx
@@ -76,7 +76,7 @@ const RootLayout: FunctionComponent<RootLayoutProps> = async ({ children }) => {
     );
   } catch (error) {
     if ((error as Error).message === should_redirect_error) {
-      redirect(PUBLIC_CYBERSECURITY_SOLUTIONS_PATH);
+      redirect(`/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}`);
     }
 
     console.error('RootLayout Error:', error);

--- a/portal-front/app/redirect/[identifier]/route.ts
+++ b/portal-front/app/redirect/[identifier]/route.ts
@@ -93,7 +93,7 @@ export async function GET(
 
   // Build the login URL from the settings and the curent URL
   const getRedirectionURL = () => {
-    const baseURL = new URL(baseUrlFront);
+    const baseURL = new URL(`${baseUrlFront}/login`);
     const redirectURL = new URL(request.url);
     redirectURL.hostname = baseURL.hostname;
     redirectURL.protocol = baseURL.protocol;


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

- use new login page when redirecting from public pages
- use absolute path to redirect user when he is not authenticated

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #665 