### PR TITLE
[backend] fix(download): dont change all data on doc download #778

### DIFF
--- a/portal-api/src/modules/services/document/document.domain.ts
+++ b/portal-api/src/modules/services/document/document.domain.ts
@@ -371,15 +371,13 @@ export const incrementDocumentsDownloads = async (
   document: DocumentModel,
   trx: Knex.Transaction
 ) => {
-  await updateDocument(
-    context,
-    document.id,
-    {
+  await db<DocumentModel>(context, 'Document')
+    .where('id', '=', document.id)
+    .update({
       download_number: document.download_number + 1,
-    },
-    [],
-    trx
-  );
+    })
+    .returning('*')
+    .transacting(trx);
 };
 
 export const deleteDocument = async <T extends DocumentModel>(


### PR DESCRIPTION
# Context: 
> On download, the function updateDocument was called and the uploader_id was modified. Now, we only modify the number of downloads and not all the data, metadata etc. 

# How to test:  
Connect as a user. 
Choose a customDasbhoard/integrationFeed/OBasScenario where you're not the author 
download it 
You should not become the author 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #778 