### PR TITLE
[backend] fix: allow unauthenticated user to access public data

### DIFF
--- a/apps/portal-api/src/modules/services/document/document.domain.ts
+++ b/apps/portal-api/src/modules/services/document/document.domain.ts
@@ -803,7 +803,7 @@ export const loadSeoDocuments = async <
   opts: Partial<QueryDocumentsArgs>,
   include_metadata?: string[]
 ) => {
-  const loadDocumentsQuery = db<Document>('Document', opts)
+  const loadDocumentsQuery = dbUnsecure<Document>('Document')
     .select('Document.*')
     .leftJoin(
       'ServiceInstance',

--- a/apps/portal-api/src/modules/services/integration-feeds/integration-feeds.graphql
+++ b/apps/portal-api/src/modules/services/integration-feeds/integration-feeds.graphql
@@ -66,8 +66,8 @@ type Connector implements Node & DocumentBase & IntegrationFeed {
   share_number: Int
   slug: String!
   labels: [Label!]
-  service_instance_id: String! @auth
-  service_instance: ServiceInstance @auth
+  service_instance_id: String!
+  service_instance: ServiceInstance
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResourceImage!]
   # Integration Feed

--- a/apps/portal-api/src/modules/settings/labels/labels.graphql
+++ b/apps/portal-api/src/modules/settings/labels/labels.graphql
@@ -37,7 +37,7 @@ type Query {
     orderBy: LabelOrdering!
     orderMode: OrderingMode!
     searchTerm: String
-  ): LabelConnection @auth
+  ): LabelConnection
   label(id: ID!): Label @auth
 }
 

--- a/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/[docSlug]/slug-document.tsx
+++ b/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/[docSlug]/slug-document.tsx
@@ -18,14 +18,16 @@ const SlugDocument = async ({
   switch (serviceInstance.slug as ServiceSlug) {
     case ServiceSlug.OPEN_CTI_INTEGRATION_FEEDS:
       return (
-        <div className="relative w-full h-[35vh]">
-          <Image
-            fill
-            className="object-cover object-top rounded-lg"
-            src={`/document/images/${serviceInstance.id}/${document.children_documents![0]!.id}`}
-            alt={`A picture of ${document.name}`}
-          />
-        </div>
+        document.children_documents![0] && (
+          <div className="relative w-full h-[35vh]">
+            <Image
+              fill
+              className="object-cover object-top rounded-lg"
+              src={`/document/images/${serviceInstance.id}/${document.children_documents![0]!.id}`}
+              alt={`A picture of ${document.name}`}
+            />
+          </div>
+        )
       );
 
     case ServiceSlug.OPEN_CTI_CUSTOM_DASHBOARDS:


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Integration feeds page is not accessible because `IntegrationFeed.service_instance` is protected by auth directive but needs to be accessed on the public page.

This PR removes the `@auth` directives to allow public rendering.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #1105 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.