### PR TITLE
[backend] chore: set correct versions for refrehs connectivity not found feature

### DIFF
--- a/apps/portal-api/src/utils/required-platform-version.ts
+++ b/apps/portal-api/src/utils/required-platform-version.ts
@@ -5,8 +5,7 @@ export const RequiredPlatformVersions: Record<
   Record<PlatformIdentifier, string>
 > = {
   RefreshConnectivityStatusSendsNotFound: {
-    // TODO: change it for the updated versions
-    [PlatformIdentifier.Opencti]: '6.9.0',
-    [PlatformIdentifier.Openaev]: '2.1.0',
+    [PlatformIdentifier.Opencti]: '6.8.16',
+    [PlatformIdentifier.Openaev]: '2.0.6',
   },
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Set the right versions for compatibility with OpenCTI and OpenAEV, fetching `not_found` refresh connectivity status. 

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #1286 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.