### PR TITLE
chore(ci): add a deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,98 @@
+name: Create Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Deployment version type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure we're on main branch
+        run: |
+          git checkout main
+          git pull origin main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "23"
+          cache: "yarn"
+          cache-dependency-path: |
+            portal-api/yarn.lock
+            portal-front/yarn.lock
+
+      - name: Verify directories exist
+        run: |
+          if [ ! -d "./portal-api" ] || [ ! -d "./portal-front" ]; then
+            echo "Error: portal-api or portal-front directory does not exist"
+            exit 1
+          fi
+
+      - name: Install dependencies for portal-api
+        working-directory: ./portal-api
+        run: |
+          yarn install
+          yarn plugin import version
+
+      - name: Install dependencies for portal-front
+        working-directory: ./portal-front
+        run: |
+          yarn install
+          yarn plugin import version
+
+      - name: Bump deployment version in portal-api
+        working-directory: ./portal-api
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "NEW_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Sync deployment version in portal-front
+        working-directory: ./portal-front
+        run: |
+          yarn version ${{ env.NEW_VERSION }}
+
+      - name: Commit and tag changes
+        run: |
+          git add portal-api/package.json portal-api/yarn.lock portal-front/package.json portal-front/yarn.lock
+          git commit -m "chore(release): bump version to ${{ env.NEW_VERSION }}"
+          git tag "v${{ env.NEW_VERSION }}"
+
+      - name: Push changes and tag
+        run: |
+          git push origin main
+          git push origin "v${{ env.NEW_VERSION }}"
+
+      - name: Summary
+        run: |
+          echo "## Deployment Summary 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Version:** v${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version Type:** ${{ github.event.inputs.version_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Components Updated:** portal-api, portal-front" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag Created:** v${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The deployment has been successfully created and pushed to the repository." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Context: 
This pull request introduces a new GitHub Actions workflow for automating deployments. 
The workflow supports versioning (patch, minor, major), installs dependencies, synchronizes versions across components, commits changes, and pushes tags.

### Deployment Automation:

* Added a new workflow in `.github/workflows/deployment.yml` named "Create Deployment" that triggers on `workflow_dispatch` with an input for version type (`patch`, `minor`, `major`).
* Configures Git, ensures the main branch is checked out, and sets up Node.js with caching for `yarn` dependencies.
* Verifies the existence of `portal-api` and `portal-front` directories, installs their dependencies, and synchronizes their versions based on the specified version type.
* Commits updated `package.json` and `yarn.lock` files, creates a version tag, and pushes the changes and tag to the repository.
* Generates a deployment summary with details such as the new version, version type, updated components, and created tag.