### PR TITLE
[backend/frontend]: improve way to get service and add OBAS Scenario email #579 #843

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -392,7 +392,6 @@ export type Mutation = {
   removePendingUserFromOrganization?: Maybe<User>;
   removeUserFromOrganization?: Maybe<User>;
   resetPassword: Success;
-  selfJoinServiceInstance?: Maybe<ServiceInstance>;
   unregisterOpenCTIPlatform: Success;
   updateCsvFeed: CsvFeed;
   updateCustomDashboard: CustomDashboard;
@@ -626,11 +625,6 @@ export type MutationRemovePendingUserFromOrganizationArgs = {
 export type MutationRemoveUserFromOrganizationArgs = {
   organization_id: Scalars['ID']['input'];
   user_id: Scalars['ID']['input'];
-};
-
-
-export type MutationSelfJoinServiceInstanceArgs = {
-  service_instance_id: Scalars['ID']['input'];
 };
 
 
@@ -2095,7 +2089,6 @@ export type MutationResolvers<ContextType = PortalContext, ParentType extends Re
   removePendingUserFromOrganization?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationRemovePendingUserFromOrganizationArgs, 'organization_id' | 'user_id'>>;
   removeUserFromOrganization?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationRemoveUserFromOrganizationArgs, 'organization_id' | 'user_id'>>;
   resetPassword?: Resolver<ResolversTypes['Success'], ParentType, ContextType>;
-  selfJoinServiceInstance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, RequireFields<MutationSelfJoinServiceInstanceArgs, 'service_instance_id'>>;
   unregisterOpenCTIPlatform?: Resolver<ResolversTypes['Success'], ParentType, ContextType, Partial<MutationUnregisterOpenCtiPlatformArgs>>;
   updateCsvFeed?: Resolver<ResolversTypes['CsvFeed'], ParentType, ContextType, RequireFields<MutationUpdateCsvFeedArgs, 'documentId' | 'input' | 'updateDocument'>>;
   updateCustomDashboard?: Resolver<ResolversTypes['CustomDashboard'], ParentType, ContextType, RequireFields<MutationUpdateCustomDashboardArgs, 'documentId' | 'input' | 'updateDocument'>>;

--- a/apps/portal-api/src/modules/services/definition/service-capability/service-capability.domain.test.ts
+++ b/apps/portal-api/src/modules/services/definition/service-capability/service-capability.domain.test.ts
@@ -1,0 +1,145 @@
+import { v4 as uuidv4 } from 'uuid';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { dbUnsecure } from '../../../../../knexfile';
+import { contextAdminUser } from '../../../../../tests/tests.const';
+import ServiceCapability, {
+  ServiceCapabilityId,
+} from '../../../../model/kanel/public/ServiceCapability';
+import ServiceDefinition, {
+  ServiceDefinitionId,
+} from '../../../../model/kanel/public/ServiceDefinition';
+import { loadServiceCapabilitiesBy } from './service-capability.domain';
+
+describe('Service Capability domain', () => {
+  let testServiceDefinitionId: ServiceDefinitionId;
+  let testServiceDefinitionId2: ServiceDefinitionId;
+  let testCapabilityIds: ServiceCapabilityId[] = [];
+  let testServiceDefIds: ServiceDefinitionId[] = [];
+
+  beforeAll(async () => {
+    const serviceDefinition = await dbUnsecure<ServiceDefinition>(
+      'ServiceDefinition'
+    )
+      .insert([
+        {
+          id: uuidv4() as ServiceDefinitionId,
+          name: 'Test Service Definition',
+          description: 'Test service definition for capability tests',
+        },
+        {
+          id: uuidv4() as ServiceDefinitionId,
+          name: '2 Test Service Definition 2',
+          description: '2 Test service definition for capability tests2 ',
+        },
+      ])
+      .returning('*');
+
+    testServiceDefinitionId =
+      serviceDefinition[0]?.id ?? (uuidv4() as ServiceDefinitionId);
+    testServiceDefinitionId2 =
+      serviceDefinition[1]?.id ?? (uuidv4() as ServiceDefinitionId);
+
+    const capabilities = await dbUnsecure<ServiceCapability>(
+      'Service_Capability'
+    )
+      .insert([
+        {
+          id: uuidv4() as ServiceCapabilityId,
+          name: 'Test Capability 1',
+          description: 'First test capability',
+          service_definition_id: testServiceDefinitionId,
+        },
+        {
+          id: uuidv4() as ServiceCapabilityId,
+          name: 'Test Capability 2',
+          description: 'Second test capability',
+          service_definition_id: testServiceDefinitionId,
+        },
+        {
+          id: uuidv4() as ServiceCapabilityId,
+          name: 'Test Capability 3',
+          description: 'Third test capability',
+          service_definition_id: testServiceDefinitionId2,
+        },
+      ])
+      .returning('*');
+
+    testCapabilityIds = capabilities.map((cap) => cap.id);
+    testServiceDefIds = serviceDefinition.map((def) => def.id);
+  });
+
+  afterAll(async () => {
+    if (testCapabilityIds.length > 0) {
+      await dbUnsecure<ServiceCapability>('Service_Capability')
+        .whereIn('id', testCapabilityIds)
+        .delete();
+    }
+
+    if (testServiceDefinitionId) {
+      await dbUnsecure<ServiceDefinition>('ServiceDefinition')
+        .whereIn('id', testServiceDefIds)
+        .delete();
+    }
+  });
+
+  describe('loadServiceCapabilitiesBy', () => {
+    it('should load service capabilities by service_definition_id', async () => {
+      const capabilities = await loadServiceCapabilitiesBy(contextAdminUser, {
+        service_definition_id: testServiceDefinitionId,
+      });
+
+      expect(capabilities).toHaveLength(2);
+      expect(capabilities[0]?.service_definition_id).toBe(
+        testServiceDefinitionId
+      );
+      expect(capabilities.map((cap) => cap.name)).toContain(
+        'Test Capability 1'
+      );
+      expect(capabilities.map((cap) => cap.name)).toContain(
+        'Test Capability 2'
+      );
+    });
+
+    it('should load service capabilities by id', async () => {
+      const capabilities = await loadServiceCapabilitiesBy(contextAdminUser, {
+        id: testCapabilityIds[0],
+      });
+
+      expect(capabilities).toHaveLength(1);
+      expect(capabilities[0]?.id).toBe(testCapabilityIds[0]);
+      expect(capabilities[0]?.name).toBe('Test Capability 1');
+    });
+
+    it('should load service capabilities by name', async () => {
+      const capabilities = await loadServiceCapabilitiesBy(contextAdminUser, {
+        name: 'Test Capability 2',
+      });
+
+      expect(capabilities).toHaveLength(1);
+      expect(capabilities[0]?.name).toBe('Test Capability 2');
+      expect(capabilities[0]?.description).toBe('Second test capability');
+    });
+
+    it('should return empty array when no capabilities match', async () => {
+      const capabilities = await loadServiceCapabilitiesBy(contextAdminUser, {
+        name: 'Non-existent Capability',
+      });
+
+      expect(capabilities).toHaveLength(0);
+      expect(capabilities).toEqual([]);
+    });
+
+    it('should handle multiple criteria', async () => {
+      const capabilities = await loadServiceCapabilitiesBy(contextAdminUser, {
+        service_definition_id: testServiceDefinitionId,
+        name: 'Test Capability 1',
+      });
+
+      expect(capabilities).toHaveLength(1);
+      expect(capabilities[0]?.name).toBe('Test Capability 1');
+      expect(capabilities[0]?.service_definition_id).toBe(
+        testServiceDefinitionId
+      );
+    });
+  });
+});

--- a/apps/portal-api/src/modules/services/definition/service-capability/service-capability.domain.ts
+++ b/apps/portal-api/src/modules/services/definition/service-capability/service-capability.domain.ts
@@ -1,0 +1,21 @@
+import { db } from '../../../../../knexfile';
+import ServiceCapability, {
+  ServiceCapabilityMutator,
+} from '../../../../model/kanel/public/ServiceCapability';
+import { PortalContext } from '../../../../model/portal-context';
+import { addPrefixToObject } from '../../../../utils/typescript';
+
+export const loadServiceCapabilitiesBy = async (
+  context: PortalContext,
+  field:
+    | addPrefixToObject<ServiceCapabilityMutator, 'Service_Capability.'>
+    | ServiceCapabilityMutator
+): Promise<ServiceCapability[]> => {
+  const serviceCapabilities: ServiceCapability[] = await db<ServiceCapability>(
+    context,
+    'Service_Capability'
+  )
+    .where(field)
+    .select('Service_Capability.*');
+  return serviceCapabilities;
+};

--- a/apps/portal-api/src/modules/services/definition/service-definition.resolver.test.ts
+++ b/apps/portal-api/src/modules/services/definition/service-definition.resolver.test.ts
@@ -1,0 +1,112 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { toGlobalId } from 'graphql-relay/node/node.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contextAdminUser } from '../../../../tests/tests.const';
+import { ServiceDefinition } from '../../../__generated__/resolvers-types';
+import { ServiceCapabilityId } from '../../../model/kanel/public/ServiceCapability';
+import { ServiceDefinitionId } from '../../../model/kanel/public/ServiceDefinition';
+import * as ServiceCapabilityDomain from './service-capability/service-capability.domain';
+import serviceDefinitionResolver from './service-definition.resolver';
+
+describe('ServiceDefinition resolver fields', () => {
+  afterEach(async () => {
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+  describe('service_capability field resolver', () => {
+    it('should load service capabilities for a given service definition', async () => {
+      const mockServiceDefinitionId =
+        'test-service-def-id' as ServiceDefinitionId;
+      const mockServiceCapabilities = [
+        {
+          id: toGlobalId('Service_Capability', '1') as ServiceCapabilityId,
+          name: 'Capability 1',
+          description: null,
+          service_definition_id: null,
+        },
+        {
+          id: toGlobalId('Service_Capability', '2') as ServiceCapabilityId,
+          name: 'Capability 2',
+          description: null,
+          service_definition_id: null,
+        },
+      ];
+
+      const mockLoadServiceCapabilitiesBy = vi
+        .spyOn(ServiceCapabilityDomain, 'loadServiceCapabilitiesBy')
+        .mockResolvedValueOnce(mockServiceCapabilities);
+      const resolver =
+        serviceDefinitionResolver.ServiceDefinition?.service_capability;
+      if (!resolver) {
+        throw new Error('service_capability resolver is not defined');
+      }
+
+      const response = await resolver(
+        { id: mockServiceDefinitionId } as unknown as ServiceDefinition,
+        {},
+        contextAdminUser,
+        {} as GraphQLResolveInfo
+      );
+
+      expect(mockLoadServiceCapabilitiesBy).toHaveBeenCalledWith(
+        contextAdminUser,
+        {
+          service_definition_id: mockServiceDefinitionId,
+        }
+      );
+      expect(response).toEqual(mockServiceCapabilities);
+    });
+
+    it('should handle empty service capabilities', async () => {
+      const mockServiceDefinitionId =
+        'test-service-def-id' as ServiceDefinitionId;
+
+      const mockLoadServiceCapabilitiesBy = vi
+        .spyOn(ServiceCapabilityDomain, 'loadServiceCapabilitiesBy')
+        .mockResolvedValueOnce([]);
+
+      const resolver =
+        serviceDefinitionResolver.ServiceDefinition?.service_capability;
+      if (!resolver) {
+        throw new Error('service_capability resolver is not defined');
+      }
+
+      const response = await resolver(
+        { id: mockServiceDefinitionId } as unknown as ServiceDefinition,
+        {},
+        contextAdminUser,
+        {} as GraphQLResolveInfo
+      );
+
+      expect(response).toEqual([]);
+      expect(mockLoadServiceCapabilitiesBy).toHaveBeenCalledOnce();
+    });
+
+    it('should handle errors from loadServiceCapabilitiesBy', async () => {
+      const mockServiceDefinitionId =
+        'test-service-def-id' as ServiceDefinitionId;
+      const mockError = new Error('Failed to load capabilities');
+
+      vi.spyOn(
+        ServiceCapabilityDomain,
+        'loadServiceCapabilitiesBy'
+      ).mockRejectedValue(mockError);
+
+      const resolver =
+        serviceDefinitionResolver.ServiceDefinition?.service_capability;
+      if (!resolver) {
+        throw new Error('service_capability resolver is not defined');
+      }
+
+      await expect(
+        resolver(
+          { id: mockServiceDefinitionId } as unknown as ServiceDefinition,
+          {},
+          contextAdminUser,
+          {} as GraphQLResolveInfo
+        )
+      ).rejects.toThrow('Failed to load capabilities');
+    });
+  });
+});

--- a/apps/portal-api/src/modules/services/definition/service-definition.resolver.ts
+++ b/apps/portal-api/src/modules/services/definition/service-definition.resolver.ts
@@ -1,0 +1,14 @@
+import { Resolvers } from '../../../__generated__/resolvers-types';
+import { ServiceCapabilityMutator } from '../../../model/kanel/public/ServiceCapability';
+import { loadServiceCapabilitiesBy } from './service-capability/service-capability.domain';
+
+const resolvers: Resolvers = {
+  ServiceDefinition: {
+    service_capability: ({ id }, _, context) =>
+      loadServiceCapabilitiesBy(context, {
+        service_definition_id: id,
+      } as ServiceCapabilityMutator),
+  },
+};
+
+export default resolvers;

--- a/apps/portal-api/src/modules/services/document/visualize-document-endpoint.ts
+++ b/apps/portal-api/src/modules/services/document/visualize-document-endpoint.ts
@@ -6,7 +6,7 @@ import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { PortalContext } from '../../../model/portal-context';
 import { logApp } from '../../../utils/app-logger.util';
 import { NotFoundError } from '../../../utils/error.util';
-import { getServiceDefinition } from '../service-instance.domain';
+import { loadServiceDefinition } from '../service-instance.domain';
 import { downloadFile } from './document-storage';
 import { loadDocumentBy } from './document.domain';
 
@@ -61,7 +61,7 @@ export const documentVisualizeEndpoint = (app) => {
     async (req, res) => {
       try {
         // Check if the user is authorized to access the document
-        const serviceDefinition = (await getServiceDefinition(
+        const serviceDefinition = (await loadServiceDefinition(
           { req, res } as PortalContext,
           fromGlobalId(req.params.serviceInstanceId).id
         )) as ServiceDefinition;

--- a/apps/portal-api/src/modules/services/service-instance.app.test.ts
+++ b/apps/portal-api/src/modules/services/service-instance.app.test.ts
@@ -1,0 +1,220 @@
+import { MockInstance } from '@vitest/spy';
+import { v4 as uuidv4 } from 'uuid';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { contextAdminUser } from '../../../tests/tests.const';
+import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
+import { SubscriptionId } from '../../model/kanel/public/Subscription';
+import { UserId } from '../../model/kanel/public/User';
+import * as subscriptionDomain from '../subcription/subscription.domain';
+import { GenericServiceCapabilityIds } from '../user_service/service-capability/generic_service_capability.const';
+import * as userServiceDomain from '../user_service/user_service.domain';
+import { serviceInstanceApp } from './service-instance.app';
+import * as serviceInstanceDomain from './service-instance.domain';
+
+describe('Service Instance app', () => {
+  describe('loadServiceInstance', () => {
+    let loadSubscriptionBySpy: MockInstance;
+    let loadUserServiceBySpy: MockInstance;
+    let loadServiceInstanceBySpy: MockInstance;
+    let grantServiceAccessSpy: MockInstance;
+
+    const mockServiceInstanceId = uuidv4() as ServiceInstanceId;
+    const mockSubscriptionId = uuidv4() as SubscriptionId;
+    const mockUserId = contextAdminUser.user.id;
+
+    const mockSubscription = {
+      id: mockSubscriptionId,
+      service_instance_id: mockServiceInstanceId,
+      organization_id: uuidv4(),
+      joining: 'INVITE_ONLY',
+      start_date: new Date(),
+      end_date: null,
+    };
+
+    const mockUserService = {
+      id: uuidv4(),
+      user_id: mockUserId,
+      subscription_id: mockSubscriptionId,
+      service_capability_id: GenericServiceCapabilityIds.AccessId,
+    };
+
+    const mockServiceInstance = {
+      id: mockServiceInstanceId,
+      name: 'Service instance 1',
+      description: 'description 1',
+      service_definition_id: uuidv4(),
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    beforeEach(() => {
+      loadSubscriptionBySpy = vi.spyOn(
+        subscriptionDomain,
+        'loadSubscriptionBy'
+      );
+      loadUserServiceBySpy = vi.spyOn(userServiceDomain, 'loadUserServiceBy');
+      loadServiceInstanceBySpy = vi.spyOn(
+        serviceInstanceDomain,
+        'loadServiceInstanceBy'
+      );
+      grantServiceAccessSpy = vi.spyOn(
+        serviceInstanceDomain,
+        'grantServiceAccess'
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should load service instance when user already has access', async () => {
+      loadSubscriptionBySpy.mockResolvedValueOnce(mockSubscription);
+      loadUserServiceBySpy.mockResolvedValueOnce([mockUserService]);
+      loadServiceInstanceBySpy.mockResolvedValueOnce(mockServiceInstance);
+
+      const result = await serviceInstanceApp.loadServiceInstance(
+        contextAdminUser,
+        mockServiceInstanceId
+      );
+
+      expect(loadSubscriptionBySpy).toHaveBeenCalledWith(contextAdminUser, {
+        service_instance_id: mockServiceInstanceId,
+      });
+      expect(loadUserServiceBySpy).toHaveBeenCalledWith(contextAdminUser, {
+        subscription_id: mockSubscriptionId,
+        user_id: mockUserId,
+      });
+      expect(grantServiceAccessSpy).not.toHaveBeenCalled();
+      expect(loadServiceInstanceBySpy).toHaveBeenCalledWith(
+        contextAdminUser,
+        'id',
+        mockServiceInstanceId
+      );
+      expect(result).toEqual(mockServiceInstance);
+    });
+
+    it('should auto-join user when subscription has AUTO_JOIN mode and user has no access', async () => {
+      const autoJoinSubscription = {
+        ...mockSubscription,
+        joining: 'AUTO_JOIN',
+      };
+      loadSubscriptionBySpy.mockResolvedValue(autoJoinSubscription);
+      loadUserServiceBySpy.mockResolvedValue([]);
+      loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
+      grantServiceAccessSpy.mockResolvedValue(undefined);
+
+      const result = await serviceInstanceApp.loadServiceInstance(
+        contextAdminUser,
+        mockServiceInstanceId
+      );
+
+      expect(grantServiceAccessSpy).toHaveBeenCalledWith(
+        contextAdminUser,
+        [GenericServiceCapabilityIds.AccessId],
+        [mockUserId],
+        mockSubscriptionId
+      );
+      expect(result).toEqual(mockServiceInstance);
+    });
+
+    it('should not auto-join user when subscription has INVITE_ONLY mode', async () => {
+      const inviteOnlySubscription = {
+        ...mockSubscription,
+        joining: 'INVITE_ONLY',
+      };
+      loadSubscriptionBySpy.mockResolvedValue(inviteOnlySubscription);
+      loadUserServiceBySpy.mockResolvedValue([]);
+      loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
+
+      const result = await serviceInstanceApp.loadServiceInstance(
+        contextAdminUser,
+        mockServiceInstanceId
+      );
+
+      expect(grantServiceAccessSpy).not.toHaveBeenCalled();
+      expect(result).toEqual(mockServiceInstance);
+    });
+
+    it('should handle multiple user services', async () => {
+      const multipleUserServices = [
+        mockUserService,
+        {
+          ...mockUserService,
+          id: uuidv4(),
+          service_capability_id: uuidv4(),
+        },
+      ];
+      loadSubscriptionBySpy.mockResolvedValue(mockSubscription);
+      loadUserServiceBySpy.mockResolvedValue(multipleUserServices);
+      loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
+
+      const result = await serviceInstanceApp.loadServiceInstance(
+        contextAdminUser,
+        mockServiceInstanceId
+      );
+
+      expect(grantServiceAccessSpy).not.toHaveBeenCalled();
+      expect(result).toEqual(mockServiceInstance);
+    });
+
+    it('should propagate errors from loadSubscriptionBy', async () => {
+      const error = new Error('Error');
+      loadSubscriptionBySpy.mockRejectedValue(error);
+
+      await expect(
+        serviceInstanceApp.loadServiceInstance(
+          contextAdminUser,
+          mockServiceInstanceId
+        )
+      ).rejects.toThrow('Error');
+
+      expect(loadUserServiceBySpy).not.toHaveBeenCalled();
+      expect(loadServiceInstanceBySpy).not.toHaveBeenCalled();
+    });
+
+    it('should propagate errors from grantServiceAccess', async () => {
+      const autoJoinSubscription = {
+        ...mockSubscription,
+        joining: 'AUTO_JOIN',
+      };
+      const error = new Error('Other error');
+      loadSubscriptionBySpy.mockResolvedValue(autoJoinSubscription);
+      loadUserServiceBySpy.mockResolvedValue([]);
+      grantServiceAccessSpy.mockRejectedValue(error);
+
+      await expect(
+        serviceInstanceApp.loadServiceInstance(
+          contextAdminUser,
+          mockServiceInstanceId
+        )
+      ).rejects.toThrow('Other error');
+
+      expect(loadServiceInstanceBySpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle different context users', async () => {
+      const differentUserId = uuidv4() as UserId;
+      const differentContext = {
+        ...contextAdminUser,
+        user: {
+          ...contextAdminUser.user,
+          id: differentUserId,
+        },
+      };
+
+      loadSubscriptionBySpy.mockResolvedValue(mockSubscription);
+      loadUserServiceBySpy.mockResolvedValue([]);
+      loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
+
+      await serviceInstanceApp.loadServiceInstance(
+        differentContext,
+        mockServiceInstanceId
+      );
+
+      expect(loadUserServiceBySpy).toHaveBeenCalledWith(differentContext, {
+        subscription_id: mockSubscriptionId,
+        user_id: differentUserId,
+      });
+    });
+  });
+});

--- a/apps/portal-api/src/modules/services/service-instance.app.ts
+++ b/apps/portal-api/src/modules/services/service-instance.app.ts
@@ -1,0 +1,37 @@
+import { ServiceInstance } from '../../__generated__/resolvers-types';
+import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
+import { PortalContext } from '../../model/portal-context';
+import { loadSubscriptionBy } from '../subcription/subscription.domain';
+import { GenericServiceCapabilityIds } from '../user_service/service-capability/generic_service_capability.const';
+import { loadUserServiceBy } from '../user_service/user_service.domain';
+import {
+  grantServiceAccess,
+  loadServiceInstanceBy,
+} from './service-instance.domain';
+
+export const serviceInstanceApp = {
+  loadServiceInstance: async (
+    context: PortalContext,
+    serviceInstanceId: ServiceInstanceId
+  ): Promise<ServiceInstance> => {
+    const subscription = await loadSubscriptionBy(context, {
+      service_instance_id: serviceInstanceId,
+    });
+    const userService = await loadUserServiceBy(context, {
+      subscription_id: subscription.id,
+      user_id: context.user.id,
+    });
+    if (userService.length === 0) {
+      console.warn('USER_MUST_JOIN_SERVICE_BEFORE_ACCESSING_IT');
+      if (subscription.joining === 'AUTO_JOIN') {
+        await grantServiceAccess(
+          context,
+          [GenericServiceCapabilityIds.AccessId],
+          [context.user.id],
+          subscription.id
+        );
+      }
+    }
+    return loadServiceInstanceBy(context, 'id', serviceInstanceId);
+  },
+};

--- a/apps/portal-api/src/modules/services/service-instance.domain.ts
+++ b/apps/portal-api/src/modules/services/service-instance.domain.ts
@@ -200,7 +200,7 @@ export const getUserJoined = async (context, id) => {
   return result?.user_joined === true;
 };
 
-export const loadServiceInstanceByIdWithCapabilities = async (
+export const loadServiceInstanceById = async (
   context: PortalContext,
   service_instance_id: string
 ): Promise<ServiceInstance> => {
@@ -242,6 +242,17 @@ export const loadServiceInstanceByIdWithCapabilities = async (
     .groupBy(['ServiceInstance.id', 'Subscription.id', 'service_def.id'])
     .first();
 
+  return serviceInstanceQuery;
+};
+
+export const loadServiceInstanceByIdWithCapabilities = async (
+  context: PortalContext,
+  service_instance_id: string
+): Promise<ServiceInstance> => {
+  const serviceInstanceQuery = await loadServiceInstanceById(
+    context,
+    service_instance_id
+  );
   const capabilities = await loadCapabilities(
     context,
     service_instance_id,

--- a/apps/portal-api/src/modules/services/services.resolver.ts
+++ b/apps/portal-api/src/modules/services/services.resolver.ts
@@ -23,6 +23,7 @@ import { extractId } from '../../utils/utils';
 import { loadOrganizationBy } from '../organizations/organizations.helper';
 import { loadCapabilities } from '../user_service/user-service-capability/user-service-capability.helper';
 import { uploadNewFile } from './document/document.helper';
+import { serviceInstanceApp } from './service-instance.app';
 import {
   getIsSubscribed,
   getServiceDefinition,
@@ -32,7 +33,6 @@ import {
   loadPublicServiceInstances,
   loadSeoServiceInstanceBySlug,
   loadSeoServiceInstances,
-  loadServiceInstanceByIdWithCapabilities,
   loadServiceInstances,
   loadServiceWithSubscriptions,
   loadSubscribedServiceInstancesByIdentifier,
@@ -76,15 +76,10 @@ const resolvers: Resolvers = {
       return loadPublicServiceInstances(context, opt);
     },
     serviceInstanceById: async (_, { service_instance_id }, context) => {
-      const serviceInstance = await loadServiceInstanceByIdWithCapabilities(
+      const serviceInstance = await serviceInstanceApp.loadServiceInstance(
         context,
-        fromGlobalId(service_instance_id).id
+        extractId<ServiceInstanceId>(service_instance_id)
       );
-
-      // Not found
-      if (!serviceInstance) {
-        return null;
-      }
 
       return serviceInstance;
     },

--- a/apps/portal-api/src/modules/services/services.resolver.ts
+++ b/apps/portal-api/src/modules/services/services.resolver.ts
@@ -26,13 +26,12 @@ import { uploadNewFile } from './document/document.helper';
 import { serviceInstanceApp } from './service-instance.app';
 import {
   getIsSubscribed,
-  getServiceDefinition,
-  getServiceDefinitionCapabilities,
   getUserJoined,
   loadLinks,
   loadPublicServiceInstances,
   loadSeoServiceInstanceBySlug,
   loadSeoServiceInstances,
+  loadServiceDefinition,
   loadServiceInstances,
   loadServiceWithSubscriptions,
   loadSubscribedServiceInstancesByIdentifier,
@@ -52,7 +51,7 @@ const resolvers: Resolvers = {
     },
     links: ({ id }, _, context) => loadLinks(context, id),
     service_definition: ({ id }, _, context) =>
-      getServiceDefinition(context, id),
+      loadServiceDefinition(context, id),
     organization_subscribed: ({ id }, _, context) =>
       getIsSubscribed(context, id),
     capabilities: ({ id }, _, context) =>
@@ -63,10 +62,6 @@ const resolvers: Resolvers = {
         context.user.selected_organization_id
       ),
     user_joined: ({ id }, _, context) => getUserJoined(context, id),
-  },
-  ServiceDefinition: {
-    service_capability: ({ id }, _, context) =>
-      getServiceDefinitionCapabilities(context, id),
   },
   Query: {
     serviceInstances: async (_, opt, context) => {

--- a/apps/portal-api/src/modules/subcription/subscription.resolver.test.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.resolver.test.ts
@@ -1,4 +1,4 @@
-import { toGlobalId } from 'graphql-relay/node/node';
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
   contextAdminUser,

--- a/apps/portal-api/src/modules/user_service/user-service.helper.ts
+++ b/apps/portal-api/src/modules/user_service/user-service.helper.ts
@@ -18,7 +18,7 @@ import {
 import { sendMail } from '../../server/mail-service';
 import { loadUserOrganization } from '../common/user-organization.domain';
 import {
-  getServiceDefinition,
+  loadServiceDefinition,
   loadServiceInstanceBy,
 } from '../services/service-instance.domain';
 import { loadUnsecureSubscriptionBy } from '../subcription/subscription.helper';
@@ -191,7 +191,7 @@ export const createUserServiceAccess = async (
     'ServiceInstance.id',
     subscription.service_instance_id
   );
-  const service_definition = await getServiceDefinition(context, service.id);
+  const service_definition = await loadServiceDefinition(context, service.id);
   await sendMail({
     to: user.email,
     template: service_definition.identifier,

--- a/apps/portal-api/src/modules/user_service/user_service.graphql
+++ b/apps/portal-api/src/modules/user_service/user_service.graphql
@@ -25,7 +25,6 @@ input UserServiceDeleteInput {
 type Mutation {
   addUserService(input: UserServiceAddInput!): [UserService] @auth
   deleteUserService(input: UserServiceDeleteInput!): UserService @auth
-  selfJoinServiceInstance(service_instance_id: ID!): ServiceInstance @auth
 }
 type Query {
   userServiceOwned(

--- a/apps/portal-api/src/modules/users/users.resolver.test.ts
+++ b/apps/portal-api/src/modules/users/users.resolver.test.ts
@@ -1,5 +1,5 @@
 import { MockInstance } from '@vitest/spy';
-import { toGlobalId } from 'graphql-relay/node/node';
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import {
   afterAll,

--- a/apps/portal-api/src/security/access.ts
+++ b/apps/portal-api/src/security/access.ts
@@ -23,6 +23,7 @@ import { setDeleteSecurityForUserServiceCapability } from './user-service-capabi
 
 import { logApp } from '../utils/app-logger.util';
 import { isUserAllowed } from './auth.helper';
+import { serviceInstanceSecurityLayer } from './layer/service-instance';
 import { userSecurityLayer } from './layer/user';
 import { userOrganizationSecurityLayer } from './layer/user-organization';
 import { userOrganizationCapabilitySecurityLayer } from './layer/user-organization-capability';
@@ -188,6 +189,7 @@ export const applyDbSecurityLayer = async (
     User_Organization_Pending: userOrganizationPendingSecurityLayer,
     UserOrganization_Capability: userOrganizationCapabilitySecurityLayer,
     User_Service: userServiceSecurityLayer,
+    ServiceInstance: serviceInstanceSecurityLayer,
   };
 
   if (tableSecurityMap[table]) {

--- a/apps/portal-api/src/security/document-security-access.ts
+++ b/apps/portal-api/src/security/document-security-access.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { dbRaw } from '../../knexfile';
 import { ServiceRestriction } from '../__generated__/resolvers-types';
 import { PortalContext } from '../model/portal-context';
-import { getServiceDefinition } from '../modules/services/service-instance.domain';
+import { loadServiceDefinition } from '../modules/services/service-instance.domain';
 import { loadCapabilities } from '../modules/user_service/user-service-capability/user-service-capability.helper';
 export const setQueryForDocument = <T>(
   context: PortalContext,
@@ -14,7 +14,7 @@ export const setQueryForDocument = <T>(
     context.user.id,
     context.user.selected_organization_id
   ).then((capabilities) => {
-    return getServiceDefinition(context, context.serviceInstanceId).then(
+    return loadServiceDefinition(context, context.serviceInstanceId).then(
       (serviceDef) => {
         if (
           !capabilities?.includes(ServiceRestriction.Upload) &&

--- a/apps/portal-api/src/security/layer/service-definition.ts
+++ b/apps/portal-api/src/security/layer/service-definition.ts
@@ -1,0 +1,50 @@
+import { KnexQueryBuilder } from '../../../knexfile';
+import { PortalContext } from '../../model/portal-context';
+import { SecuryQueryHandlers } from '../access';
+
+export const setSelectSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setInsertSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setUpdateSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setDeleteSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const serviceDefinitionSecurityLayer: SecuryQueryHandlers = {
+  select: setSelectSecurity,
+  insert: setInsertSecurity,
+  update: setUpdateSecurity,
+  del: setDeleteSecurity,
+};

--- a/apps/portal-api/src/security/layer/service-instance.ts
+++ b/apps/portal-api/src/security/layer/service-instance.ts
@@ -1,0 +1,50 @@
+import { KnexQueryBuilder } from '../../../knexfile';
+import { PortalContext } from '../../model/portal-context';
+import { SecuryQueryHandlers } from '../access';
+
+export const setSelectSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setInsertSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setUpdateSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const setDeleteSecurity = (
+  context: PortalContext,
+  qb: KnexQueryBuilder
+) => {
+  if (!context || !qb) {
+    throw new Error('Invalid parameters');
+  }
+  return qb;
+};
+
+export const serviceInstanceSecurityLayer: SecuryQueryHandlers = {
+  select: setSelectSecurity,
+  insert: setInsertSecurity,
+  update: setUpdateSecurity,
+  del: setDeleteSecurity,
+};

--- a/apps/portal-api/src/server/graphql-schema.ts
+++ b/apps/portal-api/src/server/graphql-schema.ts
@@ -7,10 +7,11 @@ import organizationsResolver from '../modules/organizations/organizations.resolv
 import rolePortalResolver from '../modules/role-portal/role-portal.resolver';
 import csvFeedsResolver from '../modules/services/csv-feeds/csv-feeds.resolver';
 import customDashboardsResolver from '../modules/services/custom-dashboards/custom-dashboards.resolver';
+import ServiceDefinitionResolver from '../modules/services/definition/service-definition.resolver';
 import vaultResolver from '../modules/services/document/document.resolver';
 import obasScenariosResolver from '../modules/services/obas-scenarios/obas-scenarios.resolver';
 import registrationResolver from '../modules/services/registration/registration.resolver';
-import servicesResolver from '../modules/services/services.resolver';
+import ServiceInstanceResolver from '../modules/services/services.resolver';
 import labelsResolver from '../modules/settings/labels/labels.resolver';
 import settingsResolver from '../modules/settings/settings.resolver';
 import subscriptionsResolver from '../modules/subcription/subscription.resolver';
@@ -31,7 +32,8 @@ const typeDefs = mergeTypeDefs(typeDefFiles);
 
 const resolvers = mergeResolvers([
   nodesResolver,
-  servicesResolver,
+  ServiceInstanceResolver,
+  ServiceDefinitionResolver,
   organizationsResolver,
   usersResolver,
   settingsResolver,

--- a/apps/portal-api/src/server/mail-template/mail.ts
+++ b/apps/portal-api/src/server/mail-template/mail.ts
@@ -24,6 +24,7 @@ export type MailTemplates = {
   vault: GenericServiceMailModel;
   custom_dashboards: GenericServiceMailModel;
   csv_feeds: GenericServiceMailModel;
+  obas_scenarios: GenericServiceMailModel;
   new_user_organization: NewUserOrganizationMailModel;
   opencti_platform_registered: PlatformRegisteredModel;
   opencti_platform_unregistered: PlatformUnregisteredModel;
@@ -38,6 +39,8 @@ export const templateSubjects: {
   custom_dashboards: (params: GenericServiceMailModel) =>
     `XTM Hub - You've been invited to the ${params.serviceName}`,
   csv_feeds: (params: GenericServiceMailModel) =>
+    `XTM Hub - You've been invited to the ${params.serviceName}`,
+  obas_scenarios: (params: GenericServiceMailModel) =>
     `XTM Hub - You've been invited to the ${params.serviceName}`,
   new_user_organization: (params: NewUserOrganizationMailModel) =>
     `XTM Hub - You've been added to the ${params.organizationName} organization`,

--- a/apps/portal-api/src/server/mail-template/obas_scenarios.html
+++ b/apps/portal-api/src/server/mail-template/obas_scenarios.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<html
+  lang="en"
+  xmlns:v="urn:schemas-microsoft-com:vml">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <meta
+      name="format-detection"
+      content="telephone=no, date=no, address=no, email=no, url=no" />
+    <meta
+      name="color-scheme"
+      content="light dark" />
+    <meta
+      name="supported-color-schemes"
+      content="light dark" />
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings
+            xmlns:o="urn:schemas-microsoft-com:office:office">
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+      <style>
+        td,
+        th,
+        div,
+        p,
+        a,
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          font-family: 'Segoe UI', sans-serif;
+          mso-line-height-rule: exactly;
+        }
+      </style>
+    <![endif]-->
+    <title>XTM Hub - Welcome to Your CSV Feeds Library</title>
+    <style>
+      @media (max-width: 600px) {
+        .sm-my-8 {
+          margin-top: 32px !important;
+          margin-bottom: 32px !important;
+        }
+        .sm-px-4 {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .sm-px-6 {
+          padding-left: 24px !important;
+          padding-right: 24px !important;
+        }
+        .sm-leading-8 {
+          line-height: 32px !important;
+        }
+      }
+    </style>
+  </head>
+  <body
+    style="
+      margin: 0;
+      width: 100%;
+      background-color: #f1f5f9;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+      word-break: break-word;
+    ">
+    <div
+      role="article"
+      aria-roledescription="email"
+      aria-label="XTM Hub - Welcome to Your CSV Feeds Library"
+      lang="en">
+      <div
+        class="sm-px-4"
+        style="
+          background-color: #f1f5f9;
+          font-family:
+            ui-sans-serif,
+            system-ui,
+            -apple-system,
+            'Segoe UI',
+            sans-serif;
+        ">
+        <table
+          align="center"
+          cellpadding="0"
+          cellspacing="0"
+          role="none">
+          <tr>
+            <td style="width: 552px; max-width: 100%">
+              <div
+                class="sm-my-8"
+                style="
+                  margin-bottom: 40px;
+                  margin-top: 40px;
+                  text-align: center;
+                ">
+                <a href="{{ base_url_front }}">
+                  <img
+                    src="{{ base_url_front }}/logo.png"
+                    width="320"
+                    alt="XTM Hub logo"
+                    style="max-width: 100%; vertical-align: middle" />
+                </a>
+              </div>
+              <table
+                style="width: 100%"
+                cellpadding="0"
+                cellspacing="0"
+                role="none">
+                <tr>
+                  <td
+                    class="sm-px-6"
+                    style="
+                      border-radius: 4px;
+                      background-color: #fffffe;
+                      padding: 48px;
+                      font-size: 16px;
+                      color: #00020c;
+                      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+                    ">
+                    <h1
+                      class="sm-leading-8"
+                      style="
+                        margin: 0 0 24px;
+                        font-size: 24px;
+                        font-weight: 400;
+                      ">
+                      Welcome to the {{ serviceName }}!
+                    </h1>
+                    <p style="margin: 0; line-height: 24px">
+                      We're thrilled to have you onboard and look forward to
+                      collaborating closely with you.
+                      <br />
+                      <br />
+                      Access a growing library of pre-built OpenBAS scenarios,
+                      tailored to specific use cases. These resources simplify
+                      data integration into OpenBAS, reducing setup time and
+                      enhancing your breach and attack simulations with
+                      structured, actionable insights.
+                      <br />
+                      <br />
+                    </p>
+                    <div style="text-align: center">
+                      <a
+                        href="{{ serviceLink }}"
+                        style="
+                          color: #f4f4f6;
+                          background-color: #001bdb;
+                          display: inline-block;
+                          border-radius: 4px;
+                          padding: 16px 24px;
+                          font-size: 16px;
+                          line-height: 1;
+                          font-weight: 600;
+                          text-decoration: none;
+                        ">
+                        <!--[if mso]>
+                          <i
+                            style="mso-font-width: 150%; mso-text-raise: 30px"
+                            hidden
+                            >&emsp;</i
+                          >
+                        <![endif]-->
+                        <span style="mso-text-raise: 16px">
+                          Access {{ serviceName }}
+                        </span>
+                        <!--[if mso]>
+                          <i
+                            hidden
+                            style="mso-font-width: 150%"
+                            >&emsp;&#8203;</i
+                          >
+                        <![endif]-->
+                      </a>
+                    </div>
+                    <p style="margin: 0; padding-top: 16px">
+                      Best regards, <br />Filigran Team
+                    </p>
+                    <div
+                      role="separator"
+                      style="
+                        height: 1px;
+                        line-height: 1px;
+                        margin: 24px 0;
+                        background-color: #cbd5e1;
+                      ">
+                      &zwj;
+                    </div>
+                    <p style="margin: 0; font-size: 14px">
+                      If you have any questions or need support, don’t hesitate
+                      to reach out to us at
+                      <a href="mailto:{{ contactEmail }}">{{ contactEmail }}</a
+                      >.
+                    </p>
+                  </td>
+                </tr>
+                <tr></tr>
+                <tr role="separator">
+                  <td style="line-height: 16px">&zwj;</td>
+                </tr>
+                <td
+                  style="
+                    padding-left: 24px;
+                    padding-right: 24px;
+                    text-align: center;
+                    font-size: 12px;
+                    color: #00020c;
+                  ">
+                  <table
+                    align="center"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="none">
+                    <tr>
+                      <td>
+                        <table
+                          style="
+                            margin: 16px;
+                            border-spacing: 4px;
+                            border-collapse: separate;
+                          "
+                          cellpadding="0"
+                          cellspacing="0"
+                          role="none">
+                          <tr>
+                            <td style="padding: 4px">
+                              <a href="https://filigran.io/">
+                                <img
+                                  src="{{ base_url_front }}/website.png"
+                                  width="24"
+                                  alt="Filigran website"
+                                  style="
+                                    max-width: 100%;
+                                    vertical-align: middle;
+                                    border: none;
+                                  " />
+                              </a>
+                            </td>
+                            <td style="padding: 4px">
+                              <a
+                                href="https://filigran-community.slack.com/join/shared_invite/zt-2pp43qkqc-EY7qC7Sk30zZfsNjgXwF5w">
+                                <img
+                                  src="{{ base_url_front }}/slack.png"
+                                  width="24"
+                                  alt="Slack community"
+                                  style="
+                                    max-width: 100%;
+                                    vertical-align: middle;
+                                    border: none;
+                                  " />
+                              </a>
+                            </td>
+                            <td style="padding: 4px">
+                              <a
+                                href="https://www.linkedin.com/company/filigran">
+                                <img
+                                  src="{{ base_url_front }}/linkedin.png"
+                                  width="24"
+                                  alt="Linkedin page"
+                                  style="
+                                    max-width: 100%;
+                                    vertical-align: middle;
+                                    border: none;
+                                  " />
+                              </a>
+                            </td>
+                            <td style="padding: 4px">
+                              <a href="https://www.youtube.com/@Filigran">
+                                <img
+                                  src="{{ base_url_front }}/youtube.png"
+                                  width="24"
+                                  alt="Youtube channel"
+                                  style="
+                                    max-width: 100%;
+                                    vertical-align: middle;
+                                    border: none;
+                                  " />
+                              </a>
+                            </td>
+                            <td style="padding: 4px">
+                              <a href="https://x.com/FiligranHQ">
+                                <img
+                                  src="{{ base_url_front }}/twitter.png"
+                                  width="24"
+                                  alt="X link"
+                                  style="
+                                    max-width: 100%;
+                                    vertical-align: middle;
+                                    border: none;
+                                  " />
+                              </a>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                  <div style="margin-bottom: 8px">
+                    <a href="https://filigran.io">
+                      <img
+                        src="{{ base_url_front }}/logo-filigran.png"
+                        width="100"
+                        alt="Filigran logo"
+                        style="max-width: 100%; vertical-align: middle" />
+                    </a>
+                  </div>
+                  <p style="margin: 0 0 40px">
+                    New York, Paris, London, Sydney
+                  </p>
+                </td>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/portal-api/tests/config-test.ts
+++ b/apps/portal-api/tests/config-test.ts
@@ -6,6 +6,7 @@ import { logApp } from '../src/utils/app-logger.util';
 const DATABASE_TEST: string =
   config.get('database-test.database') || 'test_database';
 
+let testDbInstance: Knex | null = null;
 const getDbConnection = () => {
   return pkg({
     client: 'pg',
@@ -39,7 +40,17 @@ const configTest: Knex.Config = {
   },
 };
 export const getDbTestConnection = () => {
-  return pkg(configTest);
+  if (!testDbInstance) {
+    testDbInstance = pkg(configTest);
+  }
+  return testDbInstance;
+};
+
+export const closeDbTestConnection = async () => {
+  if (testDbInstance) {
+    await testDbInstance.destroy();
+    testDbInstance = null;
+  }
 };
 
 export async function createDatabase() {
@@ -77,4 +88,8 @@ export async function cleanDatabase() {
 
 export async function setup() {
   await createDatabase();
+}
+export async function teardown() {
+  console.log('🛑 Global teardown - Closing all connections');
+  await closeDbTestConnection();
 }

--- a/apps/portal-api/tests/setup-test.ts
+++ b/apps/portal-api/tests/setup-test.ts
@@ -1,10 +1,13 @@
-import { getDbTestConnection } from './config-test';
+import { beforeAll } from 'vitest';
+import { closeDbTestConnection, getDbTestConnection } from './config-test';
 
-function isUtilOrHelper(filepath) {
+function isUtilOrHelper(filepath?: string) {
+  if (!filepath) return true;
   return /\b(util|utils|helper|helpers|pure|mock|stub|constant|constants|types)\b/i.test(
     filepath
   );
 }
+
 beforeAll(async (suite) => {
   const currentFile = suite?.file?.name;
 
@@ -12,11 +15,46 @@ beforeAll(async (suite) => {
     console.log('⚠️ Did not clean', currentFile);
     return;
   }
+
   console.log('🧹 Clean up DB', currentFile);
-  const db = getDbTestConnection();
-  await db.raw('DROP SCHEMA public CASCADE;');
-  await db.raw('CREATE SCHEMA public');
-  await db.raw('GRANT ALL ON SCHEMA public TO public');
-  await db.migrate.latest();
-  await db.seed.run();
+  const startTime = Date.now();
+
+  try {
+    const db = getDbTestConnection();
+
+    await db.transaction(async (trx) => {
+      await trx.raw('DROP SCHEMA public CASCADE;');
+      await trx.raw('CREATE SCHEMA public');
+      await trx.raw('GRANT ALL ON SCHEMA public TO public');
+    });
+
+    const [lastMigration] = await db('migrations')
+      .orderBy('id', 'desc')
+      .limit(1)
+      .catch(() => [null]);
+
+    if (!lastMigration) {
+      console.log('📦 Running migrations...');
+      await db.migrate.latest();
+    }
+
+    console.log('🌱 Running seeds...');
+    await db.seed.run();
+
+    const duration = Date.now() - startTime;
+    console.log(`✅ DB setup completed in ${duration}ms`);
+  } catch (error) {
+    console.error('❌ DB Setup error:', error);
+    throw error;
+  }
+}, 60000);
+
+process.on('SIGINT', async () => {
+  await closeDbTestConnection();
+  process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+  await closeDbTestConnection();
+  process.exit(0);
 });

--- a/apps/portal-front/app/(application)/app/(user)/manage/service/[serviceInstanceId]/subscription/[subscriptionId]/page-loader.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/manage/service/[serviceInstanceId]/subscription/[subscriptionId]/page-loader.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import Loader from '@/components/loader';
-import { ServiceById } from '@/components/service/service.graphql';
 import { UserServiceFromSubscription } from '@/components/service/user_service.graphql';
 import SubscriptionSlug from '@/components/subcription/[slug]/subscription-slug';
 import { SubscriptionById } from '@/components/subcription/subscription.graphql';
 import useMountingLoader from '@/hooks/useMountingLoader';
-import { serviceByIdQuery } from '@generated/serviceByIdQuery.graphql';
+import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { subscriptionByIdQuery } from '@generated/subscriptionByIdQuery.graphql';
 import { userServiceFromSubscriptionQuery } from '@generated/userServiceFromSubscriptionQuery.graphql';
 import * as React from 'react';
@@ -16,13 +15,13 @@ import { useLocalStorage } from 'usehooks-ts';
 // Component interface
 interface PreloaderProps {
   subscriptionId: string;
-  serviceInstanceId: string;
+  serviceInstance: serviceInstance_fragment$data;
 }
 
 // Component
 const PageLoader: React.FunctionComponent<PreloaderProps> = ({
   subscriptionId,
-  serviceInstanceId,
+  serviceInstance,
 }) => {
   const [queryRef, loadQuery] =
     useQueryLoader<userServiceFromSubscriptionQuery>(
@@ -44,17 +43,12 @@ const PageLoader: React.FunctionComponent<PreloaderProps> = ({
     subscriptionId,
   });
 
-  const [queryRefService, loadQueryService] =
-    useQueryLoader<serviceByIdQuery>(ServiceById);
-  useMountingLoader(loadQueryService, {
-    service_instance_id: serviceInstanceId,
-  });
   return (
     <>
-      {queryRef && queryRefSubscription && queryRefService ? (
+      {queryRef && queryRefSubscription && serviceInstance ? (
         <SubscriptionSlug
           queryRef={queryRef}
-          queryRefService={queryRefService}
+          serviceInstance={serviceInstance}
           queryRefSubscription={queryRefSubscription}
           subscriptionId={subscriptionId}
         />

--- a/apps/portal-front/app/(application)/app/(user)/manage/service/[serviceInstanceId]/subscription/[subscriptionId]/page.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/manage/service/[serviceInstanceId]/subscription/[subscriptionId]/page.tsx
@@ -1,4 +1,9 @@
+import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
 import { APP_PATH } from '@/utils/path/constant';
+import ServiceByIdQuery, {
+  serviceByIdQuery,
+} from '@generated/serviceByIdQuery.graphql';
+import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { redirect } from 'next/navigation';
 import { FunctionComponent } from 'react';
 import PageLoader from './page-loader';
@@ -13,11 +18,20 @@ const Page: FunctionComponent<PageProps> = async ({ params }) => {
   const { subscriptionId, serviceInstanceId } = await params;
   const decodedSubscriptionId = decodeURIComponent(subscriptionId);
   const decodedServiceInstanceId = decodeURIComponent(serviceInstanceId);
+  const response = await serverFetchGraphQL<serviceByIdQuery>(
+    ServiceByIdQuery,
+    {
+      service_instance_id: decodedServiceInstanceId,
+    }
+  );
   try {
     return (
       <PageLoader
         subscriptionId={decodedSubscriptionId}
-        serviceInstanceId={decodedServiceInstanceId}
+        serviceInstance={
+          response.data
+            .serviceInstanceById as unknown as serviceInstance_fragment$data
+        }
       />
     );
   } catch (_) {

--- a/apps/portal-front/app/(application)/app/(user)/service/csv_feeds/[serviceInstanceId]/[documentId]/page-loader.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/csv_feeds/[serviceInstanceId]/[documentId]/page-loader.tsx
@@ -11,23 +11,23 @@ import { useQueryLoader } from 'react-relay';
 // Component interface
 interface PreloaderProps {
   documentId: string;
-  service: serviceInstance_fragment$data;
+  serviceInstance: serviceInstance_fragment$data;
 }
 
 // Component
 const PageLoader: React.FunctionComponent<PreloaderProps> = ({
   documentId,
-  service,
+  serviceInstance,
 }) => {
   const [queryRef, loadQuery] = useQueryLoader<csvFeedQuery>(CsvFeedQuery);
   useMountingLoader(loadQuery, {
     documentId,
-    serviceInstanceId: service?.id,
+    serviceInstanceId: serviceInstance?.id,
   });
 
-  return queryRef && service ? (
+  return queryRef && serviceInstance ? (
     <CsvFeedSlug
-      serviceInstance={service}
+      serviceInstance={serviceInstance}
       queryRef={queryRef}
     />
   ) : (

--- a/apps/portal-front/app/(application)/app/(user)/service/csv_feeds/[serviceInstanceId]/[documentId]/page.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/csv_feeds/[serviceInstanceId]/[documentId]/page.tsx
@@ -1,14 +1,8 @@
-import {
-  serverFetchGraphQL,
-  serverMutateGraphQL,
-} from '@/relay/serverPortalApiFetch';
+import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
 import ServiceByIdQuery, {
   serviceByIdQuery,
 } from '@generated/serviceByIdQuery.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
-import ServiceSelfJoinMutation, {
-  serviceSelfJoinMutation,
-} from '@generated/serviceSelfJoinMutation.graphql';
 import PageLoader from './page-loader';
 
 interface ServiceCustomDashboardsPageProps {
@@ -19,42 +13,22 @@ const Page = async ({ params }: ServiceCustomDashboardsPageProps) => {
   const { serviceInstanceId, documentId } = await params;
   const decodedServiceInstanceId = decodeURIComponent(serviceInstanceId);
   const decodedDocumentId = decodeURIComponent(documentId);
-
-  let serviceInstance: serviceInstance_fragment$data | null | undefined = null;
-  try {
-    const response = await serverFetchGraphQL<serviceByIdQuery>(
-      ServiceByIdQuery,
-      {
-        service_instance_id: decodedServiceInstanceId,
-      }
-    );
-
-    serviceInstance = response.data
-      .serviceInstanceById as unknown as serviceInstance_fragment$data; // will be reworked in #579
-  } catch (error) {
-    // The user must self join the service before accessing it
-    if (
-      (error as Error).message ===
-      'ERROR_SERVICE_INSTANCE_USER_MUST_JOIN_SERVICE'
-    ) {
-      const response = await serverMutateGraphQL<serviceSelfJoinMutation>(
-        ServiceSelfJoinMutation,
-        {
-          service_instance_id: decodedServiceInstanceId,
-        }
-      );
-
-      serviceInstance = response.data
-        .selfJoinServiceInstance as unknown as serviceInstance_fragment$data; // will be reworked in #579
+  const response = await serverFetchGraphQL<serviceByIdQuery>(
+    ServiceByIdQuery,
+    {
+      service_instance_id: decodedServiceInstanceId,
     }
-  }
+  );
 
   return (
     <>
-      {decodedDocumentId && serviceInstance ? (
+      {decodedDocumentId && response ? (
         <PageLoader
           documentId={decodedDocumentId}
-          service={serviceInstance}
+          serviceInstance={
+            response.data
+              .serviceInstanceById as unknown as serviceInstance_fragment$data
+          }
         />
       ) : (
         <h1>Document not found</h1>

--- a/apps/portal-front/app/(application)/app/(user)/service/custom_dashboards/[serviceInstanceId]/[documentId]/page-loader.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/custom_dashboards/[serviceInstanceId]/[documentId]/page-loader.tsx
@@ -11,24 +11,24 @@ import { useQueryLoader } from 'react-relay';
 // Component interface
 interface PreloaderProps {
   documentId: string;
-  service: serviceInstance_fragment$data;
+  serviceInstance: serviceInstance_fragment$data;
 }
 
 // Component
 const PageLoader: React.FunctionComponent<PreloaderProps> = ({
   documentId,
-  service,
+  serviceInstance,
 }) => {
   const [queryRef, loadQuery] =
     useQueryLoader<customDashboardQuery>(CustomDashboardQuery);
   useMountingLoader(loadQuery, {
     documentId,
-    serviceInstanceId: service?.id,
+    serviceInstanceId: serviceInstance?.id,
   });
 
-  return queryRef && service ? (
+  return queryRef && serviceInstance ? (
     <DashboardDetails
-      serviceInstance={service}
+      serviceInstance={serviceInstance}
       queryRef={queryRef}
     />
   ) : (

--- a/apps/portal-front/app/(application)/app/(user)/service/custom_dashboards/[serviceInstanceId]/[documentId]/page.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/custom_dashboards/[serviceInstanceId]/[documentId]/page.tsx
@@ -1,14 +1,8 @@
-import {
-  serverFetchGraphQL,
-  serverMutateGraphQL,
-} from '@/relay/serverPortalApiFetch';
+import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
 import ServiceByIdQuery, {
   serviceByIdQuery,
 } from '@generated/serviceByIdQuery.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
-import ServiceSelfJoinMutation, {
-  serviceSelfJoinMutation,
-} from '@generated/serviceSelfJoinMutation.graphql';
 import PageLoader from './page-loader';
 
 interface ServiceCustomDashboardsPageProps {
@@ -20,41 +14,21 @@ const Page = async ({ params }: ServiceCustomDashboardsPageProps) => {
   const decodedServiceInstanceId = decodeURIComponent(serviceInstanceId);
   const decodedDocumentId = decodeURIComponent(documentId);
 
-  let serviceInstance: serviceInstance_fragment$data | null | undefined = null;
-  try {
-    const response = await serverFetchGraphQL<serviceByIdQuery>(
-      ServiceByIdQuery,
-      {
-        service_instance_id: decodedServiceInstanceId,
-      }
-    );
-
-    serviceInstance = response.data
-      .serviceInstanceById as unknown as serviceInstance_fragment$data;
-  } catch (error) {
-    // The user must self join the service before accessing it
-    if (
-      (error as Error).message ===
-      'ERROR_SERVICE_INSTANCE_USER_MUST_JOIN_SERVICE'
-    ) {
-      const response = await serverMutateGraphQL<serviceSelfJoinMutation>(
-        ServiceSelfJoinMutation,
-        {
-          service_instance_id: decodedServiceInstanceId,
-        }
-      );
-
-      serviceInstance = response.data
-        .selfJoinServiceInstance as unknown as serviceInstance_fragment$data;
+  const response = await serverFetchGraphQL<serviceByIdQuery>(
+    ServiceByIdQuery,
+    {
+      service_instance_id: decodedServiceInstanceId,
     }
-  }
-
+  );
   return (
     <>
-      {decodedDocumentId && serviceInstance ? (
+      {decodedDocumentId && response ? (
         <PageLoader
           documentId={decodedDocumentId}
-          service={serviceInstance}
+          serviceInstance={
+            response.data
+              .serviceInstanceById as unknown as serviceInstance_fragment$data
+          }
         />
       ) : (
         <h1>Document not found</h1>

--- a/apps/portal-front/app/(application)/app/(user)/service/obas_scenarios/[serviceInstanceId]/[documentId]/page-loader.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/obas_scenarios/[serviceInstanceId]/[documentId]/page-loader.tsx
@@ -11,24 +11,24 @@ import { useQueryLoader } from 'react-relay';
 // Component interface
 interface PreloaderProps {
   documentId: string;
-  service: serviceInstance_fragment$data;
+  serviceInstance: serviceInstance_fragment$data;
 }
 
 // Component
 const PageLoader: React.FunctionComponent<PreloaderProps> = ({
   documentId,
-  service,
+  serviceInstance,
 }) => {
   const [queryRef, loadQuery] =
     useQueryLoader<obasScenarioQuery>(ObasScenarioQuery);
   useMountingLoader(loadQuery, {
     documentId,
-    serviceInstanceId: service?.id,
+    serviceInstanceId: serviceInstance?.id,
   });
 
-  return queryRef && service ? (
+  return queryRef && serviceInstance ? (
     <ObasScenarioSlug
-      serviceInstance={service}
+      serviceInstance={serviceInstance}
       queryRef={queryRef}
     />
   ) : (

--- a/apps/portal-front/app/(application)/app/(user)/service/obas_scenarios/[serviceInstanceId]/[documentId]/page.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/obas_scenarios/[serviceInstanceId]/[documentId]/page.tsx
@@ -1,14 +1,8 @@
-import {
-  serverFetchGraphQL,
-  serverMutateGraphQL,
-} from '@/relay/serverPortalApiFetch';
+import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
 import ServiceByIdQuery, {
   serviceByIdQuery,
 } from '@generated/serviceByIdQuery.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
-import ServiceSelfJoinMutation, {
-  serviceSelfJoinMutation,
-} from '@generated/serviceSelfJoinMutation.graphql';
 import PageLoader from './page-loader';
 
 interface ServiceCustomDashboardsPageProps {
@@ -19,42 +13,22 @@ const Page = async ({ params }: ServiceCustomDashboardsPageProps) => {
   const { serviceInstanceId, documentId } = await params;
   const decodedServiceInstanceId = decodeURIComponent(serviceInstanceId);
   const decodedDocumentId = decodeURIComponent(documentId);
-
-  let serviceInstance: serviceInstance_fragment$data | null | undefined = null;
-  try {
-    const response = await serverFetchGraphQL<serviceByIdQuery>(
-      ServiceByIdQuery,
-      {
-        service_instance_id: decodedServiceInstanceId,
-      }
-    );
-
-    serviceInstance = response.data
-      .serviceInstanceById as unknown as serviceInstance_fragment$data;
-  } catch (error) {
-    // The user must self join the service before accessing it
-    if (
-      (error as Error).message ===
-      'ERROR_SERVICE_INSTANCE_USER_MUST_JOIN_SERVICE'
-    ) {
-      const response = await serverMutateGraphQL<serviceSelfJoinMutation>(
-        ServiceSelfJoinMutation,
-        {
-          service_instance_id: decodedServiceInstanceId,
-        }
-      );
-
-      serviceInstance = response.data
-        .selfJoinServiceInstance as unknown as serviceInstance_fragment$data;
+  const response = await serverFetchGraphQL<serviceByIdQuery>(
+    ServiceByIdQuery,
+    {
+      service_instance_id: decodedServiceInstanceId,
     }
-  }
+  );
 
   return (
     <>
-      {decodedDocumentId && serviceInstance ? (
+      {decodedDocumentId && response ? (
         <PageLoader
           documentId={decodedDocumentId}
-          service={serviceInstance}
+          serviceInstance={
+            response.data
+              .serviceInstanceById as unknown as serviceInstance_fragment$data
+          }
         />
       ) : (
         <h1>Document not found</h1>

--- a/apps/portal-front/app/(application)/app/(user)/service/vault/[slug]/page.tsx
+++ b/apps/portal-front/app/(application)/app/(user)/service/vault/[slug]/page.tsx
@@ -1,8 +1,32 @@
-import * as React from 'react';
+import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
+import ServiceByIdQuery, {
+  serviceByIdQuery,
+} from '@generated/serviceByIdQuery.graphql';
+import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import PageLoader from './page-loader';
 
-const Page: React.FunctionComponent = ({}) => {
-  return <PageLoader />;
+interface ServiceVaultPageProps {
+  params: Promise<{ slug: string }>;
+}
+const Page = async ({ params }: ServiceVaultPageProps) => {
+  const { slug } = await params;
+
+  const decodedServiceInstanceId = decodeURIComponent(slug);
+
+  const response = await serverFetchGraphQL<serviceByIdQuery>(
+    ServiceByIdQuery,
+    {
+      service_instance_id: decodedServiceInstanceId,
+    }
+  );
+  return (
+    <PageLoader
+      serviceInstance={
+        response.data
+          .serviceInstanceById as unknown as serviceInstance_fragment$data
+      }
+    />
+  );
 };
 
 export default Page;

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -57,7 +57,6 @@ type Mutation {
   editServiceCapability(input: EditServiceCapabilityInput, serviceInstanceId: String): SubscriptionModel
   addUserService(input: UserServiceAddInput!): [UserService]
   deleteUserService(input: UserServiceDeleteInput!): UserService
-  selfJoinServiceInstance(service_instance_id: ID!): ServiceInstance
   mergeTest(from: ID!, target: ID!): ID!
   addUser(input: AddUserInput!): User
   adminAddUser(input: AdminAddUserInput!): User

--- a/apps/portal-front/src/components/service/service.graphql.ts
+++ b/apps/portal-front/src/components/service/service.graphql.ts
@@ -154,11 +154,3 @@ export const serviceWithSubscriptionsFragment = graphql`
     }
   }
 `;
-
-export const ServiceSelfJoinMutation = graphql`
-  mutation serviceSelfJoinMutation($service_instance_id: ID!) {
-    selfJoinServiceInstance(service_instance_id: $service_instance_id) {
-      ...serviceInstance_fragment
-    }
-  }
-`;

--- a/apps/portal-front/src/components/service/service.graphql.ts
+++ b/apps/portal-front/src/components/service/service.graphql.ts
@@ -37,7 +37,7 @@ export const ServiceById = graphql`
   }
 `;
 export const serviceInstanceFragment = graphql`
-  fragment serviceInstance_fragment on ServiceInstance @inline {
+  fragment serviceInstance_fragment on ServiceInstance {
     id
     name
     description

--- a/apps/portal-front/src/components/service/vault/[slug]/document-list.tsx
+++ b/apps/portal-front/src/components/service/vault/[slug]/document-list.tsx
@@ -8,10 +8,6 @@ import {
   documentItem,
   documentsFragment,
 } from '@/components/service/document/document.graphql';
-import {
-  ServiceById,
-  serviceInstanceFragment,
-} from '@/components/service/service.graphql';
 import DeleteDocument from '@/components/service/vault/delete-document';
 import { documentListLocalStorage } from '@/components/service/vault/document-list-localstorage';
 import DownloadDocument from '@/components/service/vault/download-document';
@@ -41,11 +37,7 @@ import {
   documentsQuery$variables,
 } from '@generated/documentsQuery.graphql';
 import { DocumentOrderingEnum } from '@generated/models/DocumentOrdering.enum';
-import { serviceByIdQuery } from '@generated/serviceByIdQuery.graphql';
-import {
-  serviceInstance_fragment$data,
-  serviceInstance_fragment$key,
-} from '@generated/serviceInstance_fragment.graphql';
+import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
 import {
@@ -71,12 +63,12 @@ import { useDebounceCallback } from 'usehooks-ts';
 
 interface ServiceProps {
   queryRef: PreloadedQuery<documentsQuery>;
-  queryRefService: PreloadedQuery<serviceByIdQuery>;
+  serviceInstance: serviceInstance_fragment$data;
 }
 
 const DocumentList: React.FunctionComponent<ServiceProps> = ({
   queryRef,
-  queryRefService,
+  serviceInstance,
 }) => {
   const queryData = usePreloadedQuery<documentsQuery>(
     DocumentsListQuery,
@@ -88,16 +80,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
     documentsList$key
   >(documentsFragment, queryData);
 
-  const queryDataService = usePreloadedQuery<serviceByIdQuery>(
-    ServiceById,
-    queryRefService
-  );
-
-  const serviceData = readInlineData<serviceInstance_fragment$key>(
-    serviceInstanceFragment,
-    queryDataService.serviceInstanceById
-  );
-  const canManageService = serviceData?.capabilities.includes(
+  const canManageService = serviceInstance?.capabilities.includes(
     GenericCapabilityName.MANAGE_ACCESS
   );
 
@@ -165,7 +148,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
             <GuardCapacityComponent displayError={false}>
               <EditDocument documentData={row.original} />
             </GuardCapacityComponent>
-            {serviceData?.capabilities.some(
+            {serviceInstance?.capabilities.some(
               (capa) => capa?.toUpperCase() === ServiceCapabilityName.Upload
             ) && <EditDocument documentData={row.original} />}
             <DownloadDocument documentData={row.original} />
@@ -176,7 +159,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
                 connectionId={data.documents.__id}
               />
             </GuardCapacityComponent>
-            {serviceData?.capabilities.some(
+            {serviceInstance?.capabilities.some(
               (capa) => capa?.toUpperCase() === ServiceCapabilityName.Delete
             ) && (
               <DeleteDocument
@@ -266,18 +249,18 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
       href: `/${APP_PATH}`,
     },
     {
-      label: serviceData!.name,
+      label: serviceInstance!.name,
       original: true,
     },
   ];
   const userCanUpdate = useServiceCapability(
     ServiceCapabilityName.Upload,
-    serviceData as serviceInstance_fragment$data
+    serviceInstance
   );
   return (
     <>
       <BreadcrumbNav value={breadcrumbs} />
-      <h1 className="pb-s">{serviceData?.name}</h1>
+      <h1 className="pb-s">{serviceInstance?.name}</h1>
 
       <DataTable
         i18nKey={i18nKey(t)}
@@ -294,7 +277,7 @@ const DocumentList: React.FunctionComponent<ServiceProps> = ({
           rowCount: data.documents.totalCount,
         }}
         onClickRow={(row) => {
-          const url = `/document/visualize/${serviceData?.id}/${row.id}`;
+          const url = `/document/visualize/${serviceInstance?.id}/${row.id}`;
           window.open(url, '_blank', 'noopener,noreferrer');
         }}
         toolbar={

--- a/apps/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
+++ b/apps/portal-front/src/components/subcription/[slug]/subscription-slug.tsx
@@ -27,10 +27,6 @@ import { useMutation } from 'react-relay';
 
 import { PortalContext } from '@/components/me/app-portal-context';
 import { UserServiceForm } from '@/components/service/[slug]/userservice-form';
-import {
-  ServiceById,
-  serviceInstanceFragment,
-} from '@/components/service/service.graphql';
 import { EditUserService } from '@/components/subcription/[slug]/edit-user-service';
 import { SubscriptionById } from '@/components/subcription/subscription.graphql';
 import {
@@ -40,8 +36,7 @@ import {
 import { SheetWithPreventingDialog } from '@/components/ui/sheet-with-preventing-dialog';
 import { APP_PATH } from '@/utils/path/constant';
 import { RestrictionEnum } from '@generated/models/Restriction.enum';
-import { serviceByIdQuery } from '@generated/serviceByIdQuery.graphql';
-import { serviceInstance_fragment$key } from '@generated/serviceInstance_fragment.graphql';
+import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { subscriptionByIdQuery } from '@generated/subscriptionByIdQuery.graphql';
 import { userServiceFromSubscriptionQuery } from '@generated/userServiceFromSubscriptionQuery.graphql';
 import { useEffect } from 'react';
@@ -55,14 +50,14 @@ import {
 interface SubscriptionSlugProps {
   queryRef: PreloadedQuery<userServiceFromSubscriptionQuery>;
   queryRefSubscription: PreloadedQuery<subscriptionByIdQuery>;
-  queryRefService?: PreloadedQuery<serviceByIdQuery>;
+  serviceInstance?: serviceInstance_fragment$data;
   subscriptionId: string;
 }
 
 const SubscriptionSlug: FunctionComponent<SubscriptionSlugProps> = ({
   queryRef,
   queryRefSubscription,
-  queryRefService,
+  serviceInstance,
   subscriptionId,
 }) => {
   const t = useTranslations();
@@ -85,28 +80,18 @@ const SubscriptionSlug: FunctionComponent<SubscriptionSlugProps> = ({
     queryRefSubscription
   );
   let breadcrumbValue: BreadcrumbNavLink[] = [];
-  if (queryRefService) {
-    const queryDataService = usePreloadedQuery<serviceByIdQuery>(
-      ServiceById,
-      queryRefService
-    );
-    const serviceData = readInlineData<serviceInstance_fragment$key>(
-      serviceInstanceFragment,
-      queryDataService.serviceInstanceById
-    );
-    if (serviceData) {
-      breadcrumbValue = [
-        { label: 'MenuLinks.Home', href: `/${APP_PATH}` },
-        {
-          label: `${serviceData.name}`,
-          original: true,
-          href: `/${APP_PATH}/service/${serviceData.service_definition!.identifier}/${serviceData.id}`,
-        },
-        {
-          label: t('Service.Management.ManageUsers'),
-        },
-      ];
-    }
+  if (serviceInstance) {
+    breadcrumbValue = [
+      { label: 'MenuLinks.Home', href: `/${APP_PATH}` },
+      {
+        label: `${serviceInstance.name}`,
+        original: true,
+        href: `/${APP_PATH}/service/${serviceInstance.service_definition!.identifier}/${serviceInstance.id}`,
+      },
+      {
+        label: t('Service.Management.ManageUsers'),
+      },
+    ];
   } else {
     breadcrumbValue = [
       { label: 'MenuLinks.Home', href: `/${APP_PATH}` },


### PR DESCRIPTION
# Context: 
> Code refacto on the way to access service 
> Send email on the first access to the OBAS scenario 

# How to test:  
Subscribe to the OBAS Scenario librairy as user1
The subscriber (user1) should receive an email for OBAS Scenario lib. 
Connect as user2, in the same organization as user1. 
You should see the tile "OBAS Scenario lib" without any subscription needed. Click on the tile **for the first time**. user2 should receive an email for OBAS Scenario lib. 

You should see no regression elsewhere, specially on : 
- Custom Dashboard lib 
- CSV lib
- subscription administration as BYPASS 
- "MANAGE ACCESS" button workflow (as user with the capa "MANAGE_ACCESS" on a lib and that is not BYPASS. 

# What tests has been made: 
- [X] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #579 #843 