### PR TITLE
[Deployment] GitHub action: on Demand restore of anonymized data on S…

### DIFF
--- a/.github/workflows/restore-anonymized-data.yml
+++ b/.github/workflows/restore-anonymized-data.yml
@@ -1,0 +1,30 @@
+---
+
+name: Restore anonymized data on a test env
+
+on:
+  workflow_dispatch:
+    inputs:
+#      The XTM Hub namespace on staging environment
+      namespace:
+        description: 'xtmhub, xtmhub-dev, xtmhub-prerelease or xtmhub-dev-pr-[PR Number] for feature branch'
+        type: string
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.namespace }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-feature-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install AWX cli
+        run: pip install awxkit
+      - name: Restore anonymized data
+        run: |
+          awx --conf.host https://awx.filigran.io \
+            --conf.token ${{ secrets.AWX_TOKEN }} \
+            -f human job_templates launch 'Restore XTM Hub prod anonymized data' \
+            --inventory eu-west-staging \
+            --extra_vars "{\"ns\":\"${{ inputs.namespace }}\"}"


### PR DESCRIPTION

# Context: 

Add a new GitHub action to restore anonymized data on demand on XTM Hub instances deployed on staging.
This GitHub action just call the AWX job provided in https://github.com/FiligranHQ/platform/issues/913  for prerelease anonymized restore.

# Additional information:

Related https://github.com/FiligranHQ/platform/issues/913 