### PR TITLE
[frontend] Display connectors in dev

### DIFF
--- a/apps/portal-front/.env
+++ b/apps/portal-front/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_APP_VERSION=0.0.0-dev
+APP_ENV=development

--- a/apps/portal-front/src/lib/utils.ts
+++ b/apps/portal-front/src/lib/utils.ts
@@ -45,10 +45,9 @@ export const isEmpty = (value: unknown): boolean => {
   return false;
 };
 
-export const getEnv = () => process.env.NODE_ENV;
+export const getEnv = () => process.env.APP_ENV;
 export const isProduction = () => getEnv() === 'production';
 export const isDevelopment = () =>
-  // @ts-expect-error we have staging
   getEnv() !== 'staging' && getEnv() !== 'production';
 
 export const getServiceInstanceUrl = (


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
 
 Display number of connectors.
 
 NODE_ENV is always set to "production" by default by Nextjs in build. Use APP_ENV instead. Platform have already made the change.