### PR TITLE
[backend] change api endpoint to fetch tag instead rolling #1150

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1079,7 +1079,6 @@ export type Query = {
   publicIntegrationFeedBySlug?: Maybe<IntegrationFeed>;
   publicIntegrationFeeds: IntegrationFeedConnection;
   publicServiceInstances: ServiceConnection;
-  refreshOpenCTIManifest?: Maybe<Scalars['Boolean']['output']>;
   registeredPlatforms: Array<RegisteredPlatform>;
   rolePortal?: Maybe<RolePortal>;
   rolesPortal: Array<RolePortal>;
@@ -1096,6 +1095,7 @@ export type Query = {
   settings: Settings;
   subscribedServiceInstancesByIdentifier: Array<SubscribedServiceInstance>;
   subscriptionById?: Maybe<SubscriptionModel>;
+  updateOpenCTIManifest: Success;
   userHasOrganizationWithSubscription: Scalars['Boolean']['output'];
   userOrganizations: Array<Organization>;
   userServiceFromSubscription?: Maybe<UserServiceConnection>;
@@ -1356,6 +1356,11 @@ export type QuerySubscribedServiceInstancesByIdentifierArgs = {
 
 export type QuerySubscriptionByIdArgs = {
   subscription_id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type QueryUpdateOpenCtiManifestArgs = {
+  tag?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -2723,7 +2728,6 @@ export type QueryResolvers<ContextType = PortalContext, ParentType extends Resol
   publicIntegrationFeedBySlug?: Resolver<Maybe<ResolversTypes['IntegrationFeed']>, ParentType, ContextType, Partial<QueryPublicIntegrationFeedBySlugArgs>>;
   publicIntegrationFeeds?: Resolver<ResolversTypes['IntegrationFeedConnection'], ParentType, ContextType, RequireFields<QueryPublicIntegrationFeedsArgs, 'first' | 'orderBy' | 'orderMode' | 'slug'>>;
   publicServiceInstances?: Resolver<ResolversTypes['ServiceConnection'], ParentType, ContextType, RequireFields<QueryPublicServiceInstancesArgs, 'first' | 'orderBy' | 'orderMode'>>;
-  refreshOpenCTIManifest?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   registeredPlatforms?: Resolver<Array<ResolversTypes['RegisteredPlatform']>, ParentType, ContextType, Partial<QueryRegisteredPlatformsArgs>>;
   rolePortal?: Resolver<Maybe<ResolversTypes['RolePortal']>, ParentType, ContextType, RequireFields<QueryRolePortalArgs, 'id'>>;
   rolesPortal?: Resolver<Array<ResolversTypes['RolePortal']>, ParentType, ContextType>;
@@ -2740,6 +2744,7 @@ export type QueryResolvers<ContextType = PortalContext, ParentType extends Resol
   settings?: Resolver<ResolversTypes['Settings'], ParentType, ContextType>;
   subscribedServiceInstancesByIdentifier?: Resolver<Array<ResolversTypes['SubscribedServiceInstance']>, ParentType, ContextType, RequireFields<QuerySubscribedServiceInstancesByIdentifierArgs, 'identifier'>>;
   subscriptionById?: Resolver<Maybe<ResolversTypes['SubscriptionModel']>, ParentType, ContextType, Partial<QuerySubscriptionByIdArgs>>;
+  updateOpenCTIManifest?: Resolver<ResolversTypes['Success'], ParentType, ContextType, Partial<QueryUpdateOpenCtiManifestArgs>>;
   userHasOrganizationWithSubscription?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   userOrganizations?: Resolver<Array<ResolversTypes['Organization']>, ParentType, ContextType>;
   userServiceFromSubscription?: Resolver<Maybe<ResolversTypes['UserServiceConnection']>, ParentType, ContextType, RequireFields<QueryUserServiceFromSubscriptionArgs, 'first' | 'orderBy' | 'orderMode' | 'subscription_id'>>;

--- a/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.app.ts
+++ b/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.app.ts
@@ -6,12 +6,12 @@ import {
   ManifestExtractionResult,
 } from './ingest-manifest.helper';
 
-const OpenCTIConnectorsManifest =
-  'https://raw.githubusercontent.com/OpenCTI-Platform/connectors/master/manifest.json';
+const getOpenCTIConnectorsManifest = (tag: string) =>
+  `https://raw.githubusercontent.com/OpenCTI-Platform/connectors/tags/${tag}/manifest.json`;
 
 export const IngestManifestApp = {
-  async refreshOpenCTIManifest(): Promise<ManifestExtractionResult> {
-    const manifest = await fetchManifest(OpenCTIConnectorsManifest);
+  async updateOpenCTIManifest(tag: string): Promise<ManifestExtractionResult> {
+    const manifest = await fetchManifest(getOpenCTIConnectorsManifest(tag));
     const result = extractManifestInformation(manifest);
 
     if (result.validContracts.length > 0) {

--- a/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.graphql
+++ b/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.graphql
@@ -1,3 +1,3 @@
 type Query {
-  refreshOpenCTIManifest: Boolean @system_token
+  updateOpenCTIManifest(tag: String): Success! @system_token
 }

--- a/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.helper.ts
+++ b/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.helper.ts
@@ -142,7 +142,7 @@ const ContractSchema = z.object({
   container_image: z.string().min(1),
   container_type: z.nativeEnum(ConnectorType),
   source_code: z.string().url(),
-  subscription_link: z.string().url().or(z.literal('')),
+  subscription_link: z.string().url().or(z.literal('')).nullish(),
   manager_supported: z.boolean(),
   playbook_supported: z.boolean(),
 });

--- a/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.resolver.ts
+++ b/apps/portal-api/src/modules/ingest-manifest/ingest-manifest.resolver.ts
@@ -4,15 +4,19 @@ import { IngestManifestApp } from './ingest-manifest.app';
 
 const resolvers: Resolvers = {
   Query: {
-    refreshOpenCTIManifest: async () => {
+    updateOpenCTIManifest: async (_, { tag }) => {
       if (!isFeatureEnabled('CONNECTORS_INTEGRATION_FEEDS')) {
-        return false;
+        return {
+          success: false,
+        };
       }
 
       // Error handling is now done in the app layer
-      await IngestManifestApp.refreshOpenCTIManifest();
+      await IngestManifestApp.updateOpenCTIManifest(tag);
 
-      return true;
+      return {
+        success: true,
+      };
     },
   },
 };

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -30,7 +30,7 @@ type Success {
 }
 
 type Query {
-  refreshOpenCTIManifest: Boolean
+  updateOpenCTIManifest(tag: String): Success!
   organization(id: ID!): Organization
   organizations(first: Int = 50, after: ID, orderBy: OrganizationOrdering!, orderMode: OrderingMode!, searchTerm: String): OrganizationConnection!
   userOrganizations: [Organization!]!


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Changing and renaming the graphql endpoint to make it flexible for next release. We fetch by version instead of rolling version.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #1150 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.