### PR TITLE
[backend] fix: use global ids for service documents

### DIFF
--- a/apps/portal-api/src/modules/services/services.resolver.ts
+++ b/apps/portal-api/src/modules/services/services.resolver.ts
@@ -116,7 +116,20 @@ const resolvers: Resolvers = {
       );
     },
     serviceInstanceLinksByTags: async (_, { tags }) => {
-      return serviceInstanceApp.loadLinkServiceInstancesByTags(tags);
+      const services =
+        await serviceInstanceApp.loadLinkServiceInstancesByTags(tags);
+      return services.map((service: SeoServiceInstance) => ({
+        ...service,
+        ...(service.illustration_document_id && {
+          illustration_document_id: toGlobalId(
+            'Document',
+            service.illustration_document_id
+          ),
+        }),
+        ...(service.logo_document_id && {
+          logo_document_id: toGlobalId('Document', service.logo_document_id),
+        }),
+      }));
     },
     serviceInstanceById: async (_, { service_instance_id }, context) => {
       const serviceInstance = await serviceInstanceApp.loadServiceInstance(

--- a/apps/portal-front/src/components/service/trial-instances/public-try-opencti-callout.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/public-try-opencti-callout.tsx
@@ -9,7 +9,7 @@ export function PublicTryOpenCTICallout() {
   return (
     <Callout
       variant="destructive"
-      className="rounded-none from-blue to-turquoise-300 bg-gradient-to-r text-black justify-center uppercase">
+      className="rounded-none from-blue to-turquoise-300 bg-gradient-to-r text-black justify-center">
       <div>
         {t('Service.Trials.Explore')}
         <Link


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Use global ids for service pictures in links by tags query.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- go to free trial page
- service pictures must be displayed

## Related issues

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.