### PR TITLE
[backend] feat: add query to check OpenCTI platform enrollment status

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -690,6 +690,21 @@ export enum OctiPlatformContract {
   Ee = 'EE'
 }
 
+export enum OctiPlatformEnrollmentStatus {
+  Active = 'active',
+  Inactive = 'inactive'
+}
+
+export type OctiPlatformEnrollmentStatusInput = {
+  platformId: Scalars['String']['input'];
+  token: Scalars['String']['input'];
+};
+
+export type OctiPlatformEnrollmentStatusResponse = {
+  __typename?: 'OCTIPlatformEnrollmentStatusResponse';
+  status: OctiPlatformEnrollmentStatus;
+};
+
 export type OctiPlatformInput = {
   contract: OctiPlatformContract;
   id: Scalars['ID']['input'];
@@ -823,6 +838,7 @@ export type Query = {
   node?: Maybe<Node>;
   obasScenario?: Maybe<ObasScenario>;
   obasScenarios: ObasScenarioConnection;
+  octiPlatformEnrollmentStatus: OctiPlatformEnrollmentStatusResponse;
   octiPlatforms: Array<OctiPlatform>;
   organization?: Maybe<Organization>;
   organizationAdministrators: Array<User>;
@@ -955,6 +971,11 @@ export type QueryObasScenariosArgs = {
   orderMode: OrderingMode;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
   serviceInstanceId?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryOctiPlatformEnrollmentStatusArgs = {
+  input: OctiPlatformEnrollmentStatusInput;
 };
 
 
@@ -1588,6 +1609,9 @@ export type ResolversTypes = ResolversObject<{
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
   OCTIPlatform: ResolverTypeWrapper<OctiPlatform>;
   OCTIPlatformContract: OctiPlatformContract;
+  OCTIPlatformEnrollmentStatus: OctiPlatformEnrollmentStatus;
+  OCTIPlatformEnrollmentStatusInput: OctiPlatformEnrollmentStatusInput;
+  OCTIPlatformEnrollmentStatusResponse: ResolverTypeWrapper<OctiPlatformEnrollmentStatusResponse>;
   OCTIPlatformInput: OctiPlatformInput;
   ObasScenario: ResolverTypeWrapper<ObasScenario>;
   ObasScenarioConnection: ResolverTypeWrapper<ObasScenarioConnection>;
@@ -1699,6 +1723,8 @@ export type ResolversParentTypes = ResolversObject<{
   Mutation: {};
   Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
   OCTIPlatform: OctiPlatform;
+  OCTIPlatformEnrollmentStatusInput: OctiPlatformEnrollmentStatusInput;
+  OCTIPlatformEnrollmentStatusResponse: OctiPlatformEnrollmentStatusResponse;
   OCTIPlatformInput: OctiPlatformInput;
   ObasScenario: ObasScenario;
   ObasScenarioConnection: ObasScenarioConnection;
@@ -2030,6 +2056,11 @@ export type OctiPlatformResolvers<ContextType = PortalContext, ParentType extend
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type OctiPlatformEnrollmentStatusResponseResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['OCTIPlatformEnrollmentStatusResponse'] = ResolversParentTypes['OCTIPlatformEnrollmentStatusResponse']> = ResolversObject<{
+  status?: Resolver<ResolversTypes['OCTIPlatformEnrollmentStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type ObasScenarioResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['ObasScenario'] = ResolversParentTypes['ObasScenario']> = ResolversObject<{
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   children_documents?: Resolver<Maybe<Array<ResolversTypes['ShareableResourceImage']>>, ParentType, ContextType>;
@@ -2129,6 +2160,7 @@ export type QueryResolvers<ContextType = PortalContext, ParentType extends Resol
   node?: Resolver<Maybe<ResolversTypes['Node']>, ParentType, ContextType, RequireFields<QueryNodeArgs, 'id'>>;
   obasScenario?: Resolver<Maybe<ResolversTypes['ObasScenario']>, ParentType, ContextType, Partial<QueryObasScenarioArgs>>;
   obasScenarios?: Resolver<ResolversTypes['ObasScenarioConnection'], ParentType, ContextType, RequireFields<QueryObasScenariosArgs, 'first' | 'orderBy' | 'orderMode'>>;
+  octiPlatformEnrollmentStatus?: Resolver<ResolversTypes['OCTIPlatformEnrollmentStatusResponse'], ParentType, ContextType, RequireFields<QueryOctiPlatformEnrollmentStatusArgs, 'input'>>;
   octiPlatforms?: Resolver<Array<ResolversTypes['OCTIPlatform']>, ParentType, ContextType>;
   organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryOrganizationArgs, 'id'>>;
   organizationAdministrators?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryOrganizationAdministratorsArgs, 'organizationId'>>;
@@ -2423,6 +2455,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   Mutation?: MutationResolvers<ContextType>;
   Node?: NodeResolvers<ContextType>;
   OCTIPlatform?: OctiPlatformResolvers<ContextType>;
+  OCTIPlatformEnrollmentStatusResponse?: OctiPlatformEnrollmentStatusResponseResolvers<ContextType>;
   ObasScenario?: ObasScenarioResolvers<ContextType>;
   ObasScenarioConnection?: ObasScenarioConnectionResolvers<ContextType>;
   ObasScenarioEdge?: ObasScenarioEdgeResolvers<ContextType>;

--- a/apps/portal-api/src/modules/services/contract/domain.ts
+++ b/apps/portal-api/src/modules/services/contract/domain.ts
@@ -37,6 +37,17 @@ export const serviceContractDomain = {
     return success;
   },
 
+  loadConfigurationByPlatformAndToken: async (
+    context: PortalContext,
+    { platformId, token }: { platformId: string; token: string }
+  ): Promise<ServiceConfiguration | null> => {
+    return db(context, 'Service_Configuration')
+      .where({ status: ServiceConfigurationStatus.Active })
+      .whereRaw("config->>'platform_id' = ?", platformId)
+      .whereRaw("config->>'token' = ?", token)
+      .first();
+  },
+
   loadConfigurationsByPlatform: async (
     context: PortalContext,
     platformId: string

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.app.ts
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.app.ts
@@ -5,6 +5,9 @@ import {
   CanUnenrollOctiPlatformInput,
   EnrollOctiPlatformInput,
   OctiPlatform,
+  OctiPlatformEnrollmentStatus,
+  OctiPlatformEnrollmentStatusInput,
+  OctiPlatformEnrollmentStatusResponse,
   OrganizationCapability,
   ServiceConfigurationStatus,
   ServiceDefinitionIdentifier,
@@ -72,6 +75,22 @@ export const enrollmentApp = {
       url: platform.config.platform_url,
       contract: platform.config.platform_contract,
     }));
+  },
+
+  loadOCTIPlatformEnrollmentStatus: async (
+    context: PortalContext,
+    input: OctiPlatformEnrollmentStatusInput
+  ): Promise<OctiPlatformEnrollmentStatusResponse> => {
+    const serviceConfiguration =
+      await serviceContractDomain.loadConfigurationByPlatformAndToken(
+        context,
+        input
+      );
+    return {
+      status: serviceConfiguration
+        ? OctiPlatformEnrollmentStatus.Active
+        : OctiPlatformEnrollmentStatus.Inactive,
+    };
   },
 
   enrollOCTIPlatform: async (

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.graphql
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.graphql
@@ -58,6 +58,20 @@ input UnenrollOCTIPlatformInput {
   platformId: String!
 }
 
+input OCTIPlatformEnrollmentStatusInput {
+  platformId: String!
+  token: String!
+}
+
+enum OCTIPlatformEnrollmentStatus {
+  active
+  inactive
+}
+
+type OCTIPlatformEnrollmentStatusResponse {
+  status: OCTIPlatformEnrollmentStatus!
+}
+
 type Query {
   canEnrollOCTIPlatform(input: CanEnrollOCTIPlatformInput!): CanEnrollResponse!
     @auth
@@ -65,6 +79,9 @@ type Query {
     input: CanUnenrollOCTIPlatformInput!
   ): CanUnenrollResponse!
   octiPlatforms: [OCTIPlatform!]! @auth
+  octiPlatformEnrollmentStatus(
+    input: OCTIPlatformEnrollmentStatusInput!
+  ): OCTIPlatformEnrollmentStatusResponse!
 }
 
 type Mutation {

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.resolver.ts
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.resolver.ts
@@ -61,6 +61,8 @@ const resolvers: Resolvers = {
     },
     octiPlatforms: async (_, _z, context) =>
       enrollmentApp.loadOCTIPlatforms(context),
+    octiPlatformEnrollmentStatus: async (_, { input }, context) =>
+      enrollmentApp.loadOCTIPlatformEnrollmentStatus(context, input),
   },
   Mutation: {
     enrollOCTIPlatform: async (_, { input }, context) => {

--- a/apps/portal-front/app/(embed)/layout.tsx
+++ b/apps/portal-front/app/(embed)/layout.tsx
@@ -58,8 +58,9 @@ const RootLayout: FunctionComponent<RootLayoutProps> = async ({ children }) => {
         <PageLoader>
           <div className="flex flex-col items-center justify-center min-h-screen">
             <div className="w-1/3">
-              <LogoXTMDark className="p-6" />
               <ContentLayout>
+                <LogoXTMDark className="pb-6" />
+
                 <Card className="p-xl bg-page-background">{children}</Card>
               </ContentLayout>
             </div>

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -113,6 +113,7 @@ type Query {
   canEnrollOCTIPlatform(input: CanEnrollOCTIPlatformInput!): CanEnrollResponse!
   canUnenrollOCTIPlatform(input: CanUnenrollOCTIPlatformInput!): CanUnenrollResponse!
   octiPlatforms: [OCTIPlatform!]!
+  octiPlatformEnrollmentStatus(input: OCTIPlatformEnrollmentStatusInput!): OCTIPlatformEnrollmentStatusResponse!
   seoObasScenariosByServiceSlug(serviceSlug: String): [ObasScenario]
   seoObasScenarioBySlug(slug: String): ObasScenario
   obasScenarios(first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, filters: [Filter!], serviceInstanceId: String): ObasScenarioConnection!
@@ -401,6 +402,20 @@ type CanUnenrollResponse {
 
 input UnenrollOCTIPlatformInput {
   platformId: String!
+}
+
+input OCTIPlatformEnrollmentStatusInput {
+  platformId: String!
+  token: String!
+}
+
+enum OCTIPlatformEnrollmentStatus {
+  active
+  inactive
+}
+
+type OCTIPlatformEnrollmentStatusResponse {
+  status: OCTIPlatformEnrollmentStatus!
 }
 
 type ServiceLink implements Node {

--- a/apps/portal-front/src/components/enroll/form/organization.tsx
+++ b/apps/portal-front/src/components/enroll/form/organization.tsx
@@ -44,7 +44,7 @@ export const EnrollOrganizationForm: React.FC<Props> = ({
           fieldConfig={{
             organizationId: {
               fieldType: ({ field }) => (
-                <div className="flex flex-col">
+                <div className="flex flex-col gap-2">
                   {organizations.map((organization) => {
                     return (
                       <FormItem
@@ -52,7 +52,7 @@ export const EnrollOrganizationForm: React.FC<Props> = ({
                         className="flex justify-start gap-xs items-center">
                         <FormControl>
                           <Input
-                            className="w-auto accent-primary"
+                            className="w-auto h-4 w-4 accent-primary"
                             aria-labelledby={`enroll-form-organization-${organization.name}`}
                             type="radio"
                             onChange={() => {

--- a/apps/portal-front/src/components/enroll/state/layout.tsx
+++ b/apps/portal-front/src/components/enroll/state/layout.tsx
@@ -15,7 +15,7 @@ export const EnrollStateLayout: React.FC<Props> = ({
 }) => {
   const t = useTranslations();
   return (
-    <div className="h-full flex flex-col justify-between">
+    <div className="h-full flex flex-col justify-between gap-xl">
       <div className="flex flex-col gap-m">{children}</div>
       <div className="flex justify-end gap-s">
         {Boolean(cancel) && (

--- a/apps/portal-front/src/components/service/document/one-click-deploy/choose-platform-form.tsx
+++ b/apps/portal-front/src/components/service/document/one-click-deploy/choose-platform-form.tsx
@@ -56,7 +56,7 @@ const ChoosePlatformForm = ({
                         onChange={() => field.onChange(platform.url)}
                         checked={field.value === platform.url}
                         value={platform.url}
-                        className="h-6 w-6 accent-primary"
+                        className="h-4 w-4 accent-primary"
                       />
                       <FormLabel htmlFor={platform.url}>
                         {platform.title}


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

- add a query to let OpenCTI check its enrollment status

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- enroll or unenroll an OpenCTI platfor
- use GraphQL API to get the enrollment status

# What tests has been made: 
- [x] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #65
Related #742 