### PR TITLE
[frontend] feat(custom dashboards): add modal before deleting custom dashboard (#475)

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -352,6 +352,7 @@
         "Updated": "The custom dashboard {name} has been modified successfully"
       },
       "AddDashboard": "Add new dashboard",
+      "DeleteDashboard": "Delete the custom dashboard {name}",
       "Form": {
         "DescriptionLabel": "Description",
         "DescriptionPlaceholder": "This is a paragraph to describe the document.",
@@ -382,6 +383,7 @@
         "Author": "Author",
         "DeleteSentence": "After clicking that button, click VALIDATE to permanently delete this image."
       },
+      "SureDeleteDashboard": "Are you sure you want to delete the {name} dashboard?",
       "UpdateDashboard": "Update dashboard"
     },
     "ObasScenario": {

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -345,6 +345,7 @@
         "Updated": "Le custom dashboard {name} a été modifié avec succès"
       },
       "AddDashboard": "Nouveau tableau de bord",
+      "DeleteDashboard": "Supprimer le tableau de bord {name}",
       "Form": {
         "DescriptionLabel": "Description",
         "DescriptionPlaceholder": "Description du tableau de bord",
@@ -374,6 +375,7 @@
         "Author": "Auteur",
         "DeleteSentence": "Après avoir cliqué sur ce bouton, cliquez sur VALIDER pour supprimer définitivement cette image"
       },
+      "SureDeleteDashboard": "Etes-vous sûr de vouloir supprimer le tableau de bord {name} ?",
       "UpdateDashboard": "Tableau de bord des mises à jour"
     },
     "ObasScenario": {

--- a/apps/portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx
+++ b/apps/portal-front/src/components/service/csv-feeds/[serviceInstanceId]/csv-feed-form.tsx
@@ -211,7 +211,7 @@ export const CsvFeedForm = ({
             label: t('Service.CsvFeed.Form.NameLabel'),
           },
         }}>
-        <SheetFooter className="pt-2">
+        <SheetFooter className="sm:justify-between pt-2">
           {csvFeed && (
             <CsvFeedDelete
               userCanDelete={userCanDelete}
@@ -219,7 +219,7 @@ export const CsvFeedForm = ({
               csvFeed={csvFeed}
             />
           )}
-          <div className="flex gap-s">
+          <div className="ml-auto flex gap-s">
             <Button
               variant="outline"
               type="button"

--- a/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-delete.tsx
+++ b/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-delete.tsx
@@ -1,0 +1,49 @@
+import { AlertDialogComponent } from '@/components/ui/alert-dialog';
+import { useDialogContext } from '@/components/ui/sheet-with-preventing-dialog';
+import { customDashboardsItem_fragment$data } from '@generated/customDashboardsItem_fragment.graphql';
+import { Button } from 'filigran-ui';
+import { useTranslations } from 'next-intl';
+
+interface CustomDashboardDeleteProps {
+  userCanDelete?: boolean;
+  onDelete?: () => void;
+  customDashboard: customDashboardsItem_fragment$data;
+}
+
+export const CustomDashboardDelete = ({
+  userCanDelete,
+  onDelete,
+  customDashboard,
+}: CustomDashboardDeleteProps) => {
+  const t = useTranslations();
+  const { handleCloseSheet } = useDialogContext();
+
+  return (
+    userCanDelete && (
+      <AlertDialogComponent
+        actionButtonText={t('Utils.Delete')}
+        variantName={'destructive'}
+        AlertTitle={t('Service.CustomDashboards.DeleteDashboard', {
+          name: customDashboard.name,
+        })}
+        triggerElement={
+          <Button
+            variant="outline-destructive"
+            className=""
+            aria-label={t('Service.CustomDashboards.DeleteDashboard', {
+              name: customDashboard.name,
+            })}>
+            {t('Utils.Delete')}
+          </Button>
+        }
+        onClickContinue={(e: React.MouseEvent<HTMLButtonElement>) => {
+          onDelete?.();
+          handleCloseSheet(e);
+        }}>
+        {t('Service.CustomDashboards.SureDeleteDashboard', {
+          name: customDashboard.name,
+        })}
+      </AlertDialogComponent>
+    )
+  );
+};

--- a/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
+++ b/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
@@ -490,7 +490,7 @@ export const CustomDashboardUpdateForm = ({
                 images: { fieldType: () => <></> },
               }),
         }}>
