### PR TITLE
[backend] - fix(freeTrials): compute hub_status based on actual_state #1364

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -341,10 +341,10 @@ export enum DeploymentRequestPlatformRegion {
 
 export enum DeploymentRequestPlatformState {
   Active = 'active',
-  Inactive = 'inactive',
   Provisioning = 'provisioning',
   Removed = 'removed',
-  Removing = 'removing'
+  Removing = 'removing',
+  Unprovisioned = 'unprovisioned'
 }
 
 export type Document = {
@@ -1842,7 +1842,6 @@ export type UpdateDeploymentRequestInput = {
   actual_state?: InputMaybe<DeploymentRequestPlatformState>;
   end_date?: InputMaybe<Scalars['Date']['input']>;
   failure_reason?: InputMaybe<Scalars['String']['input']>;
-  hub_status?: InputMaybe<DeploymentRequestHubStatus>;
   id: Scalars['ID']['input'];
   ordering?: InputMaybe<Scalars['Int']['input']>;
   platform_id?: InputMaybe<Scalars['String']['input']>;

--- a/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
@@ -98,7 +98,7 @@ describe('Deployment app', () => {
         service_instance_id: expect.any(String),
         hub_status: DeploymentRequestHubStatus.Pending,
         target_state: DeploymentRequestPlatformState.Active,
-        actual_state: null,
+        actual_state: DeploymentRequestPlatformState.Unprovisioned,
         ordering: expect.any(Number),
         type: DeploymentRequestDeploymentType.Trial,
         use_case: 'use_case',
@@ -142,8 +142,8 @@ describe('Deployment app', () => {
         request_date: expect.any(Date),
         service_instance_id: expect.any(String),
         hub_status: DeploymentRequestHubStatus.Queued,
-        target_state: DeploymentRequestPlatformState.Inactive,
-        actual_state: null,
+        target_state: DeploymentRequestPlatformState.Unprovisioned,
+        actual_state: DeploymentRequestPlatformState.Unprovisioned,
         ordering: expect.any(Number),
         type: DeploymentRequestDeploymentType.Trial,
         use_case: 'use_case',
@@ -353,8 +353,8 @@ describe('Deployment app', () => {
       // Synced: inactive target vs inactive actual
       const synced3 = await insertOpenCtiDeploymentRequest({
         hub_status: DeploymentRequestHubStatus.Expired,
-        target_state: DeploymentRequestPlatformState.Inactive,
-        actual_state: DeploymentRequestPlatformState.Inactive,
+        target_state: DeploymentRequestPlatformState.Unprovisioned,
+        actual_state: DeploymentRequestPlatformState.Unprovisioned,
       });
 
       const deployments = await DeploymentsApp.loadPlatformDeploymentRequests({
@@ -453,7 +453,7 @@ describe('Deployment app', () => {
         region: DeploymentRequestPlatformRegion.UsEast,
         request_date: expect.any(Date),
         service_instance_id: expect.any(String),
-        hub_status: DeploymentRequestHubStatus.Pending,
+        hub_status: DeploymentRequestHubStatus.Active,
         target_state: DeploymentRequestPlatformState.Active,
         actual_state: DeploymentRequestPlatformState.Active,
         ordering: expect.any(Number),
@@ -482,7 +482,7 @@ describe('Deployment app', () => {
     it(' with Active status, it should create ServiceGroup with admin', async () => {
       const deployment = await DeploymentsApp.updateDeploymentRequest({
         id: initialDeployment?.id as string,
-        hub_status: DeploymentRequestHubStatus.Active,
+        actual_state: DeploymentRequestPlatformState.Active,
         start_date: new Date(2025, 1, 3),
         end_date: new Date(2025, 2, 3),
         platform_id: 'fake product instance id',
@@ -519,7 +519,7 @@ describe('Deployment app', () => {
 
       expect(userReaderGroup.length).toBe(0);
     });
-    it('should should throw if deployment request does not exist', async () => {
+    it('should throw if deployment request does not exist', async () => {
       const call = DeploymentsApp.updateDeploymentRequest({
         id: uuidv4(),
         actual_state: DeploymentRequestPlatformState.Active,
@@ -559,15 +559,6 @@ describe('Deployment app', () => {
         );
       }
     );
-    it('should should throw when status requested is not allowed', async () => {
-      const call = DeploymentsApp.updateDeploymentRequest({
-        id: initialDeployment?.id as string,
-        hub_status: DeploymentRequestHubStatus.Expired,
-      });
-      await expect(call).rejects.toThrow(
-        BadRequestErrorCode.DeploymentRequestStatusUpdateNotAllowed
-      );
-    });
     describe('telemetry', () => {
       it('should send a telemetry event', async () => {
         vi.useFakeTimers();
@@ -599,7 +590,7 @@ describe('Deployment app', () => {
           platform_id: 'fake product instance id',
           start_date,
           end_date,
-          status: undefined,
+          status: DeploymentRequestHubStatus.Active,
         });
       });
 

--- a/apps/portal-api/src/modules/services/deployments/deployments.app.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.ts
@@ -48,7 +48,7 @@ import {
 } from '../../telemetry/telemetry.helper';
 import {
   assertFreeTrialsLimit,
-  isHubStatusTransitionValid,
+  computeHubStatus,
   isPlatformStateTransitionValid,
 } from './deployments.helper';
 
@@ -112,9 +112,9 @@ export const DeploymentsApp = {
             hub_status: hubStatus,
             target_state:
               hubStatus === DeploymentRequestHubStatus.Queued
-                ? DeploymentRequestPlatformState.Inactive
+                ? DeploymentRequestPlatformState.Unprovisioned
                 : DeploymentRequestPlatformState.Active,
-            actual_state: null,
+            actual_state: DeploymentRequestPlatformState.Unprovisioned,
             ordering,
             type: input.type,
             platform_identifier: input.platform_identifier,
@@ -197,18 +197,6 @@ export const DeploymentsApp = {
     }
 
     if (
-      input.hub_status &&
-      !isHubStatusTransitionValid(
-        deploymentRequest.hub_status as DeploymentRequestHubStatus,
-        input.hub_status
-      )
-    ) {
-      throw new Error(
-        BadRequestErrorCode.DeploymentRequestStatusUpdateNotAllowed
-      );
-    }
-
-    if (
       input.actual_state &&
       !isPlatformStateTransitionValid(
         deploymentRequest.actual_state as DeploymentRequestPlatformState,
@@ -225,6 +213,22 @@ export const DeploymentsApp = {
       (!input.start_date || !input.end_date);
     if (isActiveInputDataInvalid) {
       throw new Error(BadRequestErrorCode.MissingStartOrEndDate);
+    }
+
+    let newStatus = computeHubStatus(
+      deploymentRequest.hub_status,
+      input.actual_state
+    );
+    // if no status is computed, it means it the transition is invalid.
+    // Let's just keep the same hub_status and log an error to investigate.
+    if (!newStatus) {
+      logApp.error('Invalid deployment request hub status update', {
+        deploymentRequest: deploymentRequest.id,
+        new_hub_status: newStatus,
+        previous_hub_status: deploymentRequest.hub_status,
+        actual_state: input.actual_state,
+      });
+      newStatus = deploymentRequest.hub_status;
     }
 
     await withTransaction(async () => {
@@ -246,18 +250,15 @@ export const DeploymentsApp = {
         failure_reason: input.failure_reason,
         actual_state: input.actual_state,
         ordering: input.ordering,
+        hub_status: newStatus,
       };
-
-      if (input.hub_status) {
-        updateData.hub_status = input.hub_status;
-      }
 
       await DeploymentRequestDomain.updateDeploymentRequestById(
         deploymentRequestId,
         updateData
       );
 
-      if (input.hub_status === DeploymentRequestHubStatus.Active) {
+      if (newStatus === DeploymentRequestHubStatus.Active) {
         await DeploymentRequestDomain.initialiseServiceGroup(
           input.id as DeploymentRequestId
         );
@@ -272,7 +273,7 @@ export const DeploymentsApp = {
         organization,
         deploymentRequest.user_requester_id,
         {
-          status: input.hub_status,
+          status: newStatus,
           start_date: input.start_date,
           end_date: input.end_date,
           deployment_id: deploymentRequest.id,

--- a/apps/portal-api/src/modules/services/deployments/deployments.graphql
+++ b/apps/portal-api/src/modules/services/deployments/deployments.graphql
@@ -19,11 +19,11 @@ enum DeploymentRequestHubStatus {
 }
 
 enum DeploymentRequestPlatformState {
+  unprovisioned
   provisioning
   active
   removing
   removed
-  inactive
 }
 
 type DeploymentRequest implements Node {
@@ -81,7 +81,6 @@ input CreateDeploymentRequestInput {
 
 input UpdateDeploymentRequestInput {
   id: ID!
-  hub_status: DeploymentRequestHubStatus
   start_date: Date
   end_date: Date
   platform_id: String

--- a/apps/portal-api/src/modules/services/deployments/deployments.helper.test.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.helper.test.ts
@@ -12,6 +12,7 @@ import { AlreadyExistsErrorCode } from '../../../utils/error/error.code';
 import { DeploymentRequestDomain } from './deployments.domain';
 import {
   assertFreeTrialsLimit,
+  computeHubStatus,
   isHubStatusTransitionValid,
   isPlatformStateTransitionValid,
 } from './deployments.helper';
@@ -61,7 +62,10 @@ describe('isHubStatusTransitionValid', () => {
 
 describe('isPlatformStateTransitionValid', () => {
   const validTransitions = [
-    [null, DeploymentRequestPlatformState.Provisioning],
+    [
+      DeploymentRequestPlatformState.Unprovisioned,
+      DeploymentRequestPlatformState.Provisioning,
+    ],
     [
       DeploymentRequestPlatformState.Provisioning,
       DeploymentRequestPlatformState.Active,
@@ -71,16 +75,8 @@ describe('isPlatformStateTransitionValid', () => {
       DeploymentRequestPlatformState.Removing,
     ],
     [
-      DeploymentRequestPlatformState.Active,
-      DeploymentRequestPlatformState.Inactive,
-    ],
-    [
       DeploymentRequestPlatformState.Removing,
       DeploymentRequestPlatformState.Removed,
-    ],
-    [
-      DeploymentRequestPlatformState.Inactive,
-      DeploymentRequestPlatformState.Active,
     ],
   ] as const;
 
@@ -142,10 +138,163 @@ describe('assertFreeTrialsLimit', () => {
       type: DeploymentRequestDeploymentType.Trial,
       hub_status: DeploymentRequestHubStatus.Pending,
       target_state: DeploymentRequestPlatformState.Active,
-      actual_state: null,
+      actual_state: DeploymentRequestPlatformState.Active,
     });
     await expect(
       assertFreeTrialsLimit(PLATFORM_ORGANIZATION_UUID)
     ).rejects.toThrow(AlreadyExistsErrorCode.FreeTrialAlreadyExists);
+  });
+});
+
+describe('computeHubStatus', () => {
+  describe('when actualState is null/undefined', () => {
+    it.each([
+      [DeploymentRequestHubStatus.Pending, undefined],
+      [DeploymentRequestHubStatus.Active, null],
+      [DeploymentRequestHubStatus.Expired, undefined],
+      [DeploymentRequestHubStatus.Cancelled, null],
+    ])(
+      'should return %s when actualState is %s',
+      (currentStatus, actualState) => {
+        const result = computeHubStatus(currentStatus, actualState);
+        expect(result).toBe(currentStatus);
+      }
+    );
+  });
+
+  describe('validation errors', () => {
+    it('should throw error when current status is Queued', () => {
+      const result = computeHubStatus(
+        DeploymentRequestHubStatus.Queued,
+        DeploymentRequestPlatformState.Provisioning
+      );
+      expect(result).toBeNull();
+    });
+
+    it.each([
+      [DeploymentRequestHubStatus.Pending],
+      [DeploymentRequestHubStatus.Active],
+      [DeploymentRequestHubStatus.Failed],
+      [DeploymentRequestHubStatus.Expired],
+      [DeploymentRequestHubStatus.Cancelled],
+    ])(
+      'should throw error when platform state is Unprovisioned from %s',
+      (currentStatus) => {
+        const result = computeHubStatus(
+          currentStatus,
+          DeploymentRequestPlatformState.Unprovisioned
+        );
+        expect(result).toBeNull();
+      }
+    );
+
+    it.each([
+      [
+        DeploymentRequestHubStatus.Active,
+        DeploymentRequestPlatformState.Provisioning,
+      ],
+      [
+        DeploymentRequestHubStatus.Expired,
+        DeploymentRequestPlatformState.Active,
+      ],
+      [
+        DeploymentRequestHubStatus.Expired,
+        DeploymentRequestPlatformState.Provisioning,
+      ],
+      [
+        DeploymentRequestHubStatus.Cancelled,
+        DeploymentRequestPlatformState.Active,
+      ],
+      [
+        DeploymentRequestHubStatus.Cancelled,
+        DeploymentRequestPlatformState.Provisioning,
+      ],
+      [
+        DeploymentRequestHubStatus.Pending,
+        DeploymentRequestPlatformState.Removing,
+      ],
+      [
+        DeploymentRequestHubStatus.Active,
+        DeploymentRequestPlatformState.Removing,
+      ],
+      [
+        DeploymentRequestHubStatus.Failed,
+        DeploymentRequestPlatformState.Removing,
+      ],
+      [
+        DeploymentRequestHubStatus.Pending,
+        DeploymentRequestPlatformState.Removed,
+      ],
+      [
+        DeploymentRequestHubStatus.Active,
+        DeploymentRequestPlatformState.Removed,
+      ],
+      [
+        DeploymentRequestHubStatus.Failed,
+        DeploymentRequestPlatformState.Removed,
+      ],
+    ])(
+      'should throw error for invalid transition from %s with platform state %s',
+      (currentStatus, platformState) => {
+        const result = computeHubStatus(currentStatus, platformState);
+        expect(result).toBeNull();
+      }
+    );
+  });
+
+  describe('valid state transitions', () => {
+    it.each([
+      [
+        DeploymentRequestHubStatus.Pending,
+        DeploymentRequestPlatformState.Active,
+        DeploymentRequestHubStatus.Active,
+      ],
+      [
+        DeploymentRequestHubStatus.Pending,
+        DeploymentRequestPlatformState.Provisioning,
+        DeploymentRequestHubStatus.Pending,
+      ],
+      [
+        DeploymentRequestHubStatus.Failed,
+        DeploymentRequestPlatformState.Provisioning,
+        DeploymentRequestHubStatus.Pending,
+      ],
+      [
+        DeploymentRequestHubStatus.Failed,
+        DeploymentRequestPlatformState.Active,
+        DeploymentRequestHubStatus.Active,
+      ],
+      [
+        DeploymentRequestHubStatus.Active,
+        DeploymentRequestPlatformState.Active,
+        DeploymentRequestHubStatus.Active,
+      ],
+      [
+        DeploymentRequestHubStatus.Cancelled,
+        DeploymentRequestPlatformState.Removing,
+        DeploymentRequestHubStatus.Cancelled,
+      ],
+      [
+        DeploymentRequestHubStatus.Cancelled,
+        DeploymentRequestPlatformState.Removed,
+        DeploymentRequestHubStatus.Cancelled,
+      ],
+      [
+        DeploymentRequestHubStatus.Expired,
+        DeploymentRequestPlatformState.Removing,
+        DeploymentRequestHubStatus.Expired,
+      ],
+      [
+        DeploymentRequestHubStatus.Expired,
+        DeploymentRequestPlatformState.Removed,
+        DeploymentRequestHubStatus.Expired,
+      ],
+    ])(
+      'should transition from %s with platform state %s to %s',
+      (currentStatus, platformState, expectedStatus) => {
+        const result = computeHubStatus(currentStatus, platformState);
+        expect(result).toBe(expectedStatus);
+      }
+    );
   });
 });

--- a/apps/portal-api/src/modules/services/deployments/deployments.helper.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.helper.ts
@@ -58,8 +58,12 @@ const VALID_HUB_STATUS_TRANSITIONS: HubStatusTransition[] = [
 
 const VALID_PLATFORM_STATE_TRANSITIONS: PlatformStateTransition[] = [
   {
-    from: null,
+    from: DeploymentRequestPlatformState.Unprovisioned,
     to: DeploymentRequestPlatformState.Provisioning,
+  },
+  {
+    from: DeploymentRequestPlatformState.Unprovisioned,
+    to: DeploymentRequestPlatformState.Active,
   },
   {
     from: DeploymentRequestPlatformState.Provisioning,
@@ -70,16 +74,8 @@ const VALID_PLATFORM_STATE_TRANSITIONS: PlatformStateTransition[] = [
     to: DeploymentRequestPlatformState.Removing,
   },
   {
-    from: DeploymentRequestPlatformState.Active,
-    to: DeploymentRequestPlatformState.Inactive,
-  },
-  {
     from: DeploymentRequestPlatformState.Removing,
     to: DeploymentRequestPlatformState.Removed,
-  },
-  {
-    from: DeploymentRequestPlatformState.Inactive,
-    to: DeploymentRequestPlatformState.Active,
   },
 ];
 
@@ -112,4 +108,47 @@ export const assertFreeTrialsLimit = async (organizationId: OrganizationId) => {
   if (freeTrialsRequests) {
     throw new Error(AlreadyExistsErrorCode.FreeTrialAlreadyExists);
   }
+};
+
+export const computeHubStatus = (
+  currentHubStatus: DeploymentRequestHubStatus,
+  actualState: DeploymentRequestPlatformState | null | undefined
+) => {
+  if (!actualState) {
+    return currentHubStatus;
+  }
+
+  if (
+    currentHubStatus === DeploymentRequestHubStatus.Queued ||
+    actualState === DeploymentRequestPlatformState.Unprovisioned
+  ) {
+    return null;
+  }
+
+  let newHubStatus = currentHubStatus;
+
+  switch (actualState) {
+    case DeploymentRequestPlatformState.Active:
+      newHubStatus = DeploymentRequestHubStatus.Active;
+      break;
+    case DeploymentRequestPlatformState.Provisioning:
+      newHubStatus = DeploymentRequestHubStatus.Pending;
+      break;
+    case DeploymentRequestPlatformState.Removing:
+    case DeploymentRequestPlatformState.Removed:
+      if (
+        currentHubStatus !== DeploymentRequestHubStatus.Expired &&
+        currentHubStatus !== DeploymentRequestHubStatus.Cancelled
+      ) {
+        return null;
+      }
+      newHubStatus = currentHubStatus;
+      break;
+  }
+
+  if (!isHubStatusTransitionValid(currentHubStatus, newHubStatus)) {
+    return null;
+  }
+
+  return newHubStatus;
 };

--- a/apps/portal-api/src/modules/services/deployments/deployments.resolver.test.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.resolver.test.ts
@@ -44,7 +44,7 @@ describe('Deployment app', () => {
         type: DeploymentRequestDeploymentType.Trial,
         hub_status: DeploymentRequestHubStatus.Pending,
         target_state: DeploymentRequestPlatformState.Active,
-        actual_state: null,
+        actual_state: DeploymentRequestPlatformState.Unprovisioned,
       });
     });
   });
@@ -69,7 +69,7 @@ describe('Deployment app', () => {
         end_date: null,
         hub_status: DeploymentRequestHubStatus.Pending,
         target_state: DeploymentRequestPlatformState.Active,
-        actual_state: null,
+        actual_state: DeploymentRequestPlatformState.Unprovisioned,
       });
 
       const updatedDeployment = await resolver.Mutation.updateDeploymentRequest(
@@ -97,7 +97,7 @@ describe('Deployment app', () => {
         await resolver.Mutation.updateDeploymentRequest(undefined, {
           input: {
             id: initialDeployment.id,
-            actual_state: DeploymentRequestPlatformState.Active,
+            actual_state: DeploymentRequestPlatformState.Provisioning,
             start_date: new Date(2025, 1, 3),
             end_date: new Date(2025, 2, 3),
             platform_id: 'fake product instance id',
@@ -113,7 +113,7 @@ describe('Deployment app', () => {
         type: DeploymentRequestDeploymentType.Trial,
         hub_status: DeploymentRequestHubStatus.Pending,
         target_state: DeploymentRequestPlatformState.Active,
-        actual_state: DeploymentRequestPlatformState.Active,
+        actual_state: DeploymentRequestPlatformState.Provisioning,
         start_date: new Date(2025, 1, 3),
         end_date: new Date(2025, 2, 3),
         platform_id: 'fake product instance id',
@@ -125,7 +125,7 @@ describe('Deployment app', () => {
         requester_last_name: 'lastname',
       });
     });
-    it('should return an error when hub status transition is not allowed', async () => {
+    it('should return an error when status transition is not allowed', async () => {
       const initialDeploymentData = {
         activity_sector: 'cybersecurity',
         job_title: 'myJob',
@@ -140,12 +140,13 @@ describe('Deployment app', () => {
       );
       const updates = {
         id: initialDeployment.id,
-        hub_status: DeploymentRequestHubStatus.Expired,
+        actual_state: DeploymentRequestPlatformState.Removed,
       };
 
       const call = resolver.Mutation.updateDeploymentRequest(undefined, {
         input: updates,
       });
+
       await expect(call).rejects.toThrow(
         ErrorCode.DeploymentRequestStatusUpdateNotAllowed
       );

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -283,11 +283,11 @@ enum DeploymentRequestHubStatus {
 }
 
 enum DeploymentRequestPlatformState {
+  unprovisioned
   provisioning
   active
   removing
   removed
-  inactive
 }
 
 type DeploymentRequest implements Node {
@@ -345,7 +345,6 @@ input CreateDeploymentRequestInput {
 
 input UpdateDeploymentRequestInput {
   id: ID!
-  hub_status: DeploymentRequestHubStatus
   start_date: Date
   end_date: Date
   platform_id: String


### PR DESCRIPTION
# Context
We need to compute hub_status based on actual_state. 
hub_status should not be updatable by the endpoint
inactive state is replaced by unprovisioned

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
Test updateDeploymentRequest works as defined.

## Related issues

- Related to #1364

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.