### PR TITLE
[ci] fix: move auto feature env delete in new workflow

### DIFF
--- a/.github/workflows/auto-delete-feature-env.yml
+++ b/.github/workflows/auto-delete-feature-env.yml
@@ -1,0 +1,23 @@
+name: Auto delete feature env
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+
+jobs:
+  delete-feature-env:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install AWX cli
+        run: pip install awxkit
+
+      - name: Delete
+        run: |
+          awx --conf.host https://awx.filigran.io \
+            --conf.token ${{ secrets.AWX_TOKEN }} \
+            -f human job_templates launch 'Delete XTM Hub feature branch for testing' \
+            --inventory eu-west-staging \
+            --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.pull_request.number }}\"}"

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -264,22 +264,6 @@ jobs:
             -f human job_templates launch 'Deploy XTM Hub feature branch for testing' \
             --inventory eu-west-staging \
             --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.number }}\",\"xtmhub_node_env\":\"development\"}"
-
-  delete-feature-branch:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    steps:
-      - name: Install AWX cli
-        run: pip install awxkit
-
-      - name: Delete
-        run: |
-          awx --conf.host https://awx.filigran.io \
-            --conf.token ${{ secrets.AWX_TOKEN }} \
-            -f human job_templates launch 'Delete XTM Hub feature branch for testing' \
-            --inventory eu-west-staging \
-            --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.pull_request.number }}\"}"
   build-images-prod:
     needs:
       - run-e2e-tests


### PR DESCRIPTION
# Context: 
> Describe briefly the context of you PR. Add any relevant screenshots or screen recording for the product team.

Auto deletion is currently not working because the job to delete a feature env is not triggered on a closed PR.
This PR moves the job to a new workflow, triggered only when a PR is closed (merged or not).

# How to test:  
> Describe how to reproduce and test what you've done. Add screeshots of you local tests. 

- create a new PR
- close it
- delete feature env workflow is triggered