### PR TITLE
[frontend] fix(alignment): shareable services buttons and breadcrumb

### DIFF
--- a/apps/portal-front/src/components/service/document/shareable-resource-slug.tsx
+++ b/apps/portal-front/src/components/service/document/shareable-resource-slug.tsx
@@ -90,13 +90,12 @@ const ShareableResourceSlug: React.FunctionComponent<
         <h1 className="whitespace-nowrap">{documentData.name}</h1>
 
         <BadgeOverflowCounter badges={documentData.labels as BadgeOverflow[]} />
-
-        <ShareLinkButton
-          documentId={documentData.id}
-          url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${documentData?.service_instance?.slug}/${documentData?.slug}`}
-        />
-        {shouldShowOneClickDeployComponent ? (
-          <div className="flex items-center gap-2 ml-auto">
+        <div className="flex items-center gap-2 ml-auto">
+          <ShareLinkButton
+            documentId={documentData.id}
+            url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${documentData?.service_instance?.slug}/${documentData?.slug}`}
+          />
+          {shouldShowOneClickDeployComponent ? (
             <TooltipProvider>
               <Tooltip
                 delayDuration={50}
@@ -118,10 +117,7 @@ const ShareableResourceSlug: React.FunctionComponent<
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            {updateActions}
-          </div>
-        ) : (
-          <>
+          ) : (
             <Button
               onClick={() => {
                 incrementDownloadNumber();
@@ -129,13 +125,12 @@ const ShareableResourceSlug: React.FunctionComponent<
               }}>
               {t('Utils.Download')}
             </Button>
-            <div>{updateActions}</div>
-          </>
-        )}
-
-        {shouldShowOneClickDeployComponent && (
-          <OneClickDeploy documentData={documentData} />
-        )}
+          )}
+          {updateActions}
+          {shouldShowOneClickDeployComponent && (
+            <OneClickDeploy documentData={documentData} />
+          )}
+        </div>
       </div>
       {children}
       <div className="flex flex-col-reverse lg:flex-row w-full mt-l gap-xl">

--- a/apps/portal-front/src/components/ui/breadcrumb-nav.tsx
+++ b/apps/portal-front/src/components/ui/breadcrumb-nav.tsx
@@ -28,7 +28,7 @@ export const BreadcrumbNav: FunctionComponent<BreadcrumbProps> = ({
   const t = useTranslations();
   return (
     <Breadcrumb className="pb-s sm:pb-l">
-      <BreadcrumbList>
+      <BreadcrumbList className="pl-0">
         {value.map(({ href, label, original }, index) => {
           const lastIndex = value.length - 1 === index;
           return (


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
- buttons on shareable services are not well aligned and not responsive when there is no  tags and not 'deploy in opencti' button
- breadcrumb is not well aligned




## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
- Check buttons are well aligned and responsive even when there is no tag, and no button 'deploy in opencti'
- check buttons display is responsive
- Check breadcrumb is well aligned

<img width="1102" height="333" alt="image" src="https://github.com/user-attachments/assets/8e7ce599-7ddf-479f-90f6-00b5e5b36d9d" />


## Related issues

- Related to #1076

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.