### PR TITLE
[backend/frontend] fix(UserServiceAddInput) - change input to create userService #879

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1473,7 +1473,8 @@ export type UserService = Node & {
 export type UserServiceAddInput = {
   capabilities?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   email: Array<Scalars['String']['input']>;
-  subscriptionId: Scalars['ID']['input'];
+  serviceInstanceId?: InputMaybe<Scalars['ID']['input']>;
+  subscriptionId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type UserServiceCapability = Node & {

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -360,6 +360,7 @@ export type Mutation = {
   addSubscriptionInService?: Maybe<ServiceInstance>;
   addUser?: Maybe<User>;
   addUserService?: Maybe<Array<Maybe<UserService>>>;
+  addYourselfInUserService?: Maybe<Array<Maybe<UserService>>>;
   adminAddUser?: Maybe<User>;
   adminEditUser: User;
   changeSelectedOrganization?: Maybe<User>;
@@ -455,6 +456,11 @@ export type MutationAddUserArgs = {
 
 export type MutationAddUserServiceArgs = {
   input: UserServiceAddInput;
+};
+
+
+export type MutationAddYourselfInUserServiceArgs = {
+  input: UserServiceAddYourselfInput;
 };
 
 
@@ -1473,8 +1479,12 @@ export type UserService = Node & {
 export type UserServiceAddInput = {
   capabilities?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   email: Array<Scalars['String']['input']>;
-  serviceInstanceId?: InputMaybe<Scalars['ID']['input']>;
   subscriptionId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type UserServiceAddYourselfInput = {
+  email: Array<Scalars['String']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type UserServiceCapability = Node & {
@@ -1715,6 +1725,7 @@ export type ResolversTypes = ResolversObject<{
   UserPendingSubscription: ResolverTypeWrapper<UserPendingSubscription>;
   UserService: ResolverTypeWrapper<UserService>;
   UserServiceAddInput: UserServiceAddInput;
+  UserServiceAddYourselfInput: UserServiceAddYourselfInput;
   UserServiceCapability: ResolverTypeWrapper<UserServiceCapability>;
   UserServiceConnection: ResolverTypeWrapper<UserServiceConnection>;
   UserServiceDeleteInput: UserServiceDeleteInput;
@@ -1820,6 +1831,7 @@ export type ResolversParentTypes = ResolversObject<{
   UserPendingSubscription: UserPendingSubscription;
   UserService: UserService;
   UserServiceAddInput: UserServiceAddInput;
+  UserServiceAddYourselfInput: UserServiceAddYourselfInput;
   UserServiceCapability: UserServiceCapability;
   UserServiceConnection: UserServiceConnection;
   UserServiceDeleteInput: UserServiceDeleteInput;
@@ -2058,6 +2070,7 @@ export type MutationResolvers<ContextType = PortalContext, ParentType extends Re
   addSubscriptionInService?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType, Partial<MutationAddSubscriptionInServiceArgs>>;
   addUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAddUserArgs, 'input'>>;
   addUserService?: Resolver<Maybe<Array<Maybe<ResolversTypes['UserService']>>>, ParentType, ContextType, RequireFields<MutationAddUserServiceArgs, 'input'>>;
+  addYourselfInUserService?: Resolver<Maybe<Array<Maybe<ResolversTypes['UserService']>>>, ParentType, ContextType, RequireFields<MutationAddYourselfInUserServiceArgs, 'input'>>;
   adminAddUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAdminAddUserArgs, 'input'>>;
   adminEditUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationAdminEditUserArgs, 'id' | 'input'>>;
   changeSelectedOrganization?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationChangeSelectedOrganizationArgs, 'organization_id'>>;

--- a/apps/portal-api/src/modules/user_service/user_service.app.ts
+++ b/apps/portal-api/src/modules/user_service/user_service.app.ts
@@ -1,0 +1,57 @@
+import { Knex } from 'knex';
+import Subscription from '../../model/kanel/public/Subscription';
+import { UserId } from '../../model/kanel/public/User';
+import UserService from '../../model/kanel/public/UserService';
+import { PortalContext } from '../../model/portal-context';
+import {
+  getOrCreateUser,
+  insertUserIntoOrganization,
+} from '../users/users.helper';
+import {
+  createUserServiceAccess,
+  isUserServiceExist,
+} from './user-service.helper';
+
+export const userServiceApp = {
+  addUserService: async (
+    context: PortalContext,
+    trx: Knex.Transaction,
+    subscription: Subscription,
+    emails: string[],
+    capabilities: string[]
+  ): Promise<UserService[]> => {
+    try {
+      const userServices: UserService[] = [];
+      for (const email of emails) {
+        const user = await getOrCreateUser({
+          email: email,
+        });
+
+        await insertUserIntoOrganization(context, user, subscription.id);
+        const userServiceAlreadyExist = await isUserServiceExist(
+          user.id as UserId,
+          subscription.id
+        );
+
+        if (!userServiceAlreadyExist) {
+          const createdUserService = await createUserServiceAccess(
+            context,
+            trx,
+            {
+              subscription_id: subscription.id,
+              user_id: user.id as UserId,
+              capabilities: capabilities,
+            }
+          );
+          userServices.push(createdUserService);
+        }
+      }
+
+      await trx.commit();
+
+      return userServices;
+    } catch {
+      await trx.rollback();
+    }
+  },
+};

--- a/apps/portal-api/src/modules/user_service/user_service.graphql
+++ b/apps/portal-api/src/modules/user_service/user_service.graphql
@@ -13,7 +13,8 @@ enum UserServiceOrdering {
 input UserServiceAddInput {
   email: [String!]!
   capabilities: [String]
-  subscriptionId: ID!
+  subscriptionId: ID
+  serviceInstanceId: ID
 }
 
 input UserServiceDeleteInput {

--- a/apps/portal-api/src/modules/user_service/user_service.graphql
+++ b/apps/portal-api/src/modules/user_service/user_service.graphql
@@ -14,6 +14,10 @@ input UserServiceAddInput {
   email: [String!]!
   capabilities: [String]
   subscriptionId: ID
+}
+
+input UserServiceAddYourselfInput {
+  email: [String!]!
   serviceInstanceId: ID
 }
 
@@ -25,6 +29,7 @@ input UserServiceDeleteInput {
 
 type Mutation {
   addUserService(input: UserServiceAddInput!): [UserService] @auth
+  addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService] @auth
   deleteUserService(input: UserServiceDeleteInput!): UserService @auth
 }
 type Query {

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -740,7 +740,8 @@ enum UserServiceOrdering {
 input UserServiceAddInput {
   email: [String!]!
   capabilities: [String]
-  subscriptionId: ID!
+  subscriptionId: ID
+  serviceInstanceId: ID
 }
 
 input UserServiceDeleteInput {

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -56,6 +56,7 @@ type Mutation {
   deleteSubscription(subscription_id: ID!): ServiceInstance
   editServiceCapability(input: EditServiceCapabilityInput, serviceInstanceId: String): SubscriptionModel
   addUserService(input: UserServiceAddInput!): [UserService]
+  addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService]
   deleteUserService(input: UserServiceDeleteInput!): UserService
   mergeTest(from: ID!, target: ID!): ID!
   addUser(input: AddUserInput!): User
@@ -741,6 +742,10 @@ input UserServiceAddInput {
   email: [String!]!
   capabilities: [String]
   subscriptionId: ID
+}
+
+input UserServiceAddYourselfInput {
+  email: [String!]!
   serviceInstanceId: ID
 }
 

--- a/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
+++ b/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
@@ -1,6 +1,6 @@
 import GuardCapacityComponent from '@/components/admin-guard';
 import { PortalContext } from '@/components/me/app-portal-context';
-import { UserServiceCreateMutation } from '@/components/service/user_service.graphql';
+import { UserServiceAddYourselfMutation } from '@/components/service/user_service.graphql';
 import { AlertDialogComponent } from '@/components/ui/alert-dialog';
 import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { ServiceInstanceJoinTypeEnum } from '@generated/models/ServiceInstanceJoinType.enum';
@@ -16,7 +16,7 @@ export default function useGetAction(
   const t = useTranslations();
   const { me } = useContext(PortalContext);
 
-  const [userServiceJoin] = useMutation(UserServiceCreateMutation);
+  const [userServiceJoin] = useMutation(UserServiceAddYourselfMutation);
 
   const getAction = (service: serviceList_fragment$data) => {
     if (

--- a/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
+++ b/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
@@ -35,7 +35,6 @@ export default function useGetAction(
                 input: {
                   email: me?.email,
                   serviceInstanceId: service.id,
-                  organizationId: me?.selected_organization_id,
                 },
               },
             });

--- a/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
+++ b/apps/portal-front/src/components/service/home/hooks/useGetAction.tsx
@@ -7,6 +7,7 @@ import { ServiceInstanceJoinTypeEnum } from '@generated/models/ServiceInstanceJo
 import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
 import { Button } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { useContext } from 'react';
 import { useMutation } from 'react-relay';
 
@@ -15,6 +16,7 @@ export default function useGetAction(
 ) {
   const t = useTranslations();
   const { me } = useContext(PortalContext);
+  const router = useRouter();
 
   const [userServiceJoin] = useMutation(UserServiceAddYourselfMutation);
 
@@ -36,6 +38,11 @@ export default function useGetAction(
                   email: me?.email,
                   serviceInstanceId: service.id,
                 },
+              },
+              onCompleted: () => {
+                router.push(
+                  `/app/service/${service.service_definition?.identifier}/${service.id}`
+                );
               },
             });
           }}>

--- a/apps/portal-front/src/components/service/user_service.graphql.ts
+++ b/apps/portal-front/src/components/service/user_service.graphql.ts
@@ -180,6 +180,38 @@ export const UserServiceCreateMutation = graphql`
     }
   }
 `;
+export const UserServiceAddYourselfMutation = graphql`
+  mutation userServiceAddYourselfMutation(
+    $input: UserServiceAddYourselfInput!
+    $connections: [ID!]!
+  ) {
+    addYourselfInUserService(input: $input)
+      @prependNode(connections: $connections, edgeTypeName: "UserServiceEdge") {
+      id
+      user {
+        id
+        first_name
+        last_name
+        email
+      }
+      user_service_capability {
+        id
+        generic_service_capability {
+          id
+          name
+        }
+        subscription_capability {
+          id
+          service_capability {
+            id
+            description
+            name
+          }
+        }
+      }
+    }
+  }
+`;
 
 export const UserServiceDeleteMutation = graphql`
   mutation userServiceDeleteMutation(

--- a/apps/portal-front/src/components/service/user_service.graphql.ts
+++ b/apps/portal-front/src/components/service/user_service.graphql.ts
@@ -183,10 +183,8 @@ export const UserServiceCreateMutation = graphql`
 export const UserServiceAddYourselfMutation = graphql`
   mutation userServiceAddYourselfMutation(
     $input: UserServiceAddYourselfInput!
-    $connections: [ID!]!
   ) {
-    addYourselfInUserService(input: $input)
-      @prependNode(connections: $connections, edgeTypeName: "UserServiceEdge") {
+    addYourselfInUserService(input: $input) {
       id
       user {
         id


### PR DESCRIPTION
# Context: 
> use the correct format for route userServiceCreate.

# How to test:  
Check there is no regression on: 

- **Connect** as BYPASS. Create users: 
user1 in organizationA with capability MANAGE_SUBSCRIPTION
userX in organizationA 
user2 in organizationA 
user3 in organizationA 
Go on the "service integreation feeds" service. Create a CSV Feed. 

- **Connect** as user1 of organizationA with the MANAGE_SUBSCRIPTION capability on the organization 
Subscribe to service integreation feeds => You should be redirect, get access to that service and be able to "MANAGE USERS" in this service (!important: this page of management is not available if you don't have any document in the service. Add at least one, done in first step). In that "Manage users" page, add userX of your organization in the service integreation feeds .  
- **Connect** as user2 of organizationA  without any capability. You should see the service integreation feeds in your homepage among "available services" and be able to click on that service integreation feeds . You should receive a welcome email. You should be able to see everything in that service integreation feeds. 
- As user3 of OrganizationA, connect to OpenCTI on Integration Feeds. Click on the button "Import from Hub". You should be redirected to the Hub. You should see the service integreation feeds in highlighted services, with a button "Join". Click on that button. You should receive an email and be redirected to the service integreation feeds , be able to see the CSV Feeds in the service integreation feeds (without any other capability on the service). 


# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

Related #879 