### PR TITLE
[backend] - fix(elasticsearch/kibana): change port to avoid conflicts with opencti and openbas #634

### DIFF
--- a/apps/portal-api/config/default.json
+++ b/apps/portal-api/config/default.json
@@ -85,7 +85,7 @@
   "elasticsearch": {
     "protocol": "http",
     "host": "localhost",
-    "port": 9202,
+    "port": 9204,
     "username": null,
     "password": null
   },

--- a/xtm-hub-dev/docker-compose.yml
+++ b/xtm-hub-dev/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
     ports:
-      - "9202:9200"
-      - "9302:9300"
+      - "9204:9200"
+      - "9304:9300"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       - ELASTICSEARCH_HOSTS=http://portal-elasticsearch:9200
     restart: unless-stopped
     ports:
-      - 5601:5601
+      - 5603:5601
     depends_on:
       - portal-elasticsearch
 


### PR DESCRIPTION
# Context: 
> Elastic search and kibana were added for telemetry. However, the exposed ports collide with opencti and openbas

# How to test:  
- test elastic search/kibana start well
- test the server starts well
- test there is no conflict with opencti and openbas

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #634