### PR TITLE
[backend] fix: use default color during label creation

### DIFF
--- a/apps/portal-api/src/modules/settings/labels/labels.app.ts
+++ b/apps/portal-api/src/modules/settings/labels/labels.app.ts
@@ -6,13 +6,16 @@ import { objectLabelDomain } from '../objectLabel/object-label.domain';
 import { labelsDomain } from './labels.domain';
 
 export const labelsApp = {
-  loadOrCreateLabel: async (initializer: LabelInitializer): Promise<Label> => {
-    const existing = await labelsDomain.loadLabelByLikeName(initializer.name);
+  loadOrCreateLabel: async ({
+    name,
+    color = '#0099cc',
+  }: LabelInitializer): Promise<Label> => {
+    const existing = await labelsDomain.loadLabelByLikeName(name);
     if (existing) {
       return existing;
     }
 
-    return labelsDomain.insertLabel(initializer);
+    return labelsDomain.insertLabel({ name, color });
   },
 
   deleteLabelBy: async (field: LabelMutator): Promise<Label> => {


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Default label color was removed with https://github.com/FiligranHQ/xtm-hub/commit/64364738f899e55b40eec958b088dce7d8dae3ea. This PR adds it again to prevent errors when creating new labels

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- ingest connector manifest
- check there is no issues when loading connector list

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.