### PR TITLE
[backend] add endpoint createAudienceAPI with Auth0 #1299

### DIFF
--- a/apps/portal-api/src/thirdparty/auth0/client.ts
+++ b/apps/portal-api/src/thirdparty/auth0/client.ts
@@ -10,9 +10,23 @@ export interface Auth0UpdateUser {
   country?: string;
 }
 
+export interface Auth0UpdateUserRBACInstance {
+  [key: string]: {
+    groups: string[];
+  };
+}
+
 export interface Auth0Client {
   updateUser(user: Auth0UpdateUser): Promise<void>;
   resetPassword(email: string): Promise<void>;
+  createAudienceAPI(
+    organization_name: string,
+    platform_id: string
+  ): Promise<void>;
+  updateUserRBACInstance(
+    email: string,
+    userRBACInstance: Auth0UpdateUserRBACInstance
+  ): Promise<void>;
 }
 
 const isAuth0Enabled = !(

--- a/apps/portal-api/src/thirdparty/auth0/implementation.ts
+++ b/apps/portal-api/src/thirdparty/auth0/implementation.ts
@@ -1,6 +1,10 @@
 import { AuthenticationClient, ManagementClient } from 'auth0';
 import config from 'config';
-import { Auth0Client, Auth0UpdateUser } from './client';
+import {
+  Auth0Client,
+  Auth0UpdateUser,
+  Auth0UpdateUserRBACInstance,
+} from './client';
 
 const CONNECTION_TYPE = 'Username-Password-Authentication';
 
@@ -37,10 +41,45 @@ export const auth0ClientImplementation: Auth0Client = {
       }
     );
   },
+  updateUserRBACInstance: async (
+    email: string,
+    userRBACInstance: Auth0UpdateUserRBACInstance
+  ): Promise<void> => {
+    const users_response = await managementClient.usersByEmail.getByEmail({
+      email,
+    });
+    const auth0_user = users_response.data[0];
+    if (!auth0_user) {
+      throw new Error('AUTH0_USER_NOT_FOUND_ERROR');
+    }
+
+    await managementClient.users.update(
+      { id: auth0_user.user_id },
+      {
+        user_metadata: {
+          ...auth0_user.user_metadata,
+          rbac_instance: {
+            ...(auth0_user.user_metadata?.rbac_instance ?? {}),
+            ...userRBACInstance,
+          },
+        },
+      }
+    );
+  },
   resetPassword: async (email: string): Promise<void> => {
     await authenticationClient.database.changePassword({
       email,
       connection: CONNECTION_TYPE,
+    });
+  },
+  createAudienceAPI: async (
+    organization_name: string,
+    platform_id: string
+  ): Promise<void> => {
+    await managementClient.resourceServers.create({
+      name: `${organization_name}_${platform_id}`,
+      identifier: `https://${platform_id}`,
+      signing_alg: 'RS256',
     });
   },
 };

--- a/apps/portal-api/src/thirdparty/auth0/mock.ts
+++ b/apps/portal-api/src/thirdparty/auth0/mock.ts
@@ -1,13 +1,31 @@
-import { Auth0Client, Auth0UpdateUser } from './client';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import {
+  Auth0Client,
+  Auth0UpdateUser,
+  Auth0UpdateUserRBACInstance,
+} from './client';
 
 export const auth0ClientMock: Auth0Client = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   updateUser(user: Auth0UpdateUser): Promise<void> {
     return Promise.resolve();
   },
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   resetPassword(email: string): Promise<void> {
+    return Promise.resolve();
+  },
+
+  createAudienceAPI(
+    organization_name: string,
+    platform_id: string
+  ): Promise<void> {
+    return Promise.resolve();
+  },
+
+  updateUserRBACInstance(
+    email: string,
+    userRBACInstance: Auth0UpdateUserRBACInstance
+  ): Promise<void> {
     return Promise.resolve();
   },
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Create a function to createAudienceAPI, it will be needed when a trial instance is registered. Once is registered, we call the endpoint to create an Audience so we can create user groupe accordingly.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #1299

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.