### PR TITLE
[frontend] - fix(markdown): disable highlight to workaround cursor issue (#723)

### DIFF
--- a/apps/portal-front/src/components/ui/MarkdownInput.tsx
+++ b/apps/portal-front/src/components/ui/MarkdownInput.tsx
@@ -20,6 +20,7 @@ const MarkdownInput = ({
       <MDEditor
         value={value}
         onChange={onChange}
+        highlightEnable={false}
         style={{
           background: 'hsl(var(--page-background))',
           color: 'hsl(var(--text-foreground))',

--- a/apps/portal-front/styles/globals.css
+++ b/apps/portal-front/styles/globals.css
@@ -42,3 +42,8 @@
     list-style-type: decimal;
   }
 }
+
+/* Allow fullsize textArea in MD editor (https://github.com/uiwjs/react-md-editor/issues/625) */
+.w-md-editor-text {
+  min-height: 100% !important;
+}


### PR DESCRIPTION
# Context: 
> The markdown editor doesn't work well, the cursor doesn't display at the right place. 

This seem to be a known [issue](https://github.com/uiwjs/react-md-editor/issues/276#issuecomment-1004058923) with TailwindCSS. Workaround is to disable highlighting.
To allow the textarea to have the fullsize available (and not 100px), we need to override css class `.w-md-editor-text` ([ref](https://github.com/uiwjs/react-md-editor/issues/625)) 

# How to test:  
> Edit some text in markdown: 
- Select text and apply some markdown from the menu: the correct text should have the effect applied
- Manually enter markdown: the correct text should have the effect applied

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #723