### PR TITLE
[e2e] tech: add timeout after snapshot create and reset

### DIFF
--- a/portal-e2e-tests/tests/db-utils/snapshot.ts
+++ b/portal-e2e-tests/tests/db-utils/snapshot.ts
@@ -23,6 +23,8 @@ export const createDBSnapshot = async (): Promise<void> => {
   await dbPostgres.raw(
     `CREATE DATABASE ${SNAPSHOT_DATABASE_NAME} WITH TEMPLATE ${DB_NAME};`
   );
+
+  return new Promise((resolve) => setTimeout(resolve, 400));
 };
 
 export const resetDBSnapshot = async (): Promise<void> => {
@@ -33,6 +35,8 @@ export const resetDBSnapshot = async (): Promise<void> => {
   await dbPostgres.raw(
     `CREATE DATABASE ${DB_NAME} WITH TEMPLATE ${SNAPSHOT_DATABASE_NAME}`
   );
+
+  return new Promise((resolve) => setTimeout(resolve, 400));
 };
 
 export const removeDBSnapshot = async (): Promise<void> => {


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

Stabilise tests by letting api reconnect to database after snapshot create or reset

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [x] E2E tests
- [ ] Local tests

# Additional information:

Related #610 