### PR TITLE
[backend] fix query ambiguous on delete document

### DIFF
--- a/apps/portal-api/src/modules/services/document/domain/document.domain.ts
+++ b/apps/portal-api/src/modules/services/document/domain/document.domain.ts
@@ -485,7 +485,7 @@ export const updateDocumentWithChildren = async <T extends DocumentModel>(
   if (childIds.length > 0) {
     await db<Document>('Document')
       .whereIn(
-        'id',
+        'Document.id',
         childIds.map((childId) => childId.child_document_id)
       )
       .delete()


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

When a user have a capabilities to update document, he cannot delete an existing image.