### PR TITLE
[frontend] fix(markdown): align styles between public and private pages

### DIFF
--- a/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
+++ b/apps/portal-front/app/(public)/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
@@ -286,7 +286,7 @@ const Page = async ({
             </h3>
             <section className="border rounded border-border-light bg-page-background">
               <h2 className="p-l">{document?.short_description}</h2>
-              <div className="p-l !bg-page-background">
+              <div className="p-l !bg-page-background markdown-content">
                 <MarkdownAsync>{document?.description ?? ''}</MarkdownAsync>
               </div>
             </section>

--- a/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-slug-public.tsx
+++ b/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-slug-public.tsx
@@ -77,7 +77,7 @@ const ShareableResourceConnectorSlugPublic: React.FunctionComponent<
           </h3>
           <section className="border rounded border-border-light bg-page-background">
             <h2 className="p-l">{documentData?.short_description}</h2>
-            <div className="p-l !bg-page-background">
+            <div className="p-l !bg-page-background markdown-content">
               <MarkdownAsync>{documentData?.description ?? ''}</MarkdownAsync>
             </div>
           </section>

--- a/apps/portal-front/styles/globals.css
+++ b/apps/portal-front/styles/globals.css
@@ -31,16 +31,104 @@
   }
 
   ol {
-      @apply list-decimal pl-8;
+    @apply list-decimal pl-8;
   }
 }
 
-.wmde-markdown {
+.wmde-markdown,
+.markdown-content {
   ul {
     list-style-type: disc;
   }
   ol {
     list-style-type: decimal;
+  }
+}
+
+.markdown-content {
+  line-height: 1.6;
+  word-wrap: break-word;
+
+  h1 {
+    @apply mb-4 mt-6 border-b border-border pb-2 text-2xl font-semibold;
+  }
+  h2 {
+    @apply mb-3 mt-5 border-b border-border pb-2 text-xl font-semibold;
+  }
+  h3 {
+    @apply mb-2 mt-4 text-lg font-semibold;
+  }
+  h4,
+  h5,
+  h6 {
+    @apply mb-2 mt-3 text-base font-semibold;
+  }
+
+  p {
+    @apply my-3;
+  }
+
+  a {
+    @apply text-primary underline hover:no-underline;
+  }
+
+  ul,
+  ol {
+    @apply my-3 pl-8;
+  }
+  ul {
+    @apply list-disc;
+  }
+  ol {
+    @apply list-decimal;
+  }
+  li {
+    @apply my-1;
+  }
+  li > ul,
+  li > ol {
+    @apply my-1;
+  }
+
+  blockquote {
+    @apply my-3 border-l-4 border-border pl-4 italic text-muted-foreground;
+  }
+
+  code:not(pre code) {
+    @apply rounded bg-muted px-1.5 py-0.5 font-mono text-sm;
+  }
+
+  pre {
+    @apply my-3 overflow-x-auto rounded-md bg-muted p-4;
+  }
+  pre code {
+    @apply bg-transparent p-0 font-mono text-sm;
+  }
+
+  hr {
+    @apply my-6 border-t border-border;
+  }
+
+  table {
+    @apply my-3 w-full border-collapse;
+  }
+  th,
+  td {
+    @apply border border-border px-3 py-2 text-left;
+  }
+  th {
+    @apply bg-muted font-semibold;
+  }
+
+  img {
+    @apply my-3 h-auto max-w-full rounded;
+  }
+
+  strong {
+    @apply font-semibold;
+  }
+  em {
+    @apply italic;
   }
 }
 


### PR DESCRIPTION
# Context

Public pages (SSR) use `MarkdownAsync` from `react-markdown` for SEO purposes, while private pages use `MDEditor.Markdown` from `@uiw/react-md-editor`. 
The issue was that `react-markdown` doesn't provide default CSS styles, resulting in raw HTML output without proper formatting (headings, lists, links, etc.).

**Solution:** Added a `.markdown-content` CSS class in `globals.css` with markdown styles (headings, lists, links, code, blockquotes, tables, etc.) and applied this class to `MarkdownAsync` wrappers in public pages.

## How to test

1. Navigate to a public document page (e.g. `/cybersecurity-solutions/open-aev-scenarios/easm-scenario`)
2. Verify that markdown is properly rendered with styles (headings, lists, links, code, etc.)
3. Compare with the equivalent private page rendering (e.g. `/app/service/openaev_scenarios/U2VydmljZUluc3RhbmNlOjhjYzdlNzlkLWYzYTQtNDA2Yi1iYzdjLWIzZDY0ZjhjYzVjMQ==/RG9jdW1lbnQ6N2VmZmVhYzYtODkzOS00MzE2LTgyNzgtNmFkYmU1YzVkY2I4`)
4. Both should have consistent visual rendering

## Related issues

- Related to #1526
