### PR TITLE
[ci] fix: use first commit line to compute delete feature env identifier

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -268,27 +268,18 @@ jobs:
   delete-feature-branch:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/development'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     steps:
       - name: Install AWX cli
         run: pip install awxkit
 
       - name: Delete
         run: |
-          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
-          PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oE '#[0-9]+' | tail -1 | sed 's/#//')
-          if [ -n "$PR_NUMBER" ]; then
-            awx --conf.host https://awx.filigran.io \
-              --conf.token ${{ secrets.AWX_TOKEN }} \
-              -f human job_templates launch 'Delete XTM Hub feature branch for testing' \
-              --inventory eu-west-staging \
-              --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-$PR_NUMBER\"}"
-          else
-            echo "No PR number found in commit message"
-          fi
-
+          awx --conf.host https://awx.filigran.io \
+            --conf.token ${{ secrets.AWX_TOKEN }} \
+            -f human job_templates launch 'Delete XTM Hub feature branch for testing' \
+            --inventory eu-west-staging \
+            --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.pull_request.number }}\"}"
   build-images-prod:
     needs:
       - run-e2e-tests


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

Fix feature env deletion after merge on development by taking the first commit line only to find the feature env identifier.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- use the script present in the github action and replace `${{ github.event.head_commit.message }}` with a long commit message
- check that the PR number is the expected number

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests