### PR TITLE
[frontend]: Dont display CTA for registration services #1088

### DIFF
--- a/apps/portal-front/src/components/service/admin-service-tab.tsx
+++ b/apps/portal-front/src/components/service/admin-service-tab.tsx
@@ -99,7 +99,14 @@ const AdminServiceTab = ({ serviceData, refetch }: AdminServiceTabProps) => {
                     <span className="sr-only">{t('Utils.OpenMenu')}</span>
                   </>
                 }>
-                {row.original.service_definition?.identifier !== 'link' && (
+                {![
+                  ServiceDefinitionIdentifierEnum.LINK,
+                  ServiceDefinitionIdentifierEnum.OPENCTI_REGISTRATION,
+                  ServiceDefinitionIdentifierEnum.OPENAEV_REGISTRATION,
+                ].includes(
+                  row.original.service_definition
+                    ?.identifier as ServiceDefinitionIdentifierEnum
+                ) && (
                   <IconActionsLink
                     href={`/${APP_PATH}/admin/service/${row.id}`}>
                     {t('Service.GoToAdminLabel')}


### PR DESCRIPTION
# Context
> Display "MANAGE" CTA only for manageable services. 

## How to test
Login as BYPASS 
Go to the Admin Services Page
On Link services, registration services (OpenCTI & OpenAEV), you should not have the manage button. You have that button otherwise. 

## Related issues

- Related to #1088 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.