### PR TITLE
[backend] fix(autoregister): allow autoregister the same platform #1243

### DIFF
--- a/apps/portal-api/src/modules/services/contract/domain.ts
+++ b/apps/portal-api/src/modules/services/contract/domain.ts
@@ -82,4 +82,21 @@ export const serviceContractDomain = {
       config,
     });
   },
+
+  upsertConfiguration: async (
+    serviceInstanceId: string,
+    config: Record<string, unknown>
+  ) => {
+    await db('Service_Configuration')
+      .insert({
+        service_instance_id: serviceInstanceId,
+        config,
+      })
+      .onConflict('service_instance_id')
+      .merge();
+  },
+
+  deleteConfigurationBy: async (conditions: ServiceConfigurationMutator) => {
+    await db('Service_Configuration').where(conditions).delete();
+  },
 };

--- a/apps/portal-api/src/modules/services/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.test.ts
@@ -66,7 +66,10 @@ import { TelemetryEventType } from '../../telemetry/telemetry.types';
 import { serviceContractDomain } from '../contract/domain';
 import { DeploymentRequestDomain } from '../deployments/deployments.domain';
 import * as serviceInstanceDomain from '../service-instance.domain';
-import { loadServiceInstanceBy } from '../service-instance.domain';
+import {
+  deleteServiceInstanceBy,
+  loadServiceInstanceBy,
+} from '../service-instance.domain';
 import { registrationApp } from './registration.app';
 import { registrationDomain } from './registration.domain';
 
@@ -757,6 +760,11 @@ describe('Registration app', () => {
           user_requester_id: ADMIN_UUID,
         })) as DeploymentRequest;
     });
+    afterEach(async () => {
+      await DeploymentRequestDomain.deleteDeploymentRequestBy({});
+      await serviceContractDomain.deleteConfigurationBy({});
+      await deleteServiceInstanceBy({});
+    });
     it('should throw if deployment request is not found', async () => {
       const call = registrationApp.autoRegisterPlatform(
         uuidv4(),
@@ -819,6 +827,47 @@ describe('Registration app', () => {
           platform_title: platformConfiguration.title,
           platform_url: platformConfiguration.url,
           platform_version: platformConfiguration.version,
+          registerer_id: ADMIN_USER_ID,
+          token: deploymentRequest.platform_token,
+        },
+        service_instance_id: deploymentRequest.service_instance_id,
+        status: ServiceConfigurationStatus.Active,
+      });
+    });
+    it("should successfully register the provided platform if it's already registered", async () => {
+      const newPlatformConfiguration = {
+        id: uuidv4(),
+        title: 'My New OpenCTI platform',
+        url: 'http://example2.com',
+        contract: PlatformContract.Trial,
+        version: 'A.B.C',
+      };
+      await registrationApp.autoRegisterPlatform(
+        deploymentRequest.platform_token as string,
+        platformConfiguration
+      );
+
+      await registrationApp.autoRegisterPlatform(
+        deploymentRequest.platform_token as string,
+        newPlatformConfiguration
+      );
+
+      const oldConfiguration =
+        await serviceContractDomain.loadConfigurationByPlatform(
+          platformConfiguration.id
+        );
+      const newConfiguration =
+        await serviceContractDomain.loadConfigurationByPlatform(
+          newPlatformConfiguration.id
+        );
+      expect(oldConfiguration).toBeNull();
+      expect(newConfiguration).toMatchObject({
+        config: {
+          platform_contract: newPlatformConfiguration.contract,
+          platform_id: newPlatformConfiguration.id,
+          platform_title: newPlatformConfiguration.title,
+          platform_url: newPlatformConfiguration.url,
+          platform_version: newPlatformConfiguration.version,
           registerer_id: ADMIN_USER_ID,
           token: deploymentRequest.platform_token,
         },

--- a/apps/portal-api/src/modules/services/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.ts
@@ -431,7 +431,7 @@ export const registrationApp = {
 
     await withTransaction(async () => {
       await Promise.all([
-        serviceContractDomain.createConfiguration(
+        serviceContractDomain.upsertConfiguration(
           deploymentRequest.service_instance_id,
           configuration
         ),


### PR DESCRIPTION
# Context
Currently it's not possible to call several time the autoregister endpoint for the same platform, there is a exception of duplicate key of configuration.

## How to test
Test auto register again the same platform.

## Related issues

- Related to #1243

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.