### PR TITLE
[frontend/backend] - feature(pendingUsers/chunk3) notifications #470

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -282,6 +282,13 @@
     "Profile": "Profile",
     "ToggleUser": "Open menu user"
   },
+  "Notifications": {
+    "Title": "Notifications ({number})",
+    "UserNotification": {
+      "Title": "User Request",
+      "Text": "<nameFormat>{name}</nameFormat> wants to join your organization"
+    }
+  },
   "OrganizationActions": {
     "ErrorNameAlreadyExists": "The organization {name} already exists.",
     "OrganizationCreated": "Organization {name} has been created",

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -646,7 +646,7 @@
     }
   },
   "PendingUserListPage": {
-    "TabTitle": "Users Requests",
+    "TabTitle": "Users Requests ({nbUsers})",
     "WarningUserRejection": {
       "Title": "Are you sure?",
       "Description": "You are about to refuse this person from your organization. There is no way of going back. Are you sure ?",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -282,6 +282,13 @@
     "Profile": "Profile",
     "ToggleUser": "Ouvrir menu utilisateur"
   },
+  "Notifications": {
+    "Title": "Notifications ({number})",
+    "UserNotification": {
+      "Title": "Requête Utilisateur",
+      "Text": "<nameFormat>{name}</nameFormat> veut rejoindre votre organisation"
+    }
+  },
   "OrganizationActions": {
     "ErrorNameAlreadyExists": "L'organisation {name} existe déjà.",
     "OrganizationCreated": "L'organisation {name} a été créée",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -645,7 +645,7 @@
     }
   },
   "PendingUserListPage": {
-    "TabTitle": "Requêtes utilisateurs",
+    "TabTitle": "Requêtes utilisateurs ({nbUsers})",
     "WarningUserRejection": {
       "Title": "Êtes-vous sûr?",
       "Description": "Vous êtes sur le point de refuser cette personne de votre organisation. Il n'y a pas de retour possible. Êtes-vous sûr?",

--- a/apps/portal-front/package.json
+++ b/apps/portal-front/package.json
@@ -26,7 +26,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "extract-files": "13.0.0",
-    "filigran-icon": "0.18.0",
+    "filigran-icon": "0.18.1",
     "filigran-ui": "0.38.3",
     "graphql": "16.11.0",
     "graphql-sse": "2.5.4",

--- a/apps/portal-front/src/components/admin/user/user-list-page.tsx
+++ b/apps/portal-front/src/components/admin/user/user-list-page.tsx
@@ -7,6 +7,7 @@ import { useIsFeatureEnabled } from '@/hooks/useIsFeatureEnabled';
 import { FeatureFlag } from '@/utils/constant';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
 import { createContext, FunctionComponent, useContext, useState } from 'react';
 
 interface UserListPageProps {
@@ -41,6 +42,11 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
 
   const [connectionID, setConnectionId] = useState<string>('');
 
+  const searchParams = useSearchParams();
+  const selectedTab = searchParams.has('pendingUsers')
+    ? 'pendingUsers'
+    : 'users';
+
   return (
     <UserListContext.Provider value={{ connectionID, setConnectionId }}>
       <div className="flex justify-between">
@@ -55,7 +61,7 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
         </div>
       ) : (
         <Tabs
-          defaultValue="users"
+          defaultValue={selectedTab}
           className="">
           <TabsList>
             <TabsTrigger value="users">

--- a/apps/portal-front/src/components/admin/user/user-list-page.tsx
+++ b/apps/portal-front/src/components/admin/user/user-list-page.tsx
@@ -9,8 +9,6 @@ import {
 import { PortalContext } from '@/components/me/app-portal-context';
 import { notificationPendingUserQueryFilters } from '@/components/notification/notification-button';
 import useAdminPath from '@/hooks/useAdminPath';
-import { useIsFeatureEnabled } from '@/hooks/useIsFeatureEnabled';
-import { FeatureFlag } from '@/utils/constant';
 import { userPendingList_users$key } from '@generated/userPendingList_users.graphql';
 import { userPendingListQuery } from '@generated/userPendingListQuery.graphql';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from 'filigran-ui';
@@ -48,8 +46,6 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
   const isAdminPath = useAdminPath();
   const { me } = useContext(PortalContext);
 
-  const isPendingUsersEnabled = useIsFeatureEnabled(FeatureFlag.PENDING_USERS);
-
   const [connectionID, setConnectionId] = useState<string>('');
 
   const searchParams = useSearchParams();
@@ -77,7 +73,7 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
           {isAdminPath ? <AdminAddUser /> : <AddUser />}
         </div>
       </div>
-      {isAdminPath || !isPendingUsersEnabled ? (
+      {isAdminPath ? (
         <div className="mt-4">
           <UserList organization={organization} />
         </div>

--- a/apps/portal-front/src/components/admin/user/user-list-page.tsx
+++ b/apps/portal-front/src/components/admin/user/user-list-page.tsx
@@ -2,13 +2,22 @@ import { AddUser } from '@/components/admin/user/add-user';
 import { AdminAddUser } from '@/components/admin/user/admin-add-user';
 import PendingUserList from '@/components/admin/user/pending-user-list';
 import UserList from '@/components/admin/user/user-list';
+import {
+  UserPendingListFragment,
+  UserPendingListQuery,
+} from '@/components/admin/user/user.graphql';
+import { PortalContext } from '@/components/me/app-portal-context';
+import { notificationPendingUserQueryFilters } from '@/components/notification/notification-button';
 import useAdminPath from '@/hooks/useAdminPath';
 import { useIsFeatureEnabled } from '@/hooks/useIsFeatureEnabled';
 import { FeatureFlag } from '@/utils/constant';
+import { userPendingList_users$key } from '@generated/userPendingList_users.graphql';
+import { userPendingListQuery } from '@generated/userPendingListQuery.graphql';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { createContext, FunctionComponent, useContext, useState } from 'react';
+import { useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 
 interface UserListPageProps {
   organization?: string;
@@ -37,6 +46,7 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
 }) => {
   const t = useTranslations();
   const isAdminPath = useAdminPath();
+  const { me } = useContext(PortalContext);
 
   const isPendingUsersEnabled = useIsFeatureEnabled(FeatureFlag.PENDING_USERS);
 
@@ -46,6 +56,18 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
   const selectedTab = searchParams.has('pendingUsers')
     ? 'pendingUsers'
     : 'users';
+
+  const queryData = useLazyLoadQuery<userPendingListQuery>(
+    UserPendingListQuery,
+    notificationPendingUserQueryFilters(me!.selected_organization_id)
+  );
+
+  const [data] = useRefetchableFragment<
+    userPendingListQuery,
+    userPendingList_users$key
+  >(UserPendingListFragment, queryData);
+
+  const nbPendingUsers = data.pendingUsers.totalCount;
 
   return (
     <UserListContext.Provider value={{ connectionID, setConnectionId }}>
@@ -67,8 +89,10 @@ const UserListPage: FunctionComponent<UserListPageProps> = ({
             <TabsTrigger value="users">
               {t('UserListPage.TabTitle')}
             </TabsTrigger>
-            <TabsTrigger value="pendingUsers">
-              {t('PendingUserListPage.TabTitle')}
+            <TabsTrigger
+              value="pendingUsers"
+              disabled={!nbPendingUsers}>
+              {t('PendingUserListPage.TabTitle', { nbUsers: nbPendingUsers })}
             </TabsTrigger>
           </TabsList>
           <TabsContent value="users">

--- a/apps/portal-front/src/components/admin/user/user.graphql.ts
+++ b/apps/portal-front/src/components/admin/user/user.graphql.ts
@@ -88,3 +88,48 @@ export const ListOrganizationAdministratorsQuery = graphql`
     }
   }
 `;
+
+export const UserPendingListQuery = graphql`
+  query userPendingListQuery(
+    $count: Int!
+    $cursor: ID
+    $orderBy: UserOrdering!
+    $orderMode: OrderingMode!
+    $filters: [Filter!]
+    $searchTerm: String
+  ) {
+    ...userPendingList_users
+  }
+`;
+
+export const UserPendingListFragment = graphql`
+  fragment userPendingList_users on Query
+  @refetchable(queryName: "PendingUsersPaginationQuery") {
+    pendingUsers(
+      first: $count
+      after: $cursor
+      orderBy: $orderBy
+      orderMode: $orderMode
+      searchTerm: $searchTerm
+      filters: $filters
+    ) {
+      __id
+      totalCount
+      edges {
+        node {
+          ...userList_fragment
+        }
+      }
+    }
+  }
+`;
+
+export const UserPendingListSubscription = graphql`
+  subscription userPendingListSubscription($connections: [ID!]!) {
+    UserPending {
+      delete {
+        id @deleteEdge(connections: $connections)
+      }
+    }
+  }
+`;

--- a/apps/portal-front/src/components/header.tsx
+++ b/apps/portal-front/src/components/header.tsx
@@ -9,8 +9,10 @@ import { DisplayLogo } from '@/components/ui/display-logo';
 import { IconActions } from '@/components/ui/icon-actions';
 import { cn, isDevelopment } from '@/lib/utils';
 
+import { NotificationButton } from '@/components/notification/notification-button';
 import { ProfileMenuButton } from '@/components/profile/menu/button';
 import { formatPersonNames } from '@/utils/format/name';
+import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { Avatar, Skeleton } from 'filigran-ui';
 import {
   Sheet,
@@ -34,11 +36,18 @@ interface HeaderComponentProps {
 const HeaderComponent: React.FunctionComponent<HeaderComponentProps> = ({
   displayLogo,
 }) => {
-  const { me } = useContext(PortalContext);
+  const { me, hasOrganizationCapability } = useContext(PortalContext);
   const [open, setOpen] = useState(false);
   const currentPath = usePathname();
   const t = useTranslations();
   useEffect(() => setOpen(false), [currentPath]);
+
+  const canManageUser =
+    hasOrganizationCapability &&
+    (hasOrganizationCapability(
+      OrganizationCapabilityEnum.ADMINISTRATE_ORGANIZATION
+    ) ||
+      hasOrganizationCapability(OrganizationCapabilityEnum.MANAGE_ACCESS));
 
   const User = () =>
     me ? (
@@ -61,9 +70,9 @@ const HeaderComponent: React.FunctionComponent<HeaderComponentProps> = ({
       />
 
       <div className="mobile:hidden flex items-center gap-s">
+        {canManageUser && <NotificationButton />}
         <IconActions
           className="rounded-full"
-          label={<User />}
           icon={
             <>
               <div className="my-auto size-10">

--- a/apps/portal-front/src/components/notification/notification-button.tsx
+++ b/apps/portal-front/src/components/notification/notification-button.tsx
@@ -37,23 +37,25 @@ import {
   useSubscription,
 } from 'react-relay';
 
+export function notificationPendingUserQueryFilters(
+  organization_id: string
+): userPendingListQuery$variables {
+  return {
+    count: 20,
+    orderMode: 'asc',
+    orderBy: 'last_login',
+    filters: [{ key: 'organization_id', value: [organization_id] }],
+  };
+}
+
 export const NotificationButton: React.FC = () => {
   const t = useTranslations();
   const { me } = useContext(PortalContext);
   const [openPopover, setOpenPopover] = useState(false);
 
-  const notificationFilters: userPendingListQuery$variables = {
-    count: 20,
-    orderMode: 'asc',
-    orderBy: 'last_login',
-    filters: [
-      { key: 'organization_id', value: [me!.selected_organization_id] },
-    ],
-  };
-
   const queryData = useLazyLoadQuery<userPendingListQuery>(
     UserPendingListQuery,
-    notificationFilters
+    notificationPendingUserQueryFilters(me!.selected_organization_id)
   );
 
   const [data] = useRefetchableFragment<
@@ -89,7 +91,6 @@ export const NotificationButton: React.FC = () => {
   );
 
   const nbUsers = data.pendingUsers.totalCount;
-
   return (
     <Popover
       open={openPopover}

--- a/apps/portal-front/src/components/notification/notification-button.tsx
+++ b/apps/portal-front/src/components/notification/notification-button.tsx
@@ -1,0 +1,76 @@
+import { NotificationsIcon } from 'filigran-icon';
+
+import { APP_PATH } from '@/utils/path/constant';
+import { userList_fragment$data } from '@generated/userList_fragment.graphql';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Separator,
+} from 'filigran-ui/clients';
+import { Button } from 'filigran-ui/servers';
+import { UsersIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export const NotificationButton: React.FC = () => {
+  const t = useTranslations();
+  const [openPopover, setOpenPopover] = useState(false);
+
+  const users: userList_fragment$data[] = [];
+
+  const nbUsers = 0;
+
+  return (
+    <Popover
+      open={openPopover}
+      onOpenChange={setOpenPopover}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          className="w-9 px-0 relative">
+          <NotificationsIcon className="h-4 w-4" />
+          {nbUsers > 0 && (
+            <span className="absolute top-2 right-2.5 block h-[6px] w-[6px] transform translate-x-1/2 -translate-y-1/2 bg-red-500 rounded-full"></span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-120 px-0 pt-4 pb-0">
+        <span className="px-4">
+          {t('Notifications.Title', {
+            number: nbUsers,
+          })}
+        </span>
+        <div className="max-h-[300px] overflow-auto mt-4">
+          {users.map((user) => (
+            <div key={user.id}>
+              <Separator className="" />
+              <Link
+                href={`/${APP_PATH}/manage/user?pendingUsers`}
+                onClick={() => setOpenPopover(false)}
+                className="flex items-center my-2 px-4">
+                <UsersIcon className="mr-4 h-4 w-4 text-gray-300" />
+                <div className="">
+                  <span className="block text-sm">
+                    {t('Notifications.UserNotification.Title')}
+                  </span>
+                  <span className="block text-xs">
+                    {t.rich('Notifications.UserNotification.Text', {
+                      nameFormat: (chunk) => (
+                        <span className="text-blue">{chunk}</span>
+                      ),
+                      name: `${user.first_name} ${user.last_name}`,
+                    })}
+                  </span>
+                </div>
+              </Link>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/portal-front/src/utils/constant.ts
+++ b/apps/portal-front/src/utils/constant.ts
@@ -4,5 +4,4 @@ export const ANIMATION_TIME = 300;
 export enum FeatureFlag {
   // dummy feature flag used for testing purposes
   DUMMY = 'DUMMY',
-  PENDING_USERS = 'PENDING_USERS',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9991,7 +9991,7 @@ __metadata:
     eslint-config-next: 15.3.2
     eslint-config-prettier: 10.1.5
     extract-files: 13.0.0
-    filigran-icon: 0.18.0
+    filigran-icon: 0.18.1
     filigran-ui: 0.38.3
     graphql: 16.11.0
     graphql-sse: 2.5.4
@@ -14512,10 +14512,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filigran-icon@npm:0.18.0":
-  version: 0.18.0
-  resolution: "filigran-icon@npm:0.18.0"
-  checksum: 01b9b4a0920245bc4810e2bdd97a9c557288ed422bd96b1a475c713dd87ff78a6017c3a5bbd3a73a3fa61b75fa9a44b8ff5cd80135364d80403157b7459f4f88
+"filigran-icon@npm:0.18.1":
+  version: 0.18.1
+  resolution: "filigran-icon@npm:0.18.1"
+  checksum: a2c432c8fec499cbf6dc3c432eb8edf61d37dd624079802e2fb2bb47261ffa4d4542c0ae46dd8e2b7a675f5251b4ee3e79f6d5c181c6fc46b829e98b732f8058
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.
We need to display notifications for pending users. 
- Add a new notification panel on the left of the user image and remove the displayed name
- open the pending user tab when the users clicks on notification
- disable the pending users tab when there is no pending user (and display number of pending users)

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 
- test the notification panel displays the pending users
- test the number of users is synchronized between the pending users screen, the tab header and the notification
- test the notification is removed when a user is accepted or rejected
- test the pending user tab is disabled when there is no pending users

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #470 