### PR TITLE
[frontend] fix(cards): unreachable labels tooltip on cards (#698)

### DIFF
--- a/portal-front/src/components/ui/shareable-resource/shareable-resource-card.tsx
+++ b/portal-front/src/components/ui/shareable-resource/shareable-resource-card.tsx
@@ -49,18 +49,21 @@ const ShareableResourceCard = ({
         serviceInstance={serviceInstance}
       />
       <div className="flex flex-col flex-grow p-l space-y-s">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center">
           {document?.labels && (
             <BadgeOverflowCounter
               badges={document?.labels as BadgeOverflow[]}
+              className="z-[2]"
             />
           )}
-          <ShareLinkButton
-            documentId={document.id}
-            url={shareLinkUrl}
-            tooltipText={`Service.${localeMap[serviceInstance.slug as ServiceSlug]}.Actions.Share`}
-          />
-          {extraContent}
+          <div className="flex items-center flex-shrink-0 ml-auto">
+            <ShareLinkButton
+              documentId={document.id}
+              url={shareLinkUrl}
+              tooltipText={`Service.${localeMap[serviceInstance.slug as ServiceSlug]}.Actions.Share`}
+            />
+            {extraContent}
+          </div>
         </div>
         <Link
           className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring after:cursor-pointer after:content-[' '] after:absolute after:inset-0 after:z-[1]"


### PR DESCRIPTION
# Context: 
This pull request makes a small UI fix to the `ShareableResourceCard` component by fixing label overflow counter being unreachable.

* [`portal-front/src/components/ui/shareable-resource/shareable-resource-card.tsx`](diffhunk://#diff-fbede3b0d7762ffa6da2316840553d57af754a1b495823b8d6a340536690397fR56-R67): Added a wrapper `div` with flex alignment and spacing (`className="flex items-center ml-auto"`) for better positioning of the `ShareLinkButton` and `extraContent`. Also, added a `className` property to the `BadgeOverflowCounter` for layout adjustments.

# How to test:  
1. Create a shareable resource with a lot of labels.
2. Try to show the tooltip

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #698 