### PR TITLE
[backend] launch generate-pg-to-ts more often #832

### DIFF
--- a/apps/portal-api/package.json
+++ b/apps/portal-api/package.json
@@ -24,7 +24,7 @@
     "start-tsx": "LOCAL_DEV=true tsx --watch src/index.ts --clear-screen=false",
     "dev:tsc": "tsc --watch --preserveWatchOutput",
     "dev:node": "node --watch dist/index.js",
-    "start-dev": "concurrently \"yarn dev:tsc\" \"yarn start-tsx\" \"yarn watch:graphql\"",
+    "start-dev": "yarn generate-pg-to-ts && concurrently \"yarn dev:tsc\" \"yarn start-tsx\" \"yarn watch:graphql\"",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "lint-staged": "lint-staged",


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

launch generate-pg-to-ts more often by calling it when using start-dev command

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

Related #832