### PR TITLE
[backend] refactor: move user admin code to app layer

### DIFF
--- a/apps/portal-api/src/modules/users/users.admin.app.ts
+++ b/apps/portal-api/src/modules/users/users.admin.app.ts
@@ -1,22 +1,34 @@
 import {
+  AdminAddUserInput,
   AdminEditUserInput,
   EditUserCapabilitiesInput,
 } from '../../__generated__/resolvers-types';
+import { withTransaction } from '../../context/database.context';
 import { requestContext } from '../../context/request.context';
 import { OrganizationId } from '../../model/kanel/public/Organization';
 import { UserId } from '../../model/kanel/public/User';
+import { UserLoadUserBy } from '../../model/user';
+import { CAPABILITY_BYPASS } from '../../portal.const';
 import { dispatch } from '../../pub';
 import { updateUserSession } from '../../session-store-manager';
 import { auth0Client } from '../../thirdparty/auth0/client';
 import { logApp } from '../../utils/app-logger.util';
+import { ErrorCode } from '../../utils/error/error.code';
 import { extractId } from '../../utils/utils';
 import {
   loadUserOrganization,
   updateMultipleUserOrgWithCapabilities,
 } from '../common/user-organization.domain';
-import { loadUserDetails, updateUser } from './users.domain';
+import { loadOrganizationsFromEmail } from '../organizations/organizations.helper';
+import {
+  loadUnsecureUser,
+  loadUserBy,
+  loadUserDetails,
+  updateUser,
+} from './users.domain';
 import {
   acceptPendingUserWithCapabilities,
+  createUserWithPersonalSpace,
   mapUserToGraphqlUser,
   preventAdministratorRemovalOfAllOrganizations,
   preventAdministratorRemovalOfOneOrganization,
@@ -24,6 +36,61 @@ import {
 } from './users.helper';
 
 export const usersAdminApp = {
+  addUser: async (input: AdminAddUserInput): Promise<UserLoadUserBy> => {
+    const { user: contextUser } = requestContext.require();
+    const [organizationFromEmail] = await loadOrganizationsFromEmail(
+      input.email
+    );
+    // In most of the case there will be only one organization in the list, but in case where the scenario is an admin pltfm it can be multiple or none
+    const chosenOrganizationId: OrganizationId | undefined = input
+      .organization_capabilities?.[0]
+      ? extractId<OrganizationId>(
+          input.organization_capabilities?.[0].organization_id
+        )
+      : undefined;
+
+    // The admin orga should only allow to add users in the same organization and with the same domain.
+    // Only the admin PLTFM can by pass this check
+    const isEmailOutsideOrganization =
+      chosenOrganizationId !== organizationFromEmail?.id;
+    const hasUserBypassCapability = contextUser.capabilities.some(
+      (c) => c.id === CAPABILITY_BYPASS.id
+    );
+
+    if (isEmailOutsideOrganization && !hasUserBypassCapability) {
+      logApp.warn(
+        'You cannot add a user whose email domain is outside your organization'
+      );
+      throw new Error(ErrorCode.EmailOutsideOrganizationError);
+    }
+
+    const [existingUser] = await loadUnsecureUser({ email: input.email });
+
+    const finalUser = await withTransaction(async () => {
+      const user = existingUser
+        ? existingUser
+        : await createUserWithPersonalSpace({
+            email: input.email,
+            password: input.password,
+            first_name: input.first_name,
+            last_name: input.last_name,
+            selected_organization_id: chosenOrganizationId,
+          });
+
+      await updateMultipleUserOrgWithCapabilities(
+        user.id,
+        input.organization_capabilities
+      );
+
+      return await loadUserBy({
+        'User.id': user.id,
+      });
+    });
+
+    await dispatch('User', 'add', finalUser);
+
+    return finalUser;
+  },
   editUser: async ({
     userId,
     input,

--- a/apps/portal-api/src/modules/users/users.domain.ts
+++ b/apps/portal-api/src/modules/users/users.domain.ts
@@ -27,31 +27,6 @@ import { isAdmin } from '../role-portal/role-portal.domain';
 import { telemetryApp } from '../telemetry/telemetry.app';
 import { buildLoginEvent } from '../telemetry/telemetry.helper';
 
-export const loadUsersByOrganization = async (
-  organizationId: string,
-  excludedUserId: string,
-  role: string
-) => {
-  return dbUnsecure<User>('User')
-    .select('User.*')
-    .rightJoin('User_RolePortal', function () {
-      this.on('User_RolePortal.user_id', '=', 'User.id').andOnVal(
-        'User_RolePortal.role_portal_id',
-        '=',
-        role
-      );
-    })
-    .leftJoin('User_Organization', 'User.id', 'User_Organization.user_id')
-    .leftJoin(
-      'Organization as org',
-      'User_Organization.organization_id',
-      '=',
-      'org.id'
-    )
-    .where('org.id', organizationId)
-    .where('User.id', '!=', excludedUserId);
-};
-
 export const loadUnsecureUser = async (
   field: addPrefixToObject<UserMutator, 'User.'> | UserMutator
 ) => {

--- a/apps/portal-api/src/modules/users/users.graphql
+++ b/apps/portal-api/src/modules/users/users.graphql
@@ -114,22 +114,26 @@ input AdminAddUserInput {
 }
 
 type Mutation {
+  # Admin
+  adminAddUser(input: AdminAddUserInput!): User @auth(requires: [BYPASS])
+  adminEditUser(id: ID!, input: AdminEditUserInput!): User!
+    @auth(requires: [BYPASS])
+
   # Management
   mergeTest(from: ID!, target: ID!): ID!
     @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
   addUser(input: AddUserInput!): User
     @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
-  adminAddUser(input: AdminAddUserInput!): User @auth(requires: [BYPASS])
-  adminEditUser(id: ID!, input: AdminEditUserInput!): User!
-    @auth(requires: [BYPASS])
   editUserCapabilities(id: ID!, input: EditUserCapabilitiesInput!): User!
     @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
-  editMeUser(input: EditMeUserInput!): User! @auth
   changeSelectedOrganization(organization_id: ID!): User @auth
   removePendingUserFromOrganization(user_id: ID!, organization_id: ID!): User
     @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
   removeUserFromOrganization(user_id: ID!, organization_id: ID!): User
     @auth(requires: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
+
+  # Profile
+  editMeUser(input: EditMeUserInput!): User! @auth
   resetPassword: Success! @auth
   requestTransferPersonalSpace(new_email: String): Success! @auth
   transferPersonalSpace(requestId: ID!): Success! @auth

--- a/apps/portal-api/src/modules/users/users.resolver.ts
+++ b/apps/portal-api/src/modules/users/users.resolver.ts
@@ -15,7 +15,6 @@ import { CAPABILITY_BYPASS } from '../../portal.const';
 import { dispatch, listen } from '../../pub';
 import { logApp } from '../../utils/app-logger.util';
 
-import { withTransaction } from '../../context/database.context';
 import { requestContext } from '../../context/request.context';
 import { UserTransferRequestId } from '../../model/kanel/public/UserTransferRequest';
 import { validatePassword } from '../../security/utils/user';
@@ -31,7 +30,6 @@ import { removeUserFromOrganizationPending } from '../common/user-organization-p
 import {
   createUserOrgCapabilities,
   removeUserFromOrganization,
-  updateMultipleUserOrgWithCapabilities,
 } from '../common/user-organization.domain';
 import { loadOrganizationBy } from '../organizations/organizations.domain';
 import { loadOrganizationsFromEmail } from '../organizations/organizations.helper';
@@ -182,57 +180,12 @@ const resolvers: Resolvers = {
         });
       }
     },
-    adminAddUser: async (_, { input }, context) => {
+
+    // Admin
+    adminAddUser: async (_, { input }) => {
       try {
-        const [organizationFromEmail] = await loadOrganizationsFromEmail(
-          input.email
-        );
-        // In most of the case there will be only one organization in the list, but in case where the scenario is an admin pltfm it can be multiple or none
-        const chosenOrganization: OrganizationId | undefined = input
-          .organization_capabilities?.[0]
-          ? extractId<OrganizationId>(
-              input.organization_capabilities?.[0].organization_id
-            )
-          : undefined;
-
-        // The admin orga should only allow to add users in the same organization and with the same domain.
-        // Only the admin PLTFM can by pass this check
-        if (
-          chosenOrganization !== organizationFromEmail?.id &&
-          !context.user.capabilities.some((c) => c.id === CAPABILITY_BYPASS.id)
-        ) {
-          logApp.warn(
-            'You cannot add a user whose email domain is outside your organization'
-          );
-          throw new Error(ErrorCode.EmailOutsideOrganizationError);
-        }
-
-        const [existingUser] = await loadUnsecureUser({ email: input.email });
-
-        const loadUserFinalUser = await withTransaction(async () => {
-          const user = existingUser
-            ? existingUser
-            : await createUserWithPersonalSpace({
-                email: input.email,
-                password: input.password,
-                first_name: input.first_name,
-                last_name: input.last_name,
-                selected_organization_id: chosenOrganization,
-              });
-
-          await updateMultipleUserOrgWithCapabilities(
-            user.id,
-            input.organization_capabilities
-          );
-
-          return await loadUserBy({
-            'User.id': user.id,
-          });
-        });
-
-        await dispatch('User', 'add', loadUserFinalUser);
-
-        return mapUserToGraphqlUser(loadUserFinalUser);
+        const user = await usersAdminApp.addUser(input);
+        return mapUserToGraphqlUser(user);
       } catch (error) {
         if (error.message.includes(ErrorCode.UserDisabled)) {
           logApp.warn('You cannot add a user who is disabled in the plaform');

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -121,15 +121,15 @@ type Mutation {
   addUserService(input: UserServiceAddInput!): [UserService]
   addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService]
   deleteUserService(input: UserServiceDeleteInput!): UserService
-  mergeTest(from: ID!, target: ID!): ID!
-  addUser(input: AddUserInput!): User
   adminAddUser(input: AdminAddUserInput!): User
   adminEditUser(id: ID!, input: AdminEditUserInput!): User!
+  mergeTest(from: ID!, target: ID!): ID!
+  addUser(input: AddUserInput!): User
   editUserCapabilities(id: ID!, input: EditUserCapabilitiesInput!): User!
-  editMeUser(input: EditMeUserInput!): User!
   changeSelectedOrganization(organization_id: ID!): User
   removePendingUserFromOrganization(user_id: ID!, organization_id: ID!): User
   removeUserFromOrganization(user_id: ID!, organization_id: ID!): User
+  editMeUser(input: EditMeUserInput!): User!
   resetPassword: Success!
   requestTransferPersonalSpace(new_email: String): Success!
   transferPersonalSpace(requestId: ID!): Success!


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

- move remaining `addUser` mutation from resolver to user admin app
- reorganize mutation in GraphQL file

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- as an admin, add a new user
- check that mutation works as before

https://github.com/user-attachments/assets/b92437ab-0be6-4d0e-b78a-686c791e6eea

## Related issues

- Related to #1121

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.