### PR TITLE
[frontend] - (subscriptionModal) Rework wording #890

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -708,7 +708,7 @@
     "SubscribeService": "Subscribe to {serviceName} service",
     "SubscribeSuccessful": "You have successfully subscribed to the service. You can now find it in your subscribed services.",
     "SubscriptionRequestSuccessful": "Your request has been sent. You will soon be in touch with our team.",
-    "SureWantSubscriptionDirect": "Do you want to subscribe to the {serviceName} service ? This service is free and gives you access to resources built carefully by the Filigran Team.",
+    "SureWantSubscriptionDirect": "Get started with our free {serviceName} service and explore resources created by the Filigran team.",
     "SureWantSubscriptionUndirect": "You are going to be contacted by our commercial team to subscribe this service. Do you want to continue?",
     "Trials": {
       "Explore": "Explore the full potential of OpenCTI Enterprise Edition, start your 30 days free trial.",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -708,7 +708,7 @@
     "SubscribeService": "Souscrire au service {serviceName}",
     "SubscribeSuccessful": "Vous avez souscrit au service. Vous pouvez maintenant le retrouver dans les services souscrits !",
     "SubscriptionRequestSuccessful": "Votre requête a été envoyée. Vous serez bientôt contacté par notre équipe.",
-    "SureWantSubscriptionDirect": "Voulez-vous souscrire au service {serviceName} ? Ce service est gratuit et vous donne accès aux ressources créées par l'équipe Filigran.",
+    "SureWantSubscriptionDirect": "Commencez avec notre service gratuit {serviceName} et explorez les ressources créées par l'équipe Filigran.",
     "SureWantSubscriptionUndirect": "Vous allez être contacté par notre équipe commerciale pour souscrire au service. Voulez-vous continuer ?",
     "Trials": {
       "Explore": "Explorez tout le potentiel d'OpenCTI Enterprise Edition, commencez votre essai gratuit de 30 jours.",


### PR DESCRIPTION
# Context
> Change wording for subscriptions modals

## How to test
Subscribe to a service. You should see the new wording. 

## Related issues

- Related to #890 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests
