### PR TITLE
[frontend] feat(trials): improve cancellation info display with tooltip and unified date format

### DIFF
--- a/apps/portal-front/src/components/trials/tab/trials-tab.tsx
+++ b/apps/portal-front/src/components/trials/tab/trials-tab.tsx
@@ -287,10 +287,7 @@ const TrialsTab: FunctionComponent<TrialsTabProps> = ({ type }) => {
                 return (
                   <span className="truncate">
                     {row.original.cancellation_date
-                      ? formatDate(
-                          row.original.cancellation_date,
-                          'DATETIME_NUMERIC'
-                        )
+                      ? formatDate(row.original.cancellation_date, 'DATE_FULL')
                       : '-'}
                   </span>
                 );
@@ -305,6 +302,24 @@ const TrialsTab: FunctionComponent<TrialsTabProps> = ({ type }) => {
               header: t('TrialsDashboard.Columns.CancellationReason'),
               accessorKey: 'cancellation_reason',
               id: 'cancellation_reason',
+              cell: ({ row }: { row: { original: trials_fragment$data } }) => {
+                const reason = row.original.cancellation_reason;
+                if (!reason) return <span>-</span>;
+                return (
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="truncate block cursor-help">
+                          {reason}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="bg-gray-50 max-w-md">
+                        {reason}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                );
+              },
             },
           ]
         : []),


### PR DESCRIPTION
# Context

This PR improves the UX of the trials dashboard, specifically for the "Cancelled" trials tab, by enhancing the display of cancellation information and unifying date formats across the interface.

## How to test

1. Navigate to the Trials Dashboard
2. Switch to the **"Cancelled"** tab
3. Verify that the `Cancellation Date` column displays dates in the same format as `Start Date` and `End Date` (e.g., "Jan 15, 2026" instead of "2026-01-15 14:30:00")
4. Locate a trial with a cancellation reason
5. Hover over the cancellation reason text:
   - [ ] The cursor should change to a help cursor (question mark)
   - [ ] A tooltip should appear quickly (~200ms)
   - [ ] The tooltip should display the full cancellation reason text
   - [ ] Long text should wrap within the tooltip (max-width constraint)

### Expected behavior
- Dates are consistent across all date columns
- Cancellation reasons are easily readable without horizontal scrolling
- Tooltip provides full context for truncated cancellation reasons

## Related issues

- Related to #1466

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests