### PR TITLE
[frontend/backend] - (ServiceList): Add filters and information on services as Admin #912

### DIFF
--- a/apps/portal-api/knexfile.ts
+++ b/apps/portal-api/knexfile.ts
@@ -228,6 +228,17 @@ export const paginate = async <T, U>(
               value.map((id) => extractId(id))
             );
         }
+      } else if (key === FilterKey.ServiceDefinitionIdentifier) {
+        if (value.length > 0) {
+          queryContext
+            .leftJoin(
+              'ServiceDefinition',
+              'ServiceDefinition.id',
+              '=',
+              `${type}.service_definition_id`
+            )
+            .whereIn('ServiceDefinition.identifier', value);
+        }
       } else if (key.includes('id')) {
         queryContext.whereIn(
           key,
@@ -269,6 +280,7 @@ export const paginate = async <T, U>(
     .orderBy([{ column: orderBy, order: orderMode }])
     .offset(currentOffset)
     .limit(first)
+    .select(`${type}.*`)
     .secureQuery({ ...opts });
 
   const [query, { totalCount }] = await Promise.all([

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -277,7 +277,8 @@ export type Filter = {
 export enum FilterKey {
   Label = 'label',
   OrganizationId = 'organization_id',
-  PersonalSpace = 'personal_space'
+  PersonalSpace = 'personal_space',
+  ServiceDefinitionIdentifier = 'serviceDefinition_identifier'
 }
 
 export type GenericServiceCapability = Node & {
@@ -1078,9 +1079,11 @@ export type QueryServiceInstanceByIdWithSubscriptionsArgs = {
 
 export type QueryServiceInstancesArgs = {
   after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<Array<Filter>>;
   first: Scalars['Int']['input'];
   orderBy: ServiceInstanceOrdering;
   orderMode: OrderingMode;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1253,7 +1256,7 @@ export enum ServiceInstanceCreationStatus {
 export type ServiceInstanceEdge = {
   __typename?: 'ServiceInstanceEdge';
   cursor: Scalars['String']['output'];
-  node: ServiceInstance;
+  node?: Maybe<ServiceInstance>;
 };
 
 export enum ServiceInstanceJoinType {
@@ -2340,7 +2343,7 @@ export type ServiceInstanceResolvers<ContextType = PortalContext, ParentType ext
 
 export type ServiceInstanceEdgeResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['ServiceInstanceEdge'] = ResolversParentTypes['ServiceInstanceEdge']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['ServiceInstance'], ParentType, ContextType>;
+  node?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/apps/portal-api/src/modules/common/common.graphql
+++ b/apps/portal-api/src/modules/common/common.graphql
@@ -6,6 +6,7 @@ enum FilterKey {
   label
   organization_id
   personal_space
+  serviceDefinition_identifier
 }
 
 input Filter {

--- a/apps/portal-api/src/modules/services/service-instance.domain.ts
+++ b/apps/portal-api/src/modules/services/service-instance.domain.ts
@@ -163,6 +163,24 @@ export const loadServiceInstances = async (context: PortalContext, opts) =>
     opts
   );
 
+export const getServiceInstanceSubscriptions = async (context, id) => {
+  const subscription = await db<Subscription>(context, 'Subscription')
+    .where('Subscription.service_instance_id', '=', id)
+    .leftJoin('Organization', 'Organization.id', 'Subscription.organization_id')
+    .select([
+      'Subscription.*',
+      dbRaw(
+        formatRawObject({
+          columnName: 'Organization',
+          typename: 'Organization',
+          as: 'organization',
+        })
+      ),
+    ]);
+
+  return subscription;
+};
+
 export const getUserJoined = async (context, id) => {
   const result = await db<{ user_joined: boolean }>(context, 'ServiceInstance')
     .where('ServiceInstance.id', '=', id)

--- a/apps/portal-api/src/modules/services/service-instance.domain.ts
+++ b/apps/portal-api/src/modules/services/service-instance.domain.ts
@@ -131,9 +131,9 @@ export const loadPublicServiceInstances = (context: PortalContext, opts) => {
   );
 };
 
-export const getIsSubscribed = async (context, id) => {
+export const loadIsSubscribed = async (context, id) => {
   const organizationId = context.user.selected_organization_id;
-  const { organization_subscribed } = await db<{
+  const serviceInstance = await db<{
     organization_subscribed: boolean;
   }>(context, 'ServiceInstance')
     .where('ServiceInstance.id', '=', id)
@@ -153,17 +153,24 @@ export const getIsSubscribed = async (context, id) => {
         `)
     )
     .first();
-  return organization_subscribed;
+  return serviceInstance?.organization_subscribed ?? false;
 };
 
-export const loadServiceInstances = async (context: PortalContext, opts) =>
-  paginate<ServiceInstance, ServiceConnection>(
+export const loadServiceInstances = async (context: PortalContext, opts) => {
+  const { filters, searchTerm, orderBy } = opts;
+  return paginate<ServiceInstance, ServiceConnection>(
     context,
     'ServiceInstance',
-    opts
+    {
+      ...opts,
+      orderBy: `ServiceInstance.${orderBy}`,
+      filters,
+      searchTerm,
+    }
   );
+};
 
-export const getServiceInstanceSubscriptions = async (context, id) => {
+export const loadServiceInstanceSubscriptions = async (context, id) => {
   const subscription = await db<Subscription>(context, 'Subscription')
     .where('Subscription.service_instance_id', '=', id)
     .leftJoin('Organization', 'Organization.id', 'Subscription.organization_id')

--- a/apps/portal-api/src/modules/services/service-instance.graphql
+++ b/apps/portal-api/src/modules/services/service-instance.graphql
@@ -40,7 +40,7 @@ type ServiceInstance implements Node {
 
 type ServiceInstanceEdge {
   cursor: String!
-  node: ServiceInstance!
+  node: ServiceInstance
 }
 
 type ServiceConnection {
@@ -96,6 +96,8 @@ type Query {
     after: ID
     orderBy: ServiceInstanceOrdering!
     orderMode: OrderingMode!
+    searchTerm: String
+    filters: [Filter!]
   ): ServiceConnection! @auth(requires: [BYPASS])
   serviceInstanceById(service_instance_id: ID): ServiceInstance @auth
   serviceInstanceByIdWithSubscriptions(

--- a/apps/portal-api/src/modules/services/services.resolver.ts
+++ b/apps/portal-api/src/modules/services/services.resolver.ts
@@ -25,15 +25,15 @@ import { loadCapabilities } from '../user_service/user-service-capability/user-s
 import { uploadNewFile } from './document/document.helper';
 import { serviceInstanceApp } from './service-instance.app';
 import {
-  getIsSubscribed,
-  getServiceInstanceSubscriptions,
   getUserJoined,
+  loadIsSubscribed,
   loadLinks,
   loadPublicServiceInstances,
   loadSeoServiceInstanceBySlug,
   loadSeoServiceInstances,
   loadServiceDefinition,
   loadServiceInstances,
+  loadServiceInstanceSubscriptions,
   loadServiceWithSubscriptions,
   loadSubscribedServiceInstancesByIdentifier,
 } from './service-instance.domain';
@@ -54,7 +54,7 @@ const resolvers: Resolvers = {
     service_definition: ({ id }, _, context) =>
       loadServiceDefinition(context, id),
     organization_subscribed: ({ id }, _, context) =>
-      getIsSubscribed(context, id),
+      loadIsSubscribed(context, id),
     capabilities: ({ id }, _, context) =>
       loadCapabilities(
         context,
@@ -64,7 +64,7 @@ const resolvers: Resolvers = {
       ),
     user_joined: ({ id }, _, context) => getUserJoined(context, id),
     subscriptions: ({ id }, _, context) =>
-      getServiceInstanceSubscriptions(context, id),
+      loadServiceInstanceSubscriptions(context, id),
   },
   Query: {
     serviceInstances: async (_, opt, context) => {

--- a/apps/portal-api/src/modules/services/services.resolver.ts
+++ b/apps/portal-api/src/modules/services/services.resolver.ts
@@ -26,6 +26,7 @@ import { uploadNewFile } from './document/document.helper';
 import { serviceInstanceApp } from './service-instance.app';
 import {
   getIsSubscribed,
+  getServiceInstanceSubscriptions,
   getUserJoined,
   loadLinks,
   loadPublicServiceInstances,
@@ -62,6 +63,8 @@ const resolvers: Resolvers = {
         context.user.selected_organization_id
       ),
     user_joined: ({ id }, _, context) => getUserJoined(context, id),
+    subscriptions: ({ id }, _, context) =>
+      getServiceInstanceSubscriptions(context, id),
   },
   Query: {
     serviceInstances: async (_, opt, context) => {

--- a/apps/portal-api/src/modules/user_service/user_service.graphql
+++ b/apps/portal-api/src/modules/user_service/user_service.graphql
@@ -29,7 +29,8 @@ input UserServiceDeleteInput {
 
 type Mutation {
   addUserService(input: UserServiceAddInput!): [UserService] @auth
-  addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService] @auth
+  addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService]
+    @auth
   deleteUserService(input: UserServiceDeleteInput!): UserService @auth
 }
 type Query {

--- a/apps/portal-front/app/(application)/app/(admin)/admin/service/page.tsx
+++ b/apps/portal-front/app/(application)/app/(admin)/admin/service/page.tsx
@@ -27,19 +27,24 @@ const Page = () => {
     count: 50,
     orderBy: 'name',
     orderMode: 'asc',
+    searchTerm: '',
+    filters: [],
   });
-  const [data] = useRefetchableFragment<
+  const [data, refetch] = useRefetchableFragment<
     serviceQuery,
     servicesList_services$key
   >(servicesListFragment, queryData);
   const serviceData = data?.serviceInstances?.edges.map(
-    (service) => service.node as serviceList_fragment$data
+    (service) => service?.node as serviceList_fragment$data
   );
   return (
     <>
       <BreadcrumbNav value={breadcrumbValue} />
       <h1 className="sr-only">{t('MenuLinks.Services')}</h1>
-      <AdminServiceTab serviceData={serviceData} />
+      <AdminServiceTab
+        serviceData={serviceData}
+        refetch={refetch}
+      />
     </>
   );
 };

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -365,6 +365,7 @@
     },
     "ComingSoon": "Coming soon",
     "CreationStatus": "Creation status",
+    "Organizations": "Organizations",
     "CsvFeed": {
       "Actions": {
         "Added": "The CSV {name} has been added successfully",

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -471,6 +471,7 @@
     "Description": "Description",
     "GoTo": "Go to service page",
     "GoToAdminLabel": "Manage",
+    "SearchServices": "Search service...",
     "GoToLabel": "Go to",
     "GoToManagement": "Go to service management",
     "HighlightedServices": "To use this feature, please subscribe to one of the highlighted services first",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -365,6 +365,7 @@
     },
     "ComingSoon": "Bientôt disponible",
     "CreationStatus": "Statut de la création",
+    "Organizations": "Organizations",
     "CsvFeed": {
       "Actions": {
         "Added": "{name} a été ajouté",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -471,6 +471,7 @@
     "Description": "Description",
     "GoTo": "Aller au service",
     "GoToAdminLabel": "Administrer",
+    "SearchServices": "Recherche un service...",
     "GoToLabel": "Consulter",
     "GoToManagement": "Aller à la gestion des services",
     "HighlightedServices": "Pour utiliser cette fonctionnalité, veuillez d'abord souscrire à l'un des services mis en surbrillance",

--- a/apps/portal-front/package.json
+++ b/apps/portal-front/package.json
@@ -27,7 +27,7 @@
     "clsx": "2.1.1",
     "extract-files": "13.0.0",
     "filigran-icon": "0.18.1",
-    "filigran-ui": "0.38.3",
+    "filigran-ui": "0.39.9",
     "graphql": "16.11.0",
     "graphql-sse": "2.5.4",
     "lucide-react": "0.471.1",

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -12,6 +12,7 @@ enum FilterKey {
   label
   organization_id
   personal_space
+  serviceDefinition_identifier
 }
 
 input Filter {
@@ -122,7 +123,7 @@ type Query {
   openCTIPlatformRegistrationStatus(input: OpenCTIPlatformRegistrationStatusInput!): OpenCTIPlatformRegistrationStatusResponse!
   openCTIPlatformAssociatedOrganization(platformId: String!): Organization!
   publicServiceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!): ServiceConnection!
-  serviceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!): ServiceConnection!
+  serviceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!, searchTerm: String, filters: [Filter!]): ServiceConnection!
   serviceInstanceById(service_instance_id: ID): ServiceInstance
   serviceInstanceByIdWithSubscriptions(service_instance_id: ID): ServiceInstance
   subscribedServiceInstancesByIdentifier(identifier: ServiceDefinitionIdentifier!): [SubscribedServiceInstance!]!
@@ -538,7 +539,7 @@ type ServiceInstance implements Node {
 
 type ServiceInstanceEdge {
   cursor: String!
-  node: ServiceInstance!
+  node: ServiceInstance
 }
 
 type ServiceConnection {

--- a/apps/portal-front/src/components/service/admin-service-tab.tsx
+++ b/apps/portal-front/src/components/service/admin-service-tab.tsx
@@ -2,21 +2,36 @@
 
 import { EditService } from '@/components/service/edit-service';
 import { IconActions, IconActionsLink } from '@/components/ui/icon-actions';
+import { SearchInput } from '@/components/ui/search-input';
+import { DEBOUNCE_TIME } from '@/utils/constant';
 import { i18nKey } from '@/utils/datatable';
 import { APP_PATH } from '@/utils/path/constant';
+import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
+import { serviceQuery } from '@generated/serviceQuery.graphql';
+import { servicesList_services$key } from '@generated/servicesList_services.graphql';
 import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
-import { Badge, DataTable } from 'filigran-ui';
+import { Badge, Combobox, DataTable } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import { RefetchFnDynamic } from 'react-relay';
+import { useDebounceCallback } from 'usehooks-ts';
 
 interface AdminServiceTabProps {
   serviceData: serviceList_fragment$data[];
+  refetch: RefetchFnDynamic<serviceQuery, servicesList_services$key>;
 }
 
-const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
+const AdminServiceTab = ({ serviceData, refetch }: AdminServiceTabProps) => {
   const t = useTranslations();
-
+  const [selectedValue, setSelectedValue] = useState<
+    | {
+        value: string;
+        label: string;
+      }
+    | undefined
+  >(undefined);
   const columns: ColumnDef<serviceList_fragment$data>[] = [
     {
       accessorKey: 'name',
@@ -41,15 +56,16 @@ const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
         return (
           <>
             {row.original.service_definition?.identifier ===
-              'opencti_registration' && (
+              ServiceDefinitionIdentifierEnum.OPENCTI_REGISTRATION && (
               <Badge>
                 {row.original.subscriptions?.[0]?.organization.name.toUpperCase()}
               </Badge>
             )}
 
             {row.original.service_definition?.identifier !==
-              'opencti_registration' &&
-              row.original.service_definition?.identifier !== 'link' && (
+              ServiceDefinitionIdentifierEnum.OPENCTI_REGISTRATION &&
+              row.original.service_definition?.identifier !==
+                ServiceDefinitionIdentifierEnum.LINK && (
                 <>
                   {row.original.subscriptions?.length}{' '}
                   {t('Service.Organizations')}
@@ -88,11 +104,66 @@ const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
     },
   ];
 
+  const getServiceDefinitionData = useMemo(() => {
+    return serviceData
+      .map((service) => ({
+        value: service.service_definition?.identifier ?? '',
+        label: service.service_definition?.name ?? '',
+      }))
+      .filter(
+        (item, index, self) =>
+          index === self.findIndex((t) => t.value === item.value)
+      );
+  }, []);
+
+  const handleInputChange = (inputValue: string) => {
+    refetch({ searchTerm: inputValue });
+  };
+  const handleIdentifierChange = (
+    selectedValue: { value: string; label: string } | undefined
+  ) => {
+    setSelectedValue(selectedValue);
+    if (!selectedValue) {
+      refetch({ filters: [] });
+      return;
+    }
+    refetch({
+      filters: [
+        {
+          key: 'serviceDefinition_identifier',
+          value: [selectedValue.value],
+        },
+      ],
+    });
+  };
+
+  const debounceHandleInput = useDebounceCallback(
+    (e) => handleInputChange(e.target.value),
+    DEBOUNCE_TIME
+  );
+
   return (
     <DataTable
       columns={columns}
       i18nKey={i18nKey(t)}
       data={serviceData}
+      toolbar={
+        <div className="flex flex-col-reverse items-center justify-between gap-s sm:flex-row">
+          <SearchInput
+            containerClass="w-full sm:w-1/3"
+            placeholder={t('Service.SearchServices')}
+            onChange={debounceHandleInput}
+          />
+          <Combobox
+            dataTab={getServiceDefinitionData}
+            order={'Filter by service'}
+            placeholder={'Choose a value'}
+            emptyCommand={'Not found'}
+            onValueChange={handleIdentifierChange}
+            value={selectedValue}
+          />
+        </div>
+      }
       tableOptions={{
         getSortedRowModel: getSortedRowModel(),
       }}

--- a/apps/portal-front/src/components/service/admin-service-tab.tsx
+++ b/apps/portal-front/src/components/service/admin-service-tab.tsx
@@ -7,7 +7,7 @@ import { APP_PATH } from '@/utils/path/constant';
 import { serviceList_fragment$data } from '@generated/serviceList_fragment.graphql';
 import { ColumnDef, getSortedRowModel } from '@tanstack/react-table';
 import { MoreVertIcon } from 'filigran-icon';
-import { DataTable } from 'filigran-ui';
+import { Badge, DataTable } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
 
 interface AdminServiceTabProps {
@@ -32,6 +32,32 @@ const AdminServiceTab = ({ serviceData }: AdminServiceTabProps) => {
       accessorKey: 'creation_status',
       id: 'creation_status',
       header: t('Service.CreationStatus'),
+    },
+    {
+      accessorKey: 'organizations',
+      id: 'organizations',
+      header: t('Service.Organizations'),
+      cell: ({ row }) => {
+        return (
+          <>
+            {row.original.service_definition?.identifier ===
+              'opencti_registration' && (
+              <Badge>
+                {row.original.subscriptions?.[0]?.organization.name.toUpperCase()}
+              </Badge>
+            )}
+
+            {row.original.service_definition?.identifier !==
+              'opencti_registration' &&
+              row.original.service_definition?.identifier !== 'link' && (
+                <>
+                  {row.original.subscriptions?.length}{' '}
+                  {t('Service.Organizations')}
+                </>
+              )}
+          </>
+        );
+      },
     },
     {
       id: 'actions',

--- a/apps/portal-front/src/components/service/service.graphql.ts
+++ b/apps/portal-front/src/components/service/service.graphql.ts
@@ -109,6 +109,8 @@ export const servicesListFragment = graphql`
       after: $cursor
       orderBy: $orderBy
       orderMode: $orderMode
+      searchTerm: $searchTerm
+      filters: $filters
     ) {
       __id
       totalCount
@@ -128,6 +130,8 @@ export const ServiceListQuery = graphql`
     $cursor: ID
     $orderBy: ServiceInstanceOrdering!
     $orderMode: OrderingMode!
+    $filters: [Filter!]
+    $searchTerm: String
   ) {
     ...servicesList_services
   }

--- a/apps/portal-front/src/components/service/service.graphql.ts
+++ b/apps/portal-front/src/components/service/service.graphql.ts
@@ -60,6 +60,11 @@ export const serviceListFragment = graphql`
     public
     join_type
     tags
+    subscriptions {
+      organization {
+        name
+      }
+    }
     links {
       name
       url

--- a/yarn.lock
+++ b/yarn.lock
@@ -10116,7 +10116,7 @@ __metadata:
     eslint-config-prettier: 10.1.5
     extract-files: 13.0.0
     filigran-icon: 0.18.1
-    filigran-ui: 0.38.3
+    filigran-ui: 0.39.9
     graphql: 16.11.0
     graphql-sse: 2.5.4
     husky: 9.1.7
@@ -14657,9 +14657,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filigran-ui@npm:0.38.3":
-  version: 0.38.3
-  resolution: "filigran-ui@npm:0.38.3"
+"filigran-ui@npm:0.39.9":
+  version: 0.39.9
+  resolution: "filigran-ui@npm:0.39.9"
   dependencies:
     "@dnd-kit/core": 6.1.0
     "@dnd-kit/modifiers": 7.0.0
@@ -14704,7 +14704,7 @@ __metadata:
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0 || ^19.0
     react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0
-  checksum: 2ffa6e7449bdfed101b6c02a5df519fb431d6f1644465581d433589b00afa0ea2f42086f357d2bde224dc2c4e0e3a1d1038ecb014c338a7ed46e7e739ae70171
+  checksum: af6be73bc1ef489f1d1761dfb4fd4aa39e165698a8293510ec9587b5014bc014a4cd5d18c5c8b341be7751b4a19ab0756dea25313a7105326e620d508dbf9707
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Context: 
> Connected as BYPASS, I have now more information about services in the list. I can also filter it. 

# How to test:  
Connect as BYPASS. Go to the serviceList. See the column with the organization information (about the number of organization that have subscribed or the organization's name that have the OpenCTI platform). You can also filter the services. 
Check hthere is no regression on public pages
# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #912 
