### PR TITLE
[backend/frontend] - fix(telemetry): one click deploy event is not sent  #1154

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -810,8 +810,8 @@ export type Node = {
 };
 
 export type OneClickDeployInput = {
-  platform_id: Scalars['ID']['input'];
   platform_identifier: PlatformIdentifier;
+  platform_service_instance_id: Scalars['ID']['input'];
   resource_id: Scalars['ID']['input'];
   resource_title: Scalars['String']['input'];
   service_instance_id: Scalars['ID']['input'];

--- a/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
+++ b/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
@@ -22,7 +22,7 @@ import {
   ServiceConfigurationStatus,
 } from '../../__generated__/resolvers-types';
 import type { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
-import { serviceContractDomain } from '../services/contract/domain';
+import * as serviceInstanceDomain from '../services/service-instance.domain';
 
 // Mock the ES Client
 vi.mock('@elastic/elasticsearch', () => ({
@@ -96,15 +96,16 @@ describe('TelemetryApp', () => {
       const telemetrySpy = vi
         .spyOn(telemetryApp, 'sendTelemetryEvent')
         .mockResolvedValue();
+      const platform_id = '916121bf-d246-4a43-8522-24be19537b91';
+      const platformServiceInstanceId = '5891d6cf-1737-48bb-8f60-de520a93f2bd';
       vi.spyOn(
-        serviceContractDomain,
-        'loadConfigurationByPlatform'
+        serviceInstanceDomain,
+        'loadPlatformConfigurationByServiceInstanceId'
       ).mockResolvedValue({
-        service_instance_id:
-          '5891d6cf-1737-48bb-8f60-de520a93f2bd' as ServiceInstanceId,
+        service_instance_id: platformServiceInstanceId as ServiceInstanceId,
         config: {
           token: '59dea7ba-b3b3-4b42-bb60-6326159dc937',
-          platform_id: '916121bf-d246-4a43-8522-24be19537b91',
+          platform_id: platform_id,
           platform_url: 'https://testing.obas.staging.filigran.io/',
           registerer_id: '7de5c830-ed96-45ff-91a7-b384943a4620',
           platform_title: 'Open AEV Instance',
@@ -115,7 +116,6 @@ describe('TelemetryApp', () => {
       });
 
       const fakeResourceId = 'c07f6909-f8c5-4f61-b17d-b5b2da9b2799';
-      const fakePlatformId = '11b0fe37-0623-4487-af23-0efa6de157a4';
 
       await telemetryApp.sendOneClickDeployEvent(contextAdminUser, {
         userId: ADMIN_UUID,
@@ -127,7 +127,10 @@ describe('TelemetryApp', () => {
           ),
           resource_id: toGlobalId('DocumentId', fakeResourceId),
           resource_title: 'CsvFeed Title',
-          platform_id: toGlobalId('OpenCTIPlatform', fakePlatformId),
+          platform_service_instance_id: toGlobalId(
+            'RegisteredPlatform',
+            platformServiceInstanceId
+          ),
         },
       });
 
@@ -143,7 +146,7 @@ describe('TelemetryApp', () => {
         service_type: TelemetryEventServiceType.CSV_FEEDS,
         resource_id: fakeResourceId,
         resource_title: 'CsvFeed Title',
-        platform_id: fakePlatformId,
+        platform_id: platform_id,
         platform_version: '1.0.0',
         target_product: TelemetryTargetProduct.OPEN_CTI,
       });
@@ -155,15 +158,16 @@ describe('TelemetryApp', () => {
       const telemetrySpy = vi
         .spyOn(telemetryApp, 'sendTelemetryEvent')
         .mockResolvedValue();
+      const platformId = '916121bf-d246-4a43-8522-24be19537b91';
+      const platformServiceInstanceId = '5891d6cf-1737-48bb-8f60-de520a93f2bd';
       vi.spyOn(
-        serviceContractDomain,
-        'loadConfigurationByPlatform'
+        serviceInstanceDomain,
+        'loadPlatformConfigurationByServiceInstanceId'
       ).mockResolvedValue({
-        service_instance_id:
-          '5891d6cf-1737-48bb-8f60-de520a93f2bd' as ServiceInstanceId,
+        service_instance_id: platformServiceInstanceId as ServiceInstanceId,
         config: {
           token: '59dea7ba-b3b3-4b42-bb60-6326159dc937',
-          platform_id: '916121bf-d246-4a43-8522-24be19537b91',
+          platform_id: platformId,
           platform_url: 'https://testing.obas.staging.filigran.io/',
           registerer_id: '7de5c830-ed96-45ff-91a7-b384943a4620',
           platform_title: 'Open AEV Instance',
@@ -173,7 +177,6 @@ describe('TelemetryApp', () => {
       });
 
       const fakeResourceId = 'c07f6909-f8c5-4f61-b17d-b5b2da9b2799';
-      const fakePlatformId = '11b0fe37-0623-4487-af23-0efa6de157a4';
 
       await telemetryApp.sendOneClickDeployEvent(contextAdminUser, {
         userId: ADMIN_UUID,
@@ -185,7 +188,10 @@ describe('TelemetryApp', () => {
           ),
           resource_id: toGlobalId('DocumentId', fakeResourceId),
           resource_title: 'CsvFeed Title',
-          platform_id: toGlobalId('OpenCTIPlatform', fakePlatformId),
+          platform_service_instance_id: toGlobalId(
+            'RegisteredPlatform',
+            platformServiceInstanceId
+          ),
         },
       });
 
@@ -201,7 +207,7 @@ describe('TelemetryApp', () => {
         service_type: TelemetryEventServiceType.CSV_FEEDS,
         resource_id: fakeResourceId,
         resource_title: 'CsvFeed Title',
-        platform_id: fakePlatformId,
+        platform_id: platformId,
         target_product: TelemetryTargetProduct.OPEN_CTI,
       });
     });

--- a/apps/portal-api/src/modules/telemetry/telemetry.app.ts
+++ b/apps/portal-api/src/modules/telemetry/telemetry.app.ts
@@ -7,8 +7,10 @@ import { esDbClient } from '../../thirdparty/elasticsearch/client';
 import { logApp } from '../../utils/app-logger.util';
 import { extractId } from '../../utils/utils';
 import { loadOrganizationBy } from '../organizations/organizations.domain';
-import { serviceContractDomain } from '../services/contract/domain';
-import { loadServiceDefinitionByServiceInstance } from '../services/service-instance.domain';
+import {
+  loadPlatformConfigurationByServiceInstanceId,
+  loadServiceDefinitionByServiceInstance,
+} from '../services/service-instance.domain';
 import { buildOneClickDeployEvent } from './telemetry.helper';
 import { TelemetryEvent, TelemetryEventType } from './telemetry.types';
 
@@ -57,11 +59,13 @@ export const telemetryApp = {
       extractId<ServiceInstanceId>(input.service_instance_id)
     );
 
-    const platform_id = extractId<'RegisteredPlatform'>(input.platform_id);
+    const platformServiceInstanceId = extractId<'RegisteredPlatform'>(
+      input.platform_service_instance_id
+    );
     const serviceConfiguration =
-      await serviceContractDomain.loadConfigurationByPlatform(
+      await loadPlatformConfigurationByServiceInstanceId(
         context,
-        platform_id
+        platformServiceInstanceId
       );
 
     const config = serviceConfiguration.config as object;
@@ -71,7 +75,7 @@ export const telemetryApp = {
       userId,
       serviceDefinition.identifier,
       input.platform_identifier,
-      platform_id,
+      'platform_id' in config ? (config.platform_id as string) : undefined,
       'platform_version' in config
         ? (config.platform_version as string)
         : undefined,

--- a/apps/portal-api/src/modules/telemetry/telemetry.graphql
+++ b/apps/portal-api/src/modules/telemetry/telemetry.graphql
@@ -8,7 +8,7 @@ input OneClickDeployInput {
   service_instance_id: ID!
   resource_id: ID!
   resource_title: String!
-  platform_id: ID!
+  platform_service_instance_id: ID!
 }
 
 type SendTelemetryMutation {

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -849,7 +849,7 @@ input OneClickDeployInput {
   service_instance_id: ID!
   resource_id: ID!
   resource_title: String!
-  platform_id: ID!
+  platform_service_instance_id: ID!
 }
 
 type SendTelemetryMutation {

--- a/apps/portal-front/src/components/service/document/one-click-deploy/one-click-deploy.tsx
+++ b/apps/portal-front/src/components/service/document/one-click-deploy/one-click-deploy.tsx
@@ -100,7 +100,7 @@ const OneClickDeploy = ({ documentData }: OneClickDeployProps) => {
               service_instance_id: documentData.service_instance!.id,
               resource_id: documentData.id,
               resource_title: documentData.name,
-              platform_id: platform!.id,
+              platform_service_instance_id: platform!.id,
             },
           },
         });


### PR DESCRIPTION

# Context
One click deploy event are not sent. There is an error in the logs `Error in sendTelemetryEvent resolver`.

## How to test
One click deploy a document. 
There must be no error in the log, and event must be inserted in elastic search

## Related issues

- Related to #1154

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.