### PR TITLE
[frontend]-fix(ObasRebrand): Fix redirect #906

### DIFF
--- a/apps/portal-front/src/utils/shareable-resources/utils/shareable-resources.client.utils.ts
+++ b/apps/portal-front/src/utils/shareable-resources/utils/shareable-resources.client.utils.ts
@@ -22,7 +22,7 @@ export function getServiceInfo(
         '. Discover more dashboards like this in our OpenCTI Custom Dashboards Library, available for download on the XTM Hub.',
     },
     [ServiceSlug.OPEN_BAS_SCENARIOS]: {
-      link: `/redirect/obas_scenarios?service_instance_id=${serviceInstance.id}&document_id=${documentId}`,
+      link: `/redirect/openaev_scenarios?service_instance_id=${serviceInstance.id}&document_id=${documentId}`,
       description:
         '. Discover more widgets like this in our OpenBAS Scenarios Library, available for download on the XTM Hub.',
     },


### PR DESCRIPTION
# Context: 

The download on public page is KO for OBAS scenario

# How to test:  
Go on public page > Obas scenario
CLick on download : you should be redirected to the login page and not see an error 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #906 