### PR TITLE
fix(freetrials): redirect to registration page when needed #1416

### DIFF
--- a/apps/portal-front/app/redirect/[identifier]/create-free-trial.graphql.ts
+++ b/apps/portal-front/app/redirect/[identifier]/create-free-trial.graphql.ts
@@ -10,6 +10,7 @@ const CreateFreeTrialRegisteredPlatformsStatusAndTypeQuery = graphql`
       deployment_request {
         type
         hub_status
+        counts_in_orga_quota
       }
     }
   }

--- a/apps/portal-front/app/redirect/[identifier]/create-free-trial.ts
+++ b/apps/portal-front/app/redirect/[identifier]/create-free-trial.ts
@@ -2,7 +2,6 @@ import { serverFetchGraphQL } from '@/relay/serverPortalApiFetch';
 import type { createFreeTrialRegisteredPlatformsStatusAndTypeQuery } from '@generated/createFreeTrialRegisteredPlatformsStatusAndTypeQuery.graphql';
 import CreateFreeTrialRegisteredPlatformsStatusAndTypeQuery from '@generated/createFreeTrialRegisteredPlatformsStatusAndTypeQuery.graphql';
 import { DeploymentRequestDeploymentTypeEnum } from '@generated/models/DeploymentRequestDeploymentType.enum';
-import { DeploymentRequestHubStatusEnum } from '@generated/models/DeploymentRequestHubStatus.enum';
 import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { RestrictionEnum } from '@generated/models/Restriction.enum';
@@ -48,19 +47,11 @@ export const redirectToCreateFreeTrial = async (request: NextRequest) => {
     const freeTrials = platforms.filter(
       (platform) =>
         platform.deployment_request?.type ===
-        DeploymentRequestDeploymentTypeEnum.TRIAL
+          DeploymentRequestDeploymentTypeEnum.TRIAL &&
+        platform.deployment_request.counts_in_orga_quota === true
     );
 
-    const isTrialStarted = [
-      DeploymentRequestHubStatusEnum.QUEUED,
-      DeploymentRequestHubStatusEnum.PENDING,
-      DeploymentRequestHubStatusEnum.ACTIVE,
-    ].includes(
-      freeTrials[0]?.deployment_request
-        ?.hub_status as DeploymentRequestHubStatusEnum
-    );
-
-    if (isTrialStarted) {
+    if (freeTrials.length > 0) {
       const instanceUrl = new URL(
         `/app/service/opencti_registration/${freeTrials[0]?.id}`,
         baseUrlFront
@@ -68,7 +59,7 @@ export const redirectToCreateFreeTrial = async (request: NextRequest) => {
       return NextResponse.redirect(instanceUrl);
     }
 
-    return NextResponse.redirect(`${freeTrialUrl}?openForm`);
+    return NextResponse.redirect(`${freeTrialUrl}?openForm=true`);
   } catch (error) {
     if ((error as Error).message === 'UNAUTHENTICATED') {
       return NextResponse.redirect(redirectionUrl);


### PR DESCRIPTION
# Context
create-free-trial redirection doesn't always redirect to the right page:
it redirects to the platform page only in case the trial is pending, active, or queued. It should redirect always if trial exist, unless it doesn't count in quota.

## How to test
- Test the create free trial redirection depending on the trial status: it should redirect to the platform page unless we can start a new trial

## Related issues

- Related to #1416

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.