### PR TITLE
[backend/frontend] fix: return null when loading organization of unregistered platform

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -859,7 +859,7 @@ export type Query = {
   organization?: Maybe<Organization>;
   organizations: OrganizationConnection;
   pendingUsers: UserConnection;
-  platformAssociatedOrganization: Organization;
+  platformAssociatedOrganization?: Maybe<Organization>;
   publicServiceInstances: ServiceConnection;
   registeredPlatforms: Array<RegisteredPlatform>;
   rolePortal?: Maybe<RolePortal>;
@@ -2310,7 +2310,7 @@ export type QueryResolvers<ContextType = PortalContext, ParentType extends Resol
   organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryOrganizationArgs, 'id'>>;
   organizations?: Resolver<ResolversTypes['OrganizationConnection'], ParentType, ContextType, RequireFields<QueryOrganizationsArgs, 'first' | 'orderBy' | 'orderMode'>>;
   pendingUsers?: Resolver<ResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<QueryPendingUsersArgs, 'first' | 'orderBy' | 'orderMode'>>;
-  platformAssociatedOrganization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<QueryPlatformAssociatedOrganizationArgs, 'platformId'>>;
+  platformAssociatedOrganization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryPlatformAssociatedOrganizationArgs, 'platformId'>>;
   publicServiceInstances?: Resolver<ResolversTypes['ServiceConnection'], ParentType, ContextType, RequireFields<QueryPublicServiceInstancesArgs, 'first' | 'orderBy' | 'orderMode'>>;
   registeredPlatforms?: Resolver<Array<ResolversTypes['RegisteredPlatform']>, ParentType, ContextType, RequireFields<QueryRegisteredPlatformsArgs, 'input'>>;
   rolePortal?: Resolver<Maybe<ResolversTypes['RolePortal']>, ParentType, ContextType, RequireFields<QueryRolePortalArgs, 'id'>>;

--- a/apps/portal-api/src/modules/common/error-code.ts
+++ b/apps/portal-api/src/modules/common/error-code.ts
@@ -9,7 +9,6 @@ export enum ErrorCode {
   RegistrationOnAnotherOrganizationForbidden = 'REGISTRATION_ON_ANOTHER_ORGANIZATION_FORBIDDEN',
   RefreshUserPlatformTokenUnknownError = 'REFRESH_USER_PLATFORM_TOKEN_UNKNOWN_ERROR',
   ServiceContractNotFound = 'SERVICE_CONTRACT_NOT_FOUND',
-  ServiceConfigurationNotFound = 'SERVICE_CONFIGURATION_NOT_FOUND',
   ServiceDefinitionNotFound = 'SERVICE_DEFINITION_NOT_FOUND',
   SubscriptionNotFound = 'SUBSCRIPTION_NOT_FOUND',
   UnregisterPlatformUnknownError = 'UNREGISTER_PLATFORM_UNKNOWN_ERROR',

--- a/apps/portal-api/src/modules/services/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.ts
@@ -54,14 +54,14 @@ export const registrationApp = {
   loadPlatformAssociatedOrganization: async (
     context: PortalContext,
     platformId: string
-  ): Promise<Organization> => {
+  ): Promise<Organization | null> => {
     const serviceConfiguration =
       await serviceContractDomain.loadConfigurationByPlatform(
         context,
         platformId
       );
     if (!serviceConfiguration) {
-      throw new Error(ErrorCode.ServiceConfigurationNotFound);
+      return null;
     }
 
     const subscription = await loadSubscriptionBy(context, {

--- a/apps/portal-api/src/modules/services/registration/registration.graphql
+++ b/apps/portal-api/src/modules/services/registration/registration.graphql
@@ -101,7 +101,7 @@ type Query {
   ): CanUnregisterResponse! @auth
   registeredPlatforms(input: RegisteredPlatformsInput!): [RegisteredPlatform!]!
     @auth
-  platformAssociatedOrganization(platformId: String!): Organization! @auth
+  platformAssociatedOrganization(platformId: String!): Organization @auth
 }
 
 type Mutation {

--- a/apps/portal-api/src/modules/services/registration/registration.resolver.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.resolver.ts
@@ -133,7 +133,6 @@ const resolvers: Resolvers = {
         await trx.rollback();
 
         const errorMapping = {
-          [ErrorCode.ServiceConfigurationNotFound]: NotFoundError,
           [ErrorCode.SubscriptionNotFound]: NotFoundError,
           [ErrorCode.MissingCapabilityOnOrganization]: ForbiddenAccess,
           [ErrorCode.UserIsNotInOrganization]: ForbiddenAccess,

--- a/apps/portal-front/app/redirect/[identifier]/utils/load.ts
+++ b/apps/portal-front/app/redirect/[identifier]/utils/load.ts
@@ -67,7 +67,7 @@ export const loadPlatformOrganizationId = async (
       platformId,
     })) as PlatformAssociatedOrganizationResponse;
 
-    return associatedOrganization.data.platformAssociatedOrganization.id;
+    return associatedOrganization.data.platformAssociatedOrganization?.id;
   } catch (_) {}
 };
 

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -123,7 +123,7 @@ type Query {
   isPlatformRegistered(input: IsPlatformRegisteredInput!): IsPlatformRegisteredResponse!
   canUnregisterPlatform(input: CanUnregisterPlatformInput!): CanUnregisterResponse!
   registeredPlatforms(input: RegisteredPlatformsInput!): [RegisteredPlatform!]!
-  platformAssociatedOrganization(platformId: String!): Organization!
+  platformAssociatedOrganization(platformId: String!): Organization
   publicServiceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!): ServiceConnection!
   serviceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!, searchTerm: String, filters: [Filter!]): ServiceConnection!
   serviceInstanceById(service_instance_id: ID): ServiceInstance


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- try to load a resource with an unregistered platform id: [example](http://localhost:3002/redirect/custom_dashboards?service_instance_id=1f76591a-76f7-4c07-a4d1-bcb2bb4f2bb6&document_id=be3c8cec-8079-4216-90c3-f25f9e88bf69&_rsc=gq2bi&platform_id=92b94c74-34ec-4a59-99be-bb9f14110145)
- check that SERVICE_CONFIGURATION_NOT_FOUND error is not thrown

# What tests has been made: 
- [ ] Integration tests
- [ ] E2E tests
- [x] Local tests

# Additional information:

Related #880 