### PR TITLE
[backend] fix: allow user to enroll when he is the organization admin

### DIFF
--- a/apps/portal-api/src/modules/services/enrollment/enrollment.app.test.ts
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.app.test.ts
@@ -118,7 +118,7 @@ describe('Enrollment app', () => {
     let loadLastSubscriptionByServiceInstanceSpy: MockInstance;
 
     beforeEach(() => {
-      isUserAllowedSpy = vi.spyOn(authHelper, 'isUserAllowed');
+      isUserAllowedSpy = vi.spyOn(authHelper, 'isUserAllowedOnOrganization');
       loadConfigurationsByPlatformSpy = vi.spyOn(
         serviceContractDomain,
         'loadConfigurationsByPlatform'
@@ -419,12 +419,15 @@ describe('Enrollment app', () => {
   describe('canUnenrollOCTIPlatform', () => {
     const platformId = uuidv4();
 
-    let isUserAllowedSpy: MockInstance;
+    let isUserAllowedOnOrganizationSpy: MockInstance;
     let loadConfigurationByPlatformSpy: MockInstance;
     let loadActiveSubscriptionBySpy: MockInstance;
 
     beforeEach(() => {
-      isUserAllowedSpy = vi.spyOn(authHelper, 'isUserAllowed');
+      isUserAllowedOnOrganizationSpy = vi.spyOn(
+        authHelper,
+        'isUserAllowedOnOrganization'
+      );
       loadConfigurationByPlatformSpy = vi.spyOn(
         serviceContractDomain,
         'loadConfigurationByPlatform'
@@ -464,7 +467,7 @@ describe('Enrollment app', () => {
 
     it('should allow user to enroll when he has the required capabilities', async () => {
       const organizationId = uuidv4();
-      isUserAllowedSpy.mockReturnValue(Promise.resolve(true));
+      isUserAllowedOnOrganizationSpy.mockReturnValue(Promise.resolve(true));
       loadConfigurationByPlatformSpy.mockReturnValue(
         Promise.resolve({ service_instance_id: uuidv4() })
       );
@@ -489,7 +492,7 @@ describe('Enrollment app', () => {
       loadActiveSubscriptionBySpy.mockReturnValue(
         Promise.resolve({ organization_id: organizationId })
       );
-      isUserAllowedSpy.mockReturnValue(Promise.resolve(false));
+      isUserAllowedOnOrganizationSpy.mockReturnValue(Promise.resolve(false));
 
       const result = await enrollmentApp.canUnenrollOCTIPlatform(
         contextAdminUser,

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.app.ts
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.app.ts
@@ -13,7 +13,7 @@ import { OrganizationId } from '../../../model/kanel/public/Organization';
 import ServiceConfiguration from '../../../model/kanel/public/ServiceConfiguration';
 import Subscription from '../../../model/kanel/public/Subscription';
 import { PortalContext } from '../../../model/portal-context';
-import { isUserAllowed } from '../../../security/auth.helper';
+import { isUserAllowedOnOrganization } from '../../../security/auth.helper';
 import { ErrorCode } from '../../common/error-code';
 import {
   endSubscription,
@@ -149,9 +149,9 @@ export const enrollmentApp = {
       throw new Error(ErrorCode.SubscriptionNotFound);
     }
 
-    const isAllowed = await isUserAllowed(context, {
+    const isAllowed = await isUserAllowedOnOrganization(context, {
       organizationId: subscription.organization_id,
-      capability: OrganizationCapability.ManageOctiEnrollment,
+      requiredCapability: OrganizationCapability.ManageOctiEnrollment,
     });
     if (!isAllowed) {
       throw new Error(ErrorCode.MissingCapabilityOnOriginOrganization);
@@ -178,10 +178,13 @@ export const enrollmentApp = {
         context,
         platformId
       );
-    const isAllowedOnTargetOrganization = await isUserAllowed(context, {
-      organizationId,
-      capability: OrganizationCapability.ManageOctiEnrollment,
-    });
+    const isAllowedOnTargetOrganization = await isUserAllowedOnOrganization(
+      context,
+      {
+        organizationId,
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+      }
+    );
 
     const wasEnrolledOnce = !!serviceConfigurations.length;
     if (!wasEnrolledOnce) {
@@ -208,10 +211,13 @@ export const enrollmentApp = {
         return isAllowedOnTargetOrganization;
       }
 
-      const isAllowedOnOriginOrganization = await isUserAllowed(context, {
-        organizationId: subscription.organization_id,
-        capability: OrganizationCapability.ManageOctiEnrollment,
-      });
+      const isAllowedOnOriginOrganization = await isUserAllowedOnOrganization(
+        context,
+        {
+          organizationId: subscription.organization_id,
+          requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+        }
+      );
 
       return isAllowedOnTargetOrganization && isAllowedOnOriginOrganization;
     };
@@ -244,9 +250,9 @@ export const enrollmentApp = {
       throw new Error(ErrorCode.PlatformNotEnrolled);
     }
 
-    const isAllowed = await isUserAllowed(context, {
+    const isAllowed = await isUserAllowedOnOrganization(context, {
       organizationId: subscription.organization_id,
-      capability: OrganizationCapability.ManageOctiEnrollment,
+      requiredCapability: OrganizationCapability.ManageOctiEnrollment,
     });
 
     return { isAllowed, organizationId: subscription.organization_id };

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.domain.ts
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.domain.ts
@@ -12,7 +12,7 @@ import ServiceInstance, {
 } from '../../../model/kanel/public/ServiceInstance';
 import { SubscriptionId } from '../../../model/kanel/public/Subscription';
 import { PortalContext } from '../../../model/portal-context';
-import { isUserAllowed } from '../../../security/auth.helper';
+import { isUserAllowedOnOrganization } from '../../../security/auth.helper';
 import { ErrorCode } from '../../common/error-code';
 import {
   loadActiveSubscriptionBy,
@@ -91,9 +91,9 @@ export const enrollmentDomain = {
 
     const originOrganizationId = subscription.organization_id;
     if (originOrganizationId !== targetOrganizationId) {
-      const isAllowed = await isUserAllowed(context, {
+      const isAllowed = await isUserAllowedOnOrganization(context, {
         organizationId: originOrganizationId,
-        capability: OrganizationCapability.ManageOctiEnrollment,
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
       });
 
       if (!isAllowed) {

--- a/apps/portal-api/src/modules/services/enrollment/enrollment.graphql
+++ b/apps/portal-api/src/modules/services/enrollment/enrollment.graphql
@@ -69,7 +69,7 @@ type Query {
 
 type Mutation {
   enrollOCTIPlatform(input: EnrollOCTIPlatformInput!): EnrollmentResponse!
-    @auth(requires: [MANAGE_OCTI_ENROLLMENT])
+    @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_OCTI_ENROLLMENT])
   unenrollOCTIPlatform(input: UnenrollOCTIPlatformInput): Success!
-    @auth(requires: [MANAGE_OCTI_ENROLLMENT])
+    @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_OCTI_ENROLLMENT])
 }

--- a/apps/portal-api/src/security/access.ts
+++ b/apps/portal-api/src/security/access.ts
@@ -18,6 +18,7 @@ import { meUserSSESecurity, userSSESecurity } from './user-security-access';
 import { setDeleteSecurityForUserServiceCapability } from './user-service-capability-access';
 
 import { logApp } from '../utils/app-logger.util';
+import { isUserAllowed } from './auth.helper';
 import { userSecurityLayer } from './layer/user';
 import { userOrganizationCapabilitySecurityLayer } from './layer/user-organization-capability';
 import { userServiceSecurityLayer } from './layer/user-service';
@@ -33,15 +34,15 @@ export type SecuryQueryHandlers = {
 
 export const isUserGranted = (
   user?: UserLoadUserBy,
-  orgCapabilitities?: OrganizationCapability
+  requiredCapability?: OrganizationCapability
 ) => {
   return (
     !!user &&
-    (user.capabilities.some((c) => c.id === CAPABILITY_BYPASS.id) ||
-      user.selected_org_capabilities?.includes(orgCapabilitities) ||
-      user.selected_org_capabilities?.includes(
-        OrganizationCapability.AdministrateOrganization
-      ))
+    isUserAllowed({
+      userCapabilities: user.capabilities,
+      organizationCapabilities: user.selected_org_capabilities,
+      requiredCapability: requiredCapability,
+    })
   );
 };
 

--- a/apps/portal-api/src/security/auth.helper.test.ts
+++ b/apps/portal-api/src/security/auth.helper.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { OrganizationCapability } from '../__generated__/resolvers-types';
+import { CAPABILITY_BYPASS } from '../portal.const';
+import { isUserAllowed } from './auth.helper';
+
+describe('AuthHelper', () => {
+  describe('isUserAllowed', () => {
+    it('should allow user if he has bypass capability', async () => {
+      const result = isUserAllowed({
+        userCapabilities: [CAPABILITY_BYPASS],
+        organizationCapabilities: [],
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should allow user if he has the required capability', async () => {
+      const result = isUserAllowed({
+        userCapabilities: [],
+        organizationCapabilities: [OrganizationCapability.ManageOctiEnrollment],
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should allow user if he has the administrate organization capability', async () => {
+      const result = isUserAllowed({
+        userCapabilities: [],
+        organizationCapabilities: [
+          OrganizationCapability.AdministrateOrganization,
+        ],
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should not allow user if he does not have the required capabilities', async () => {
+      const result = isUserAllowed({
+        userCapabilities: [],
+        organizationCapabilities: [],
+        requiredCapability: OrganizationCapability.ManageOctiEnrollment,
+      });
+
+      expect(result).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

- fix capability check to allow admin user to enroll OpenCTI platforms

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- log in with an user which does not have `BYPASS` capability
- try to enroll a platform on your personal space
- check that the enrollment goes well

# What tests has been made: 
- [x] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

Related #65