### PR TITLE
[frontend] feat: display integration type and subtype on details pages

### DIFF
--- a/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/seo-integration.graphql.ts
+++ b/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/seo-integration.graphql.ts
@@ -28,6 +28,16 @@ export const SeoIntegrationFragment = graphql`
     active
     type
     integration_type
+
+    ... on Connector {
+      integration_subtype
+    }
+    ... on Stream {
+      integration_subtype
+    }
+    ... on TaxiiFeed {
+      integration_subtype
+    }
   }
 `;
 

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -497,7 +497,6 @@
       "LastVerifiedDate": "Last verified at",
       "Name": "OpenCTI Connectors",
       "Search": "Search a connector with name...",
-      "Type": "Type",
       "VendorContact": "Vendor Contact",
       "VisitVendor": "Visit the vendor's page to learn more and get in touch",
       "Incompatible": "{platformToBeUpdated} {count, plural, =1 {needs} other {need}} to be updated to deploy this connector.",
@@ -775,7 +774,9 @@
         "LastUpdatedAt": "Last updated at",
         "Overview": "Overview",
         "ProductVersion": "Product minimum version",
-        "Shares": "Shares"
+        "Shares": "Shares",
+        "IntegrationType": "Type",
+        "IntegrationSubType": "Subtype"
       },
       "Download": "Download",
       "FromVersion": "From version",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -497,7 +497,6 @@
       "LastVerifiedDate": "Dernière vérification",
       "Name": "Connecteurs OpenCTI",
       "Search": "Rechercher un connecteur par nom...",
-      "Type": "Type",
       "VendorContact": "Contact vendeur",
       "VisitVendor": "Visitez la page web du vendeur pour en savoir plus et rester en contact",
       "Incompatible": "{platformToBeUpdated} {count, plural, =1 {doit} other {doivent}} être mises à jour pour déployer ce connecteur.",
@@ -775,7 +774,9 @@
         "LastUpdatedAt": "Dernière mise à jour le",
         "Overview": "Vue d'ensemble",
         "ProductVersion": "Version minimale du produit",
-        "Shares": "Actions"
+        "Shares": "Actions",
+        "IntegrationType": "Type",
+        "IntegrationSubType": "Sous-type"
       },
       "Download": "Télécharger",
       "FromVersion": "Depuis la version",

--- a/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-details.tsx
+++ b/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-details.tsx
@@ -14,6 +14,7 @@ export interface ShareableResourceConnectorDetailsProps {
     name: string;
     source_code?: string | null;
     subscription_link?: string | null;
+    integration_type?: string | null;
     integration_subtype?: string | null;
     product_version?: string;
     share_number?: number | null;
@@ -66,8 +67,21 @@ export const ShareableResourceConnectorDetails: FunctionComponent<
           </Button>
         </ShareableResourceDetailItem>
       )}
+      {connectorDetails.integration_type && (
+        <ShareableResourceDetailItem
+          label={t('Service.ShareableResources.Details.IntegrationType')}>
+          <div className="flex items-center gap-s">
+            <span>
+              {t(
+                `Service.OpenctiIntegrations.Type.${connectorDetails.integration_type}`
+              )}
+            </span>
+          </div>
+        </ShareableResourceDetailItem>
+      )}
       {connectorMetadata && (
-        <ShareableResourceDetailItem label={t('Service.Connectors.Type')}>
+        <ShareableResourceDetailItem
+          label={t('Service.ShareableResources.Details.IntegrationSubType')}>
           <span>
             <Badge
               className="mr-auto"

--- a/apps/portal-front/src/components/service/document/shareable-resouce-details.tsx
+++ b/apps/portal-front/src/components/service/document/shareable-resouce-details.tsx
@@ -6,11 +6,17 @@ import { Avatar } from '@filigran/ui/clients';
 
 import { ShareableResourceBasicInformation } from '@/components/service/document/ui/shareable-resource-basic-information';
 import { ShareableResourceDetailItem } from '@/components/service/document/ui/shareable-resource-detail-item';
+import { getIntegrationSubTypeMetadata } from '@/components/service/integrations/integration.utils';
 import { roundToNearest } from '@/lib/utils';
 import { formatPersonNames } from '@/utils/format/name';
-import { ShareableResource } from '@/utils/shareable-resources/shareable-resources.types';
+import {
+  isIntegrationItem,
+  ShareableResource,
+} from '@/utils/shareable-resources/shareable-resources.types';
 import { docHasMetadata } from '@/utils/shareable-resources/utils/shareable-resources.client.utils';
+import { Badge } from '@filigran/ui/servers';
 import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 
 // Component interface
 interface ShareableResourceDetailsProps {
@@ -22,6 +28,15 @@ const ShareableResourceDetails: React.FunctionComponent<
   ShareableResourceDetailsProps
 > = ({ documentData, downloadNumber }) => {
   const t = useTranslations();
+  const isIntegration = isIntegrationItem(documentData);
+  const integrationSubTypeMetadata = useMemo(() => {
+    if (!isIntegration) {
+      return null;
+    }
+
+    return getIntegrationSubTypeMetadata(documentData.integration_subtype);
+  }, [isIntegration, documentData]);
+
   return (
     <ShareableResourceBasicInformation>
       {!documentData.uploader_organization?.personal_space && (
@@ -45,6 +60,35 @@ const ShareableResourceDetails: React.FunctionComponent<
           <span>{formatPersonNames(documentData.uploader)}</span>
         </div>
       </ShareableResourceDetailItem>
+      {isIntegration && (
+        <>
+          <ShareableResourceDetailItem
+            label={t('Service.ShareableResources.Details.IntegrationType')}>
+            <div className="flex items-center gap-s">
+              <span>
+                {t(
+                  `Service.OpenctiIntegrations.Type.${documentData.integration_type}`
+                )}
+              </span>
+            </div>
+          </ShareableResourceDetailItem>
+          {integrationSubTypeMetadata && (
+            <ShareableResourceDetailItem
+              label={t(
+                'Service.ShareableResources.Details.IntegrationSubType'
+              )}>
+              <span>
+                <Badge
+                  className="mr-auto"
+                  variant="outline"
+                  color={integrationSubTypeMetadata.color}>
+                  {integrationSubTypeMetadata.label}
+                </Badge>
+              </span>
+            </ShareableResourceDetailItem>
+          )}
+        </>
+      )}
       <ShareableResourceDetailItem
         label={t('Service.ShareableResources.Details.LastUpdatedAt')}>
         <span>


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Display integration type and subtype on generic details pages for connectors and other types of integration on public and private pages.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- load connectors
- check details pages for each type (Connectors, CSV Feeds, TAXII Feeds, Streams)
  - integration type is displayed
  - integration subtype is displayed with a badge

## Related issues

- Related to #1509 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.