### PR TITLE
[ci] fix: trigger feature env deletion on pull request

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -268,7 +268,7 @@ jobs:
   delete-feature-branch:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
     steps:
       - name: Install AWX cli
         run: pip install awxkit


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

Feature env deletion is not triggered because the wrong github event name is used.
This commit updates the event name to `pull_request` to be triggered along with the other jobs.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

This update will be triggered when is PR is closed.

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local tests

# Additional information:

Related #issueNumber