### PR TITLE
[frontend] fix(csv-feed): make sure labels are populated in the update form (#676)

### DIFF
--- a/portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx
+++ b/portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx
@@ -56,6 +56,7 @@ export const CsvFeedForm = ({
           ...doc,
           name: doc.file_name,
         })) as unknown as FileList,
+        labels: csvFeed?.labels?.map((label) => label.id),
       }) as CsvFeedFormValues,
     [csvFeed]
   );
@@ -116,11 +117,11 @@ export const CsvFeedForm = ({
                 <FormControl>
                   <MultiSelectFormField
                     noResultString={t('Utils.NotFound')}
-                    options={getLabels().map(({ name, id }) => ({
-                      label: name,
-                      value: id,
-                    }))}
-                    value={field.value || []}
+                    options={getLabels()}
+                    keyValue="id"
+                    keyLabel="name"
+                    defaultValue={field.value}
+                    value={field.value}
                     onValueChange={field.onChange}
                     placeholder={t('Service.CsvFeed.Form.LabelsLabel')}
                     variant="inverted"


### PR DESCRIPTION
# Context: 
This pull request introduces updates to the `CsvFeedForm` component to improve label handling. The most significant changes include updating the form's value initialization, and simplifying the `MultiSelectFormField` configuration for label selection.

### Label Handling Enhancements:
* Updated the `values` object to include `labels` derived from the `csvFeed` data, mapping label IDs for form initialization. (`portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx`, [portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsxR64](diffhunk://#diff-a8fe32217b0b279a9561aab2d483899c4bafe68a33ef6423e5f959a8d22f8013R64))
* Refactored the `MultiSelectFormField` configuration to use `keyValue` and `keyLabel` for mapping label options, replacing the manual mapping logic. Also adjusted the `defaultValue` and `value` properties for improved clarity and functionality. (`portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx`, [portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsxL119-R129](diffhunk://#diff-a8fe32217b0b279a9561aab2d483899c4bafe68a33ef6423e5f959a8d22f8013L119-R129))

# What tests has been made: 
- [ ] Integration tests
- [X] E2E tests
- [X] Local tests

# Additional information:

Related #676