### PR TITLE
[frontend] fix(shareable-resources): make resource card entirely clickable

### DIFF
--- a/portal-front/src/components/ui/shareable-resource/shareable-resource-card.tsx
+++ b/portal-front/src/components/ui/shareable-resource/shareable-resource-card.tsx
@@ -49,7 +49,6 @@ const ShareableResourceCard = ({
           {document?.labels && (
             <BadgeOverflowCounter
               badges={document?.labels as BadgeOverflow[]}
-              className="z-[2]"
             />
           )}
           <ShareLinkButton
@@ -59,7 +58,7 @@ const ShareableResourceCard = ({
           {extraContent}
         </div>
         <Link
-          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring after:cursor-pointer after:content-[' '] after:absolute after:inset-0"
+          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring after:cursor-pointer after:content-[' '] after:absolute after:inset-0 after:z-[1]"
           href={detailUrl}>
           <h3 className="line-clamp-2 text-ellipsis flex-1 max-h-[10rem] overflow-hidden">
             {document?.short_description}

--- a/portal-front/src/components/ui/shareable-resource/shareable-resource-illustration.tsx
+++ b/portal-front/src/components/ui/shareable-resource/shareable-resource-illustration.tsx
@@ -5,6 +5,7 @@ import { serviceByIdQuery$data } from '@generated/serviceByIdQuery.graphql';
 import { Carousel, CarouselItem } from 'filigran-ui/clients';
 import { AspectRatio } from 'filigran-ui/servers';
 import Image from 'next/image';
+import Link from 'next/link';
 import ShareableResourceBento from './shareable-resource-bento';
 
 interface ShareableResourceCardIllustrationProps {
@@ -63,10 +64,12 @@ const ShareableResourceCardIllustration = ({
             <ShareableResourceCarousel />
           )) || (
           <div className="relative h-full p-s">
-            <ShareableResourceBento
-              document={document}
-              serviceInstanceId={serviceInstance.id}
-            />
+            <Link href={detailUrl}>
+              <ShareableResourceBento
+                document={document}
+                serviceInstanceId={serviceInstance.id}
+              />
+            </Link>
           </div>
         )}
       </AspectRatio>

--- a/portal-front/src/utils/shareable-resources/shareable-resources.consts.ts
+++ b/portal-front/src/utils/shareable-resources/shareable-resources.consts.ts
@@ -1,0 +1,66 @@
+import SeoCsvFeedBySlugQuery from '@generated/seoCsvFeedBySlugQuery.graphql';
+import SeoCsvFeedsByServiceSlugQuery from '@generated/seoCsvFeedsByServiceSlugQuery.graphql';
+import SeoCustomDashboardBySlugQuery from '@generated/seoCustomDashboardBySlugQuery.graphql';
+import SeoCustomDashboardsByServiceSlugQuery from '@generated/seoCustomDashboardsByServiceSlugQuery.graphql';
+
+import {
+  MakeQueryMapParams,
+  QueryMapEntry,
+  SeoCsvFeed,
+  SeoCustomDashboard,
+  SeoResource,
+  ServiceSlug,
+} from './shareable-resources.types';
+
+function makeQueryMapEntry<TReturn>({
+  query,
+  key,
+}: Omit<MakeQueryMapParams, 'isList'>): QueryMapEntry<TReturn[]> {
+  const cast = (data: unknown): TReturn[] => {
+    const safeData = data as Record<string, unknown>;
+    return safeData[key] as TReturn[];
+  };
+  return { query, cast };
+}
+
+function makeSingleQueryMapEntry<TReturn>({
+  query,
+  key,
+}: Omit<MakeQueryMapParams, 'isList'>): QueryMapEntry<TReturn> {
+  const cast = (data: unknown): TReturn => {
+    const safeData = data as Record<string, unknown>;
+    return safeData[key] as TReturn;
+  };
+  return { query, cast };
+}
+
+export const localeMap: Record<ServiceSlug, string> = {
+  [ServiceSlug.OPEN_CTI_INTEGRATION_FEEDS]: 'CsvFeed',
+  [ServiceSlug.OPEN_CTI_CUSTOM_DASHBOARDS]: 'CustomDashboards',
+};
+
+export const queryMap: Record<ServiceSlug, QueryMapEntry<SeoResource[]>> = {
+  [ServiceSlug.OPEN_CTI_INTEGRATION_FEEDS]: makeQueryMapEntry<SeoCsvFeed>({
+    query: SeoCsvFeedsByServiceSlugQuery,
+    key: 'seoCsvFeedsByServiceSlug',
+  }),
+  [ServiceSlug.OPEN_CTI_CUSTOM_DASHBOARDS]:
+    makeQueryMapEntry<SeoCustomDashboard>({
+      query: SeoCustomDashboardsByServiceSlugQuery,
+      key: 'seoCustomDashboardsByServiceSlug',
+    }),
+};
+
+export const querySlugMap: Record<ServiceSlug, QueryMapEntry<SeoResource>> = {
+  [ServiceSlug.OPEN_CTI_INTEGRATION_FEEDS]: makeSingleQueryMapEntry<SeoCsvFeed>(
+    {
+      query: SeoCsvFeedBySlugQuery,
+      key: 'seoCsvFeedBySlug',
+    }
+  ),
+  [ServiceSlug.OPEN_CTI_CUSTOM_DASHBOARDS]:
+    makeSingleQueryMapEntry<SeoCustomDashboard>({
+      query: SeoCustomDashboardBySlugQuery,
+      key: 'seoCustomDashboardBySlug',
+    }),
+};

--- a/portal-front/src/utils/shareable-resources/shareable-resources.types.ts
+++ b/portal-front/src/utils/shareable-resources/shareable-resources.types.ts
@@ -1,0 +1,100 @@
+import { csvFeedsItem_fragment$data } from '@generated/csvFeedsItem_fragment.graphql';
+import { customDashboardsItem_fragment$data } from '@generated/customDashboardsItem_fragment.graphql';
+import { ConcreteRequest } from 'relay-runtime';
+
+export type ShareableResource =
+  | customDashboardsItem_fragment$data
+  | csvFeedsItem_fragment$data
+  | SeoCsvFeed
+  | SeoCustomDashboard;
+
+export type SeoResource = SeoCsvFeed | SeoCustomDashboard;
+
+export interface SeoCustomDashboard {
+  description: string;
+  id: string;
+  type: 'custom_dashboard';
+  children_documents: {
+    id: string;
+  }[];
+  created_at: string;
+  updated_at: string;
+  labels: {
+    color: string;
+    id: string;
+    name: string;
+  }[];
+  name: string;
+  slug: string;
+  short_description: string;
+  product_version: string;
+  download_number: number;
+  share_number: number;
+  uploader: {
+    first_name: string;
+    last_name: string;
+    picture: string;
+  };
+  active: boolean;
+  service_instance: {
+    id: string;
+    slug: string;
+  };
+  uploader_organization: {
+    id: string;
+    name: string;
+    personal_space: boolean;
+  };
+}
+
+export interface SeoCsvFeed {
+  description: string;
+  id: string;
+  type: 'csv_feed';
+  children_documents: {
+    id: string;
+  }[];
+  created_at: string;
+  updated_at: string;
+  labels: {
+    color: string;
+    id: string;
+    name: string;
+  }[];
+  name: string;
+  slug: string;
+  short_description: string;
+  download_number: number;
+  share_number: number;
+  uploader: {
+    first_name: string;
+    last_name: string;
+    picture: string;
+  };
+  active: boolean;
+  service_instance: {
+    id: string;
+    slug: string;
+  };
+  uploader_organization: {
+    id: string;
+    name: string;
+    personal_space: boolean;
+  };
+}
+
+export type QueryMapEntry<TReturn> = {
+  query: ConcreteRequest;
+  cast: (data: unknown) => TReturn;
+};
+
+export type MakeQueryMapParams = {
+  query: ConcreteRequest;
+  key: string;
+};
+
+export type ServiceInfo = { link: string; description: string };
+export enum ServiceSlug {
+  OPEN_CTI_INTEGRATION_FEEDS = 'open-cti-integration-feeds',
+  OPEN_CTI_CUSTOM_DASHBOARDS = 'open-cti-custom-dashboards',
+}


### PR DESCRIPTION
# Context: 
This pull request includes updates to improve the styling and functionality of the `ShareableResourceCard` and `ShareableResourceCardIllustration` components. 
The most important changes include adjustments to CSS classes for better layering and the addition of a `Link` wrapper for improved navigation.

### Styling improvements:
* [`portal-front/src/components/ui/shareable-resource-card.tsx`](diffhunk://#diff-eeb0088d4facf72109cec045752f245fa1614e7854c1042f13446ae9eedec6d0L52): Removed the `z-[2]` class from `BadgeOverflowCounter` and added `after:z-[1]` to the `Link` element to ensure proper layering of elements. [[1]](diffhunk://#diff-eeb0088d4facf72109cec045752f245fa1614e7854c1042f13446ae9eedec6d0L52) [[2]](diffhunk://#diff-eeb0088d4facf72109cec045752f245fa1614e7854c1042f13446ae9eedec6d0L62-R61)

### Functional enhancements:
* [`portal-front/src/components/ui/shareable-resource-illustration.tsx`](diffhunk://#diff-4eb18067e589c03d2638a7d1e275a500c220d5084b3a460a380f1def67f5e8daR63-R68): Added the `Link` component to wrap `DocumentBento` inside the `AspectRatio` container, enabling clickable navigation to the `detailUrl`.
* [`portal-front/src/components/ui/shareable-resource-illustration.tsx`](diffhunk://#diff-4eb18067e589c03d2638a7d1e275a500c220d5084b3a460a380f1def67f5e8daR8): Imported the `Link` component from `next/link` to support the new navigation functionality.

# What tests has been made: 
- [ ] Integration tests
- [X] E2E tests
- [X] Local tests

# Additional information:

Related #673 