### PR TITLE
[backend] - fix(freeTrials): set unprovisioned target_status when cancelled trial is queued #1392

### DIFF
--- a/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
@@ -906,18 +906,24 @@ describe('Deployment app', () => {
   });
   describe('cancelDeploymentRequest', () => {
     it.each`
-      isAdmin  | hub_status                                 | actual_state                                    | counts_in_orga_quota
-      ${false} | ${DeploymentRequestHubStatus.Provisioning} | ${DeploymentRequestPlatformState.Provisioning}  | ${false}
-      ${false} | ${DeploymentRequestHubStatus.Pending}      | ${DeploymentRequestPlatformState.Unprovisioned} | ${false}
-      ${false} | ${DeploymentRequestHubStatus.Queued}       | ${DeploymentRequestPlatformState.Unprovisioned} | ${false}
-      ${false} | ${DeploymentRequestHubStatus.Active}       | ${DeploymentRequestPlatformState.Active}        | ${true}
-      ${true}  | ${DeploymentRequestHubStatus.Provisioning} | ${DeploymentRequestPlatformState.Provisioning}  | ${true}
-      ${true}  | ${DeploymentRequestHubStatus.Pending}      | ${DeploymentRequestPlatformState.Unprovisioned} | ${true}
-      ${true}  | ${DeploymentRequestHubStatus.Queued}       | ${DeploymentRequestPlatformState.Unprovisioned} | ${true}
-      ${true}  | ${DeploymentRequestHubStatus.Active}       | ${DeploymentRequestPlatformState.Active}        | ${true}
+      isAdmin  | hub_status                                 | actual_state                                    | counts_in_orga_quota | target_state
+      ${false} | ${DeploymentRequestHubStatus.Provisioning} | ${DeploymentRequestPlatformState.Provisioning}  | ${false}             | ${DeploymentRequestPlatformState.Removed}
+      ${false} | ${DeploymentRequestHubStatus.Pending}      | ${DeploymentRequestPlatformState.Unprovisioned} | ${false}             | ${DeploymentRequestPlatformState.Unprovisioned}
+      ${false} | ${DeploymentRequestHubStatus.Queued}       | ${DeploymentRequestPlatformState.Unprovisioned} | ${false}             | ${DeploymentRequestPlatformState.Unprovisioned}
+      ${false} | ${DeploymentRequestHubStatus.Active}       | ${DeploymentRequestPlatformState.Active}        | ${true}              | ${DeploymentRequestPlatformState.Removed}
+      ${true}  | ${DeploymentRequestHubStatus.Provisioning} | ${DeploymentRequestPlatformState.Provisioning}  | ${true}              | ${DeploymentRequestPlatformState.Removed}
+      ${true}  | ${DeploymentRequestHubStatus.Pending}      | ${DeploymentRequestPlatformState.Unprovisioned} | ${true}              | ${DeploymentRequestPlatformState.Unprovisioned}
+      ${true}  | ${DeploymentRequestHubStatus.Queued}       | ${DeploymentRequestPlatformState.Unprovisioned} | ${true}              | ${DeploymentRequestPlatformState.Unprovisioned}
+      ${true}  | ${DeploymentRequestHubStatus.Active}       | ${DeploymentRequestPlatformState.Active}        | ${true}              | ${DeploymentRequestPlatformState.Removed}
     `(
       'Should cancel deployment request actual state $actual_state, with counts_in_orga_quota: counts_in_orga_quota',
-      async ({ isAdmin, hub_status, actual_state, counts_in_orga_quota }) => {
+      async ({
+        isAdmin,
+        hub_status,
+        actual_state,
+        counts_in_orga_quota,
+        target_state,
+      }) => {
         const initialDeployment = (await insertOpenCtiDeploymentRequest({
           hub_status,
           actual_state,
@@ -930,7 +936,7 @@ describe('Deployment app', () => {
 
         expect(deployment).toMatchObject({
           hub_status: DeploymentRequestHubStatus.Cancelled,
-          target_state: DeploymentRequestPlatformState.Removed,
+          target_state: target_state,
           counts_in_orga_quota,
           cancellation_date: expect.any(Date),
           cancellation_user_id: ADMIN_USER_ID,

--- a/apps/portal-api/src/modules/services/deployments/deployments.app.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.ts
@@ -453,12 +453,18 @@ export const DeploymentsApp = {
         DeploymentRequestPlatformState.Provisioning,
       ].includes(deploymentRequest.actual_state);
 
+    const target_state =
+      deploymentRequest.actual_state ===
+      DeploymentRequestPlatformState.Unprovisioned
+        ? DeploymentRequestPlatformState.Unprovisioned
+        : DeploymentRequestPlatformState.Removed;
+
     await withTransaction(async () => {
       await DeploymentRequestDomain.updateDeploymentRequestById(
         deploymentRequestId,
         {
           hub_status: DeploymentRequestHubStatus.Cancelled,
-          target_state: DeploymentRequestPlatformState.Removed,
+          target_state: target_state,
           cancellation_date: new Date(),
           cancellation_user_id: user.id,
           counts_in_orga_quota: countsInOrgaQuota,


### PR DESCRIPTION

# Context
When a free trial in queued status is cancelled, the target_status set is 'removed'. However, it was never deployed on platform, so it should be 'unprovisioned'

## How to test
Cancel a trial in queued status. Check target_status is unprovisioned

## Related issues

- Related to #1392

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.