### PR TITLE
[frontend/backend] - fix(freetrials): fix link for provisoning status and don't display button if no link to opencti #1344

### DIFF
--- a/apps/portal-api/src/modules/services/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.ts
@@ -524,7 +524,7 @@ const mapDomainRegisteredPlatformToGraphQL = (
     platform_id: platform.config?.platform_id ?? platform.id,
     title: platform.config?.platform_title ?? 'OpenCTI - Free Trial Platform',
     url: platform.config?.platform_url ?? '',
-    contract: platform.config?.platform_contract ?? PlatformContract.Ee,
+    contract: platform.config?.platform_contract ?? PlatformContract.Trial,
     identifier:
       platform.identifier ?? ServiceDefinitionIdentifier.OpenctiRegistration,
     version: platform.config?.platform_version ?? '',

--- a/apps/portal-front/src/components/service/trial-instances/trials-details-page.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/trials-details-page.tsx
@@ -40,15 +40,16 @@ export const TrialsDetailsPage: React.FC<Props> = ({ platform }) => {
             <span className="text-gray/60">License:</span> Enterprise Edition
           </li>
         </ul>
-
-        <Button>
-          <Link
-            target="_blank"
-            rel="noopener noreferrer"
-            href={platform.url}>
-            Access OpenCTI
-          </Link>
-        </Button>
+        {platform.url && (
+          <Button>
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href={platform.url}>
+              Access OpenCTI
+            </Link>
+          </Button>
+        )}
       </section>
       <TrialsLearnMore />
     </>


### PR DESCRIPTION
# Context
In provisioning status, the link on the trial tile returns 404 error. 

## How to test
When the trial is in provisioning status, check we can access the registration page, and that button to redirect to opencti is not displayed.

## Related issues

- Related to #1344

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.