### PR TITLE
[frontend] fix(labels): change sorting order from descending to ascending

### DIFF
--- a/apps/portal-front/src/components/admin/label/label.utils.ts
+++ b/apps/portal-front/src/components/admin/label/label.utils.ts
@@ -15,7 +15,7 @@ import {
 export const getLabels = (documentType?: string) => {
   const queryData = useLazyLoadQuery<labelListQuery>(
     LabelListQuery,
-    { count: 500, orderBy: 'name', orderMode: 'desc', documentType },
+    { count: 500, orderBy: 'name', orderMode: 'asc', documentType },
     { fetchPolicy: 'network-only' }
   );
   const [data] = useRefetchableFragment<labelListQuery, labelList_labels$key>(

--- a/apps/portal-front/src/components/admin/label/labels.tsx
+++ b/apps/portal-front/src/components/admin/label/labels.tsx
@@ -27,7 +27,7 @@ const Labels = () => {
   const t = useTranslations();
   const queryData = useLazyLoadQuery<labelListQuery>(LabelListQuery, {
     count: 100,
-    orderMode: 'desc',
+    orderMode: 'asc',
     orderBy: 'name',
   });
 


### PR DESCRIPTION
# Context

This PR fixes the label sorting order in the admin label management interface. Labels were previously sorted in descending order (Z to A), which is counter-intuitive for users. They are now sorted in ascending order (A to Z) for better user experience.

**Changes:**
- Updated label sorting order from `desc` to `asc` in `label.utils.ts` (getLabels function)
- Updated label sorting order from `desc` to `asc` in `labels.tsx` (Labels component)

## How to test

1. Navigate to the admin label management section
2. Verify that labels are displayed in alphabetical order (A to Z)
3. Check both the main labels list and any label selection dropdowns
4. Confirm the sorting is consistent across the interface

**Expected result:** Labels should be displayed alphabetically from A to Z.

## Related issues

- Related to #1452

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests