### PR TITLE
fix(pendingUsers): don't add filigran users to pending users #1543

### DIFF
--- a/apps/portal-api/src/auth/auth-user.ts
+++ b/apps/portal-api/src/auth/auth-user.ts
@@ -3,7 +3,7 @@ import { UserInfo } from '../model/user';
 import { removeAllUserRolePortal } from '../modules/role-portal/role-portal.domain';
 import { loadUserBy, updateUserAtLogin } from '../modules/users/users.domain';
 import { getOrCreateUser } from '../modules/users/users.helper';
-import { PLATFORM_ORGANIZATION_UUID, ROLE_ADMIN } from '../portal.const';
+import { PLATFORM_ORGANIZATION_UUID } from '../portal.const';
 import {
   addRoleToUser,
   ensureUserOrganizationExist,
@@ -18,14 +18,14 @@ export const loginFromProvider = async (userInfo: UserInfo) => {
   if (isEmptyField(email)) {
     throw ForbiddenAccess('User email not provided');
   }
-  const isAdminFiligran = userInfo.roles.includes(ROLE_ADMIN.name);
+  const isFiligranUser = email.endsWith('@filigran.io');
 
-  const user = await getOrCreateUser(userInfo, true, isAdminFiligran);
+  const user = await getOrCreateUser(userInfo, true, isFiligranUser);
   if (user.disabled) {
     throw ForbiddenAccess('You are not allowed to log in');
   }
   // Check if the user has the admin role, so in creation we create user then add admin role
-  if (email.endsWith('@filigran.io')) {
+  if (isFiligranUser) {
     await ensureUserOrganizationExist(user.id, PLATFORM_ORGANIZATION_UUID);
     await removeAllUserRolePortal(user.id);
     if (userInfo.roles.length > 0) {

--- a/apps/portal-api/src/modules/users/users.helper.ts
+++ b/apps/portal-api/src/modules/users/users.helper.ts
@@ -172,13 +172,13 @@ export const createNewUserFromInvitation = async (
     last_name,
     picture,
   }: Pick<UserInitializer, 'email' | 'first_name' | 'last_name' | 'picture'>,
-  isAdminFiligran: boolean = false
+  isFiligranUser: boolean = false
 ) => {
   const [organization] = await loadOrganizationsFromEmail(email);
   let userWithRoles: User;
   if (!organization) {
     userWithRoles = await createOrganisationWithAdminUser(email);
-  } else if (isAdminFiligran) {
+  } else if (isFiligranUser) {
     userWithRoles = await createUserWithPersonalSpace({
       email,
       last_name,
@@ -206,7 +206,7 @@ export const getOrCreateUser = async (
     'email' | 'first_name' | 'last_name' | 'picture'
   >,
   upsert = false,
-  isAdminFiligran = false
+  isFiligranUser = false
 ) => {
   const user = await loadUserBy({ email: userInfo.email });
   if (user && upsert) {
@@ -225,7 +225,7 @@ export const getOrCreateUser = async (
   }
   return user
     ? user
-    : await createNewUserFromInvitation(userInfo, isAdminFiligran);
+    : await createNewUserFromInvitation(userInfo, isFiligranUser);
 };
 
 export const insertUserIntoOrganization = async (


### PR DESCRIPTION
# Context
Filigran users are already added to the orga when logging, so they should not be added to the pending orga

## How to test
login with SSO as a user without BYPASS capability. you should be added to filigran orga, but not as pending user.

## Related issues

- Related to #1543

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.