### PR TITLE
[backend] fix(mails): add missing /app prefix in service email link

### DIFF
--- a/apps/portal-api/src/server/mail-service.ts
+++ b/apps/portal-api/src/server/mail-service.ts
@@ -22,7 +22,7 @@ export const buildServiceLink = ({
   serviceDefinitionIdentifier: string;
   serviceInstanceId: string;
 }) => {
-  return `${config.get('base_url_front')}/service/${serviceDefinitionIdentifier}/${toGlobalId('ServiceInstance', serviceInstanceId)}`;
+  return `${config.get('base_url_front')}/app/service/${serviceDefinitionIdentifier}/${toGlobalId('ServiceInstance', serviceInstanceId)}`;
 };
 
 export async function renderEmail<T extends keyof MailTemplates>(


### PR DESCRIPTION
# Context
This PR makes a small update to the `buildServiceLink` function in `mail-service.ts` to change the URL path for generated service links. The change ensures that service links now include `/app/` in the path, which aligns with the updated frontend routing.

Related to #1540 