-        <SheetFooter className="sm:justify-between pb-0">
+        <SheetFooter className="pb-0">
           {customDashboard && (
              <CustomDashboardDelete
                userCanDelete={userCanDelete}
@@ -498,7 +498,7 @@ export const CustomDashboardUpdateForm = ({
                customDashboard={customDashboard}
              />
           )}
-          <div className="ml-auto flex gap-s">
+          <div className="flex gap-s">
             <Button
               variant="outline"
               type="button"

--- a/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
+++ b/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
@@ -47,6 +47,9 @@ import {
 import { useForm } from 'react-hook-form';
 import slugify from 'slugify';
 import { z } from 'zod';
+import {
+  CustomDashboardDelete
+} from '@/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-delete';
 
 export const updateCustomDashboardSchema = z.object({
   name: z.string().min(1, 'Required'),
@@ -488,13 +491,12 @@ export const CustomDashboardUpdateForm = ({
               }),
         }}>
         <SheetFooter className="sm:justify-between pb-0">
-          {userCanDelete && (
-            <Button
-              variant="outline-destructive"
-              type="button"
-              onClick={onDelete}>
-              {t('Utils.Delete')}
-            </Button>
+          {customDashboard && (
+             <CustomDashboardDelete
+               userCanDelete={userCanDelete}
+               onDelete={onDelete}
+               customDashboard={customDashboard}
+             />
           )}
           <div className="ml-auto flex gap-s">
             <Button

--- a/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
+++ b/apps/portal-front/src/components/service/custom-dashboards/[serviceInstanceId]/custom-dashboard-update-form.tsx
@@ -490,7 +490,7 @@ export const CustomDashboardUpdateForm = ({
                 images: { fieldType: () => <></> },
               }),
         }}>
-        <SheetFooter className="pb-0">
+        <SheetFooter className="sm:justify-between pb-0">
           {customDashboard && (
              <CustomDashboardDelete
                userCanDelete={userCanDelete}
@@ -498,7 +498,7 @@ export const CustomDashboardUpdateForm = ({
                customDashboard={customDashboard}
              />
           )}
-          <div className="flex gap-s">
+          <div className="ml-auto flex gap-s">
             <Button
               variant="outline"
               type="button"

--- a/apps/portal-front/src/components/service/obas-scenarios/[serviceInstanceId]/obas-scenario-form.tsx
+++ b/apps/portal-front/src/components/service/obas-scenarios/[serviceInstanceId]/obas-scenario-form.tsx
@@ -192,7 +192,7 @@ export const ObasScenarioForm = ({
             label: t('Service.ObasScenario.Form.ProductVersionLabel'),
           },
         }}>
-        <SheetFooter className="pt-2">
+        <SheetFooter className="sm:justify-between pt-2">
           {obasScenario && (
             <ObasScenarioDelete
               userCanDelete={userCanDelete}
@@ -200,7 +200,7 @@ export const ObasScenarioForm = ({
               obasScenario={obasScenario}
             />
           )}
-          <div className="flex gap-s">
+          <div className="ml-auto flex gap-s">
             <Button
               variant="outline"
               type="button"


### PR DESCRIPTION
# Context: 
> The same way we use it for other delete actions, add a confirmation modal to warn the users that they're about to delete a dashboard. 
The 'Delete' button was also moved to the left for csv feed and obas scenarios as for custom dashboards

# How to test:  
- Delete a custom dashboard: a confirmation warning should appear specifying the name of the dashboard to delete
- Upon deletion, a toast should appear specifying the name of the dashboard deleted
- Delete button should be displayed on the left for all.

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #475