### PR TITLE
[backend] add logger next error User not provided #726

### DIFF
--- a/portal-api/src/auth/auth-platform.ts
+++ b/portal-api/src/auth/auth-platform.ts
@@ -1,6 +1,6 @@
 import bodyParser from 'body-parser';
 import { UserInfo } from '../model/user';
-import { logApp } from '../utils/app-logger.util';
+import { AppLogsCategory, logApp } from '../utils/app-logger.util';
 import { setCookieError } from '../utils/set-cookies.util';
 import { authenticateUser } from './auth-user';
 import { initProviders } from './providers/providers';
@@ -38,6 +38,7 @@ export const initAuthPlatform = async (app) => {
             {},
             (err: Error, user: UserInfo | false | null) => {
               if (!user) {
+                logApp.error(err, {}, AppLogsCategory.LOGIN_PROVIDER);
                 reject(new Error('User not provided'));
               } else if (err) {
                 reject(err || new Error('Invalid authentication'));


### PR DESCRIPTION
# Context: 
We didn’t have enough context to debug or resolve the “User not provided” error.
Add a logger at the point where the error is thrown.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

Related #726 