### PR TITLE
[backend] - chore(renovate): ignore elastic search/kibana docker image upgrades and helm folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "schedule": ["on sunday after 4am and before 6am"],
 
   "labels": ["dependencies", "filigran team"],
+  "ignorePaths": ["charts/**"],
   "prConcurrentLimit": 5,
   "rebaseWhen": "behind-base-branch",
 
@@ -16,6 +17,12 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "devDependencies (non-major)",
       "groupSlug": "dev-dependencies-non-major"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["elasticsearch", "docker.elastic.co/elasticsearch/elasticsearch", "docker.elastic.co/kibana/kibana"],
+      "enabled": false,
+      "description": "Ignore Elasticsearch Docker image updates"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION

# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
we don't want to automatically upgrade elastic search docker images to keep the same as prod version, or update helm folder

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
Test renovate still works well and don't open helm or elastic search/kibana docker images updates

## Related issues

N/A

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.