### PR TITLE
[frontend] fix(banners): make public free trial banner sticky, and rename callout to banner in code #1419 #1222

### DIFF
--- a/apps/portal-front/app/(application)/app/layout.tsx
+++ b/apps/portal-front/app/(application)/app/layout.tsx
@@ -5,12 +5,12 @@ import '../../../styles/globals.css';
 
 import serverPortalApiFetch from '@/relay/serverPortalApiFetch';
 
-import { AdminCallout } from '@/components/admin/admin-callout';
-import { TestEnvCallout } from '@/components/admin/test-env-callout';
+import { AdminBanner } from '@/components/admin/admin-banner';
+import { TestEnvBanner } from '@/components/admin/test-env-banner';
 import { ContentLayout } from '@/components/content-layout';
 import HeaderComponent from '@/components/header';
 import Menu from '@/components/menu/menu';
-import { TryOpenCTICallout } from '@/components/service/trial-instances/try-opencti-callout';
+import { TryOpenCTIBanner } from '@/components/service/trial-instances/try-opencti-banner';
 import { ErrorPage } from '@/components/ui/error-page';
 import { RelayProvider } from '@/relay/RelayProvider';
 import { meContext_fragment$data } from '@generated/meContext_fragment.graphql';
@@ -62,9 +62,9 @@ const RootLayout: FunctionComponent<RootLayoutProps> = async ({ children }) => {
         <div className="flex min-h-screen">
           <PageLoader>
             <div className="flex flex-col w-full h-screen">
-              <TestEnvCallout />
-              <AdminCallout />
-              <TryOpenCTICallout />
+              <TestEnvBanner />
+              <AdminBanner />
+              <TryOpenCTIBanner />
               <div className="flex flex-row flex-grow overflow-hidden">
                 <Menu />
                 <div className="flex flex-col w-full h-full overflow-auto">

--- a/apps/portal-front/app/(public)/layout.tsx
+++ b/apps/portal-front/app/(public)/layout.tsx
@@ -1,4 +1,4 @@
-import { PublicTryOpenCTICallout } from '@/components/service/trial-instances/public-try-opencti-callout';
+import { PublicTryOpenCTIBanner } from '@/components/service/trial-instances/public-try-opencti-banner';
 import { getDefaultMetadata } from '@/utils/generate-metadata';
 import { Button } from 'filigran-ui/servers';
 import 'filigran-ui/theme.css';
@@ -19,7 +19,7 @@ export default function RootLayout({
 }) {
   return (
     <div className="flex flex-col h-screen">
-      <PublicTryOpenCTICallout />
+      <PublicTryOpenCTIBanner />
       <header className="flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between sticky top-0 z-[20]">
         <Link href="/">
           <LogoXTMDark className="text-primary mr-2 w-[10rem] h-auto py-l" />

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -1,5 +1,5 @@
 {
-  "AdminCallout": "You are currently in admin mode.",
+  "AdminBanner": "You are currently in admin mode.",
   "App": {
     "Collapse": "Collapse",
     "CollapseSidebar": "Collapse sidebar",
@@ -808,7 +808,7 @@
   },
   "Sort Asc": "Sort Asc",
   "Sort Desc": "Sort Desc",
-  "TestEnvCallout": "You are viewing the {environnement} environment.",
+  "TestEnvBanner": "You are viewing the {environnement} environment.",
   "ThemeToggle": {
     "Automatic": "Automatic",
     "Dark": "Dark",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -1,5 +1,5 @@
 {
-  "AdminCallout": "Vous êtes actuellement en mode administrateur",
+  "AdminBanner": "Vous êtes actuellement en mode administrateur",
   "App": {
     "Collapse": "Réduire",
     "CollapseSidebar": "Réduire la sidebar",
@@ -808,7 +808,7 @@
   },
   "Sort Asc": "Tri Asc",
   "Sort Desc": "Sort Desc",
-  "TestEnvCallout": "Vous êtes sur l'environnement {environnement}",
+  "TestEnvBanner": "Vous êtes sur l'environnement {environnement}",
   "ThemeToggle": {
     "Automatic": "Automatique",
     "Dark": "Foncé",

--- a/apps/portal-front/src/components/admin/admin-banner.tsx
+++ b/apps/portal-front/src/components/admin/admin-banner.tsx
@@ -4,7 +4,7 @@ import { Callout } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
 import useAdminPath from '../../hooks/useAdminPath';
 
-export function AdminCallout() {
+export function AdminBanner() {
   const t = useTranslations();
   const isAdminPath = useAdminPath();
 
@@ -13,7 +13,7 @@ export function AdminCallout() {
       <Callout
         variant="warning"
         className="rounded-none text-black justify-center uppercase">
-        {t('AdminCallout')}
+        {t('AdminBanner')}
       </Callout>
     )
   );

--- a/apps/portal-front/src/components/admin/test-env-banner.tsx
+++ b/apps/portal-front/src/components/admin/test-env-banner.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useContext } from 'react';
 
-export function TestEnvCallout() {
+export function TestEnvBanner() {
   const t = useTranslations();
   const { settings } = useContext(SettingsContext);
 
@@ -17,7 +17,7 @@ export function TestEnvCallout() {
         variant="destructive"
         className="rounded-none text-black justify-center uppercase">
         <div className="">
-          {t('TestEnvCallout', {
+          {t('TestEnvBanner', {
             environnement: settings?.environment,
           })}
           <Link

--- a/apps/portal-front/src/components/login/login-layout.tsx
+++ b/apps/portal-front/src/components/login/login-layout.tsx
@@ -1,4 +1,4 @@
-import { TestEnvCallout } from '@/components/admin/test-env-callout';
+import { TestEnvBanner } from '@/components/admin/test-env-banner';
 import LoginForm from '@/components/login/login-form';
 import LoginMessage from '@/components/login/login-message';
 import LoginTitleForm from '@/components/login/login-title';
@@ -28,7 +28,7 @@ export const LoginLayout: FunctionComponent = ({}) => {
   }, [currentPath]);
   return (
     <main className="absolute inset-0 z-0 m-auto flex max-w-[450px] flex-col justify-center">
-      <TestEnvCallout />
+      <TestEnvBanner />
       <div className="flex flex-col items-center p-xl sm:p-0">
         <LoginTitleForm />
         <div className="space-y-l mt-l w-full flex flex-col items-center">

--- a/apps/portal-front/src/components/service/trial-instances/public-try-opencti-banner.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/public-try-opencti-banner.tsx
@@ -3,7 +3,7 @@ import { Callout } from 'filigran-ui';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
-export function PublicTryOpenCTICallout() {
+export function PublicTryOpenCTIBanner() {
   const t = useTranslations();
 
   return (

--- a/apps/portal-front/src/components/service/trial-instances/try-opencti-banner.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/try-opencti-banner.tsx
@@ -18,7 +18,7 @@ import { useContext } from 'react';
 import { ContactUsButton } from './contact-us-button';
 
 // Component
-export const TryOpenCTICallout = () => {
+export const TryOpenCTIBanner = () => {
   const t = useTranslations();
   const { settings } = useContext(SettingsContext);
 


### PR DESCRIPTION
# Context
- public free trial banner should be sticky.
- Callout is not clear, let's call it banner in the code

## How to test
- test free trial banner on public page is sticky
- test there is no regression on banners

## Related issues

- Related to #1419 
- Related to #1222 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.