### PR TITLE
[frontend] add region placeholder in Start a trial form

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -749,8 +749,11 @@
         "RegionPlaceholder": "Please select your preferred region for hosting",
         "AssociatedEmail": "Associated Email",
         "JobTitle": "Job title",
+        "JobTitlePlaceholder": "Please select your job title",
         "ActivitySector": "Activity sector",
+        "ActivitySectorPlaceholder": "Please select your activity sector",
         "UseCase": "Use case",
+        "UseCasePlaceholder": "Please select your use case",
         "MSSA": "MSSA",
         "MSSAAgreement": "I acknowledge that I have read, understand and agree to the trial terms of",
         "FormRequested": "You have requested a free trial. You will receive an email as soon as the platform is ready!"

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -749,8 +749,11 @@
         "RegionPlaceholder": "Veuillez sélectionner votre région préférée pour l'hébergement",
         "AssociatedEmail": "Email associé",
         "JobTitle": "Titre du poste",
+        "JobTitlePlaceholder": "Veuillez sélectionner votre titre de poste",
         "ActivitySector": "Secteur d'activité",
+        "ActivitySectorPlaceholder": "Veuillez sélectionner votre secteur d'activité",
         "UseCase": "Cas d'utilisation",
+        "UseCasePlaceholder": "Veuillez sélectionner votre cas d'utilisation",
         "MSSA": "MSSA",
         "MSSAAgreement": "*Je reconnais avoir lu, compris et accepté les conditions du procès de",
         "FormRequested": "Vous avez demandé un essai gratuit. Vous recevrez un e-mail dès que la plateforme sera prête !"

--- a/apps/portal-front/src/components/service/trial-instances/try-opencti-form.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/try-opencti-form.tsx
@@ -129,12 +129,21 @@ export const TryOpenCTIForm: FunctionComponent<TryOpenCTIFormProps> = ({
             },
             job_title: {
               label: t('Service.Trials.Form.JobTitle'),
+              inputProps: {
+                placeholder: t('Service.Trials.Form.JobTitlePlaceholder'),
+              },
             },
             activity_sector: {
               label: t('Service.Trials.Form.ActivitySector'),
+              inputProps: {
+                placeholder: t('Service.Trials.Form.ActivitySectorPlaceholder'),
+              },
             },
             use_case: {
               label: t('Service.Trials.Form.UseCase'),
+              inputProps: {
+                placeholder: t('Service.Trials.Form.UseCasePlaceholder'),
+              },
             },
             acceptTerms: {
               fieldType: ({ field }) => (


### PR DESCRIPTION
# Context
This pull request adds placeholder texts to selection fields in the trial instance form. 

<img width="1220" height="645" alt="Capture d’écran 2026-01-13 à 10 18 37" src="https://github.com/user-attachments/assets/1cb4a0d8-998d-4f84-a8a2-15dbd0ed4fad" />

## How to test
> Open the Start a trial form and look at the placeholder

## Related issues

- Related to #1481
