### PR TITLE
[frontend] - (USersList): No users on personal space #918

### DIFF
--- a/apps/portal-front/src/components/navigation.tsx
+++ b/apps/portal-front/src/components/navigation.tsx
@@ -17,7 +17,11 @@ export const NavigationApp: FunctionComponent<NavigationAppProps> = ({
   open,
 }) => {
   const t = useTranslations();
-  const { hasOrganizationCapability } = useContext(PortalContext);
+  const { hasOrganizationCapability, me } = useContext(PortalContext);
+
+  const currentOrganization = me?.organizations.find(
+    (orga) => orga.id === me?.selected_organization_id
+  );
   const canManageUser =
     hasOrganizationCapability &&
     (hasOrganizationCapability(
@@ -38,7 +42,7 @@ export const NavigationApp: FunctionComponent<NavigationAppProps> = ({
             text={t('MenuLinks.Home')}
           />
         </li>
-        {canManageUser && (
+        {canManageUser && !currentOrganization?.personal_space && (
           <li>
             <LinkMenu
               open={open}


### PR DESCRIPTION
# Context: 
> Connected, you should not see the users list when you are on your personal space. 

# How to test:  
Connect as Admin_orga 
Switch to personal space 
You should not see the users list 
Connect as User without any special capabilities
Switch to personal space 
You should not see the users list 

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [X] Local tests

# Additional information:

Related #918 