### PR TITLE
fix(selected filters): validate filters in local storage

### DIFF
--- a/apps/portal-front/src/components/service/components/use-service-list-local-storage.ts
+++ b/apps/portal-front/src/components/service/components/use-service-list-local-storage.ts
@@ -8,6 +8,22 @@ export enum ServiceListLocalStorageKey {
   OpenAEVScenarios = 'OpenAEVScenarios',
 }
 
+const deserializeSelectedFilters = (stored: string): ServiceListFilterKey[] => {
+  try {
+    const parsed = JSON.parse(stored);
+
+    if (!Array.isArray(parsed)) return [];
+
+    const validValues = Object.values(ServiceListFilterKey);
+
+    return parsed.filter((item): item is ServiceListFilterKey =>
+      validValues.includes(item)
+    );
+  } catch {
+    return [];
+  }
+};
+
 export const useServiceListLocalStorage = (
   serviceName: ServiceListLocalStorageKey
 ) => {
@@ -27,7 +43,10 @@ export const useServiceListLocalStorage = (
   const [selectedFilters, setSelectedFilters, removeSelectedFilters] =
     useLocalStorage<ServiceListFilterKey[]>(
       `selectedFilters${serviceName}List`,
-      []
+      [],
+      {
+        deserializer: deserializeSelectedFilters,
+      }
     );
 
   const [integrationTypes, setIntegrationTypes, removeIntegrationTypes] =


### PR DESCRIPTION
# Context
selected filters in local storage can contain old filter value, leading to invalid rendering of the selected filters (starting with AND)

## How to test
- in devtools, add an invalid value in the integration filters local storage. 
- Check rendering of the filters is correct on integrations page (and that this invalid value disappears from the local storage)

## Related issues

- Related to #issueNumber

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.