### PR TITLE
[frontend] styles(user-form): remove primary border on organization cards

### DIFF
--- a/apps/portal-front/src/components/admin/user/forms/admin/admin-user-update-form.tsx
+++ b/apps/portal-front/src/components/admin/user/forms/admin/admin-user-update-form.tsx
@@ -199,7 +199,7 @@ export const AdminUserUpdateForm: FunctionComponent<
         <div
           className={cn(
             '!mt-m px-l py-m space-y-s',
-            fields.length > 0 && 'border border-primary rounded'
+            fields.length > 0 && 'border bg-card rounded'
           )}>
           {fields.map((field, index) => {
             return (

--- a/apps/portal-front/src/components/admin/user/forms/admin/user-admin-form.tsx
+++ b/apps/portal-front/src/components/admin/user/forms/admin/user-admin-form.tsx
@@ -164,7 +164,7 @@ export const UserAdminForm: FunctionComponent<UserAdminFormProps> = ({
         <div
           className={cn(
             '!mt-m px-l py-s space-y-s',
-            fields.length > 0 && 'border border-primary rounded'
+            fields.length > 0 && 'border bg-card rounded'
           )}>
           {fields.map((field, index) => {
             return (


### PR DESCRIPTION
# Context

## Before :

<img width="643" height="816" alt="Image" src="https://github.com/user-attachments/assets/077993b1-b7a5-41ee-ae57-0dd5522910c4" />

## After :

<img width="810" height="915" alt="Capture d’écran 2026-01-13 à 10 36 23" src="https://github.com/user-attachments/assets/9a0e6132-bdd2-44db-ab6a-a8ff28a30951" />


## How to test
1. Go to the user list in the admin  (/app/admin/user)
2. Click on Add user
3. Check styles

## Related issues

- Related to #893
