### PR TITLE
[backend] : Fix loadRegistration query  with identifiers #796

### DIFF
--- a/apps/portal-api/src/modules/services/registration/registration.domain.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.domain.ts
@@ -147,8 +147,13 @@ export const registrationDomain = {
     }[]
   > => {
     const userSelectedOrganization = context.user.selected_organization_id;
-    const serviceDefinitionIdentifier =
-      serviceDefinitionIdentifierMappedByPlatformIdentifier[platformIdentifier];
+    const serviceDefinitionIdentifiers = platformIdentifier
+      ? [
+          serviceDefinitionIdentifierMappedByPlatformIdentifier[
+            platformIdentifier
+          ],
+        ]
+      : Object.values(serviceDefinitionIdentifierMappedByPlatformIdentifier);
 
     return await db<ServiceInstance>(context, 'ServiceInstance', opts)
       .leftJoin(
@@ -169,15 +174,7 @@ export const registrationDomain = {
         '=',
         'ServiceInstance.id'
       )
-      .modify((queryBuilder) => {
-        if (platformIdentifier) {
-          queryBuilder.where(
-            'ServiceDefinition.identifier',
-            '=',
-            serviceDefinitionIdentifier
-          );
-        }
-      })
+      .whereIn('ServiceDefinition.identifier', serviceDefinitionIdentifiers)
       .where('Subscription.organization_id', '=', userSelectedOrganization)
       .where('Subscription.status', '=', 'ACCEPTED')
       .whereIn('Subscription.joining', ['SELF_JOIN', 'AUTO_JOIN'])

--- a/apps/portal-front/src/components/service/home/owned-services.tsx
+++ b/apps/portal-front/src/components/service/home/owned-services.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import SkeletonServiceCard from '@/components/service/home/skeleton-service-card';
-import { useIsFeatureEnabled } from '@/hooks/useIsFeatureEnabled';
-import { FeatureFlag } from '@/utils/constant';
 import {
   hasTrialInstance,
   publicServiceInstanceToInstanceCardData,
@@ -27,9 +25,6 @@ const OwnedServices = ({
   publicServices,
   registeredPlatforms,
 }: OwnedServicesProps) => {
-  const isFreeTrialFeatureEnabled = useIsFeatureEnabled(
-    FeatureFlag.OPEN_CTI_FREE_TRIAL
-  );
   // Merge and sort by ordering property
   const sortedServices = [
     ...services
@@ -48,12 +43,9 @@ const OwnedServices = ({
     return (
       <Suspense>
         <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-4 gap-l">
-          {isFreeTrialFeatureEnabled &&
-            !hasTrialInstance(
-              registeredPlatforms.map(
-                registeredPlatformToServiceInstanceCardData
-              )
-            ) && <SkeletonServiceCard />}
+          {!hasTrialInstance(
+            registeredPlatforms.map(registeredPlatformToServiceInstanceCardData)
+          ) && <SkeletonServiceCard />}
           {sortedServices.map((service) => (
             <ServiceInstanceCard
               key={service.id}


### PR DESCRIPTION
# Context
> Edit the loadRegistration query to send back only registration user_services. 

## How to test
Enable FF Free_trial 
Connect as Admin User. 
Subscribe to several other services (such as dashboards). 
You should not see multiplication on service-card with "Free-trial" title :) That's it !



# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X]I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
