### PR TITLE
[backend] add logApp error on loginProvider

### DIFF
--- a/portal-api/src/auth/auth-platform.ts
+++ b/portal-api/src/auth/auth-platform.ts
@@ -36,7 +36,7 @@ export const initAuthPlatform = async (app) => {
           passport.authenticate(
             provider,
             {},
-            (err: unknown, user: UserInfo | false | null) => {
+            (err: Error, user: UserInfo | false | null) => {
               if (!user) {
                 reject(new Error('User not provided'));
               } else if (err) {

--- a/portal-api/src/auth/login-handle.ts
+++ b/portal-api/src/auth/login-handle.ts
@@ -1,4 +1,5 @@
 import { UserInfo } from '../model/user';
+import { AppLogsCategory, logApp } from '../utils/app-logger.util';
 import { ErrorType } from '../utils/error.util';
 import { loginFromProvider } from './auth-user';
 
@@ -11,6 +12,7 @@ export const providerLoginHandler = async (userInfo: UserInfo, done) => {
       if (err.name === ErrorType.ForbiddenAccess) {
         done(null, null);
       }
+      logApp.error(err, {}, AppLogsCategory.LOGIN_PROVIDER);
       done(err);
     });
 };

--- a/portal-api/src/utils/app-logger.util.ts
+++ b/portal-api/src/utils/app-logger.util.ts
@@ -18,6 +18,7 @@ export enum AppLogsCategory {
   BACKEND = 'BACKEND',
   GRAPHQL = 'BACKEND_GRAPHQL',
   FRONTEND = 'FRONTEND',
+  LOGIN_PROVIDER = 'LOGIN_PROVIDER',
 }
 
 /*


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

We’re missing some logs for issue #726. By adding a logApp error in the providerLoginHandler, we should be able to get more information about what’s happening in production.
Currently, we’re completely blind to what might have happened to the user.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #726