### PR TITLE
[backend/frontend] fix(integrations-library): filter platforms to only show active trials (#1567)

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1536,6 +1536,7 @@ export type RegisteredPlatformInput = {
 
 export type RegisteredPlatformsInput = {
   identifier?: InputMaybe<PlatformIdentifier>;
+  onlyActiveTrials?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type RegistrationResponse = {

--- a/apps/portal-api/src/modules/services/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.ts
@@ -122,6 +122,7 @@ export const registrationApp = {
   ): Promise<RegisteredPlatform[]> => {
     const platforms = await registrationDomain.loadRegisteredPlatforms({
       platformIdentifier: input?.identifier,
+      onlyActiveTrials: input?.onlyActiveTrials ?? false,
     });
 
     return platforms.map(mapDomainRegisteredPlatformToGraphQL);

--- a/apps/portal-api/src/modules/services/registration/registration.domain.test.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.domain.test.ts
@@ -4,12 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '../../../../knexfile';
 import { contextAdminUser } from '../../../../tests/tests.const';
 import {
+  DeploymentRequestDeploymentType,
+  DeploymentRequestHubStatus,
+  DeploymentRequestPlatformRegion,
   PlatformContract,
   PlatformIdentifier,
   ServiceConfigurationStatus,
   ServiceDefinitionIdentifier,
   ServiceInstanceCreationStatus,
 } from '../../../__generated__/resolvers-types';
+import DeploymentRequest from '../../../model/kanel/public/DeploymentRequest';
 import { OrganizationId } from '../../../model/kanel/public/Organization';
 import ServiceConfiguration from '../../../model/kanel/public/ServiceConfiguration';
 import ServiceInstance, {
@@ -25,6 +29,7 @@ import { ErrorCode } from '../../../utils/error/error.code';
 import * as organizationDomain from '../../organizations/organizations.domain';
 import * as subscriptionDomain from '../../subcription/subscription.domain';
 import { serviceContractDomain } from '../contract/domain';
+import { DeploymentRequestDomain } from '../deployments/deployments.domain';
 import { deleteServiceInstanceBy } from '../service-instance.domain';
 import {
   PlatformConfiguration,
@@ -351,6 +356,7 @@ describe('Registration domain', () => {
       });
     });
     afterEach(async () => {
+      await db('DeploymentRequest').delete();
       await serviceContractDomain.deleteConfigurationBy({});
       await deleteServiceInstanceBy({});
     });
@@ -414,6 +420,73 @@ describe('Registration domain', () => {
     it('should return only the registered platform linked to the service instance', async () => {
       const platforms = await registrationDomain.loadRegisteredPlatforms({
         'ServiceInstance.id': openCTIServiceInstanceId,
+      });
+
+      expect(platforms.length).toBe(1);
+      expect(platforms[0]?.config.platform_id).toBe(platformId);
+    });
+    it('should return platforms with non-active trials by default', async () => {
+      await DeploymentRequestDomain.insertDeploymentRequest({
+        id: uuidv4() as DeploymentRequest['id'],
+        service_instance_id: openCTIServiceInstanceId,
+        platform_identifier: PlatformIdentifier.Opencti,
+        region: DeploymentRequestPlatformRegion.EuWest,
+        type: DeploymentRequestDeploymentType.Trial,
+        hub_status: DeploymentRequestHubStatus.Cancelled,
+        platform_token: uuidv4(),
+        organization_requester_id: PLATFORM_ORGANIZATION_UUID,
+        user_requester_id: contextAdminUser.user.id,
+        ordering: 1,
+        request_date: new Date(),
+      });
+
+      const platforms = await registrationDomain.loadRegisteredPlatforms({
+        platformIdentifier: PlatformIdentifier.Opencti,
+      });
+
+      expect(platforms.length).toBe(1);
+      expect(platforms[0]?.config.platform_id).toBe(platformId);
+    });
+    it('should not return platforms with non-active trials when onlyActiveTrials is true', async () => {
+      await DeploymentRequestDomain.insertDeploymentRequest({
+        id: uuidv4() as DeploymentRequest['id'],
+        service_instance_id: openCTIServiceInstanceId,
+        platform_identifier: PlatformIdentifier.Opencti,
+        region: DeploymentRequestPlatformRegion.EuWest,
+        type: DeploymentRequestDeploymentType.Trial,
+        hub_status: DeploymentRequestHubStatus.Provisioning,
+        platform_token: uuidv4(),
+        organization_requester_id: PLATFORM_ORGANIZATION_UUID,
+        user_requester_id: contextAdminUser.user.id,
+        ordering: 1,
+        request_date: new Date(),
+      });
+
+      const platforms = await registrationDomain.loadRegisteredPlatforms({
+        platformIdentifier: PlatformIdentifier.Opencti,
+        onlyActiveTrials: true,
+      });
+
+      expect(platforms.length).toBe(0);
+    });
+    it('should return platforms with active trials when onlyActiveTrials is true', async () => {
+      await DeploymentRequestDomain.insertDeploymentRequest({
+        id: uuidv4() as DeploymentRequest['id'],
+        service_instance_id: openCTIServiceInstanceId,
+        platform_identifier: PlatformIdentifier.Opencti,
+        region: DeploymentRequestPlatformRegion.EuWest,
+        type: DeploymentRequestDeploymentType.Trial,
+        hub_status: DeploymentRequestHubStatus.Active,
+        platform_token: uuidv4(),
+        organization_requester_id: PLATFORM_ORGANIZATION_UUID,
+        user_requester_id: contextAdminUser.user.id,
+        ordering: 1,
+        request_date: new Date(),
+      });
+
+      const platforms = await registrationDomain.loadRegisteredPlatforms({
+        platformIdentifier: PlatformIdentifier.Opencti,
+        onlyActiveTrials: true,
       });
 
       expect(platforms.length).toBe(1);

--- a/apps/portal-api/src/modules/services/registration/registration.domain.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.domain.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../../../../knexfile';
 import {
+  DeploymentRequestHubStatus,
   OrganizationCapability,
   PlatformContract,
   PlatformIdentifier,
@@ -139,10 +140,11 @@ export const registrationDomain = {
     query: {
       platformIdentifier?: PlatformIdentifier;
       'ServiceInstance.id'?: ServiceInstanceId;
+      onlyActiveTrials?: boolean;
     } = {}
   ): Promise<DomainRegisteredPlatform[]> => {
     const { user } = requestContext.require();
-    const { platformIdentifier, ...field } = query;
+    const { platformIdentifier, onlyActiveTrials, ...field } = query;
     const userSelectedOrganization = user.selected_organization_id;
     const serviceDefinitionIdentifiers = platformIdentifier
       ? [
@@ -171,6 +173,12 @@ export const registrationDomain = {
         '=',
         'ServiceInstance.id'
       )
+      .leftJoin(
+        'DeploymentRequest',
+        'DeploymentRequest.service_instance_id',
+        '=',
+        'ServiceInstance.id'
+      )
       .whereIn('ServiceDefinition.identifier', serviceDefinitionIdentifiers)
       .where('Subscription.organization_id', '=', userSelectedOrganization)
       .where('Subscription.status', '=', 'ACCEPTED')
@@ -179,6 +187,15 @@ export const registrationDomain = {
         this.where('Service_Configuration.status', '=', 'active').orWhereNull(
           'Service_Configuration.service_instance_id'
         );
+      })
+      .where(function () {
+        if (onlyActiveTrials) {
+          this.where(
+            'DeploymentRequest.hub_status',
+            '=',
+            DeploymentRequestHubStatus.Active
+          ).orWhereNull('DeploymentRequest.id');
+        }
       })
       .where(field)
       .select([

--- a/apps/portal-api/src/modules/services/registration/registration.graphql
+++ b/apps/portal-api/src/modules/services/registration/registration.graphql
@@ -99,6 +99,7 @@ type RefreshUserPlatformTokenResponse {
 
 input RegisteredPlatformsInput {
   identifier: PlatformIdentifier
+  onlyActiveTrials: Boolean
 }
 
 input RegisteredPlatformInput {

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -926,6 +926,7 @@ type RefreshUserPlatformTokenResponse {
 
 input RegisteredPlatformsInput {
   identifier: PlatformIdentifier
+  onlyActiveTrials: Boolean
 }
 
 input RegisteredPlatformInput {

--- a/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-private-details.tsx
+++ b/apps/portal-front/src/components/service/document/connector/shareable-resource-connector-private-details.tsx
@@ -18,7 +18,9 @@ export const ShareableResourceConnectorPrivateDetails: React.FC<Props> = ({
   connectorDetails,
 }) => {
   const t = useTranslations();
-  const { platforms } = useRegisteredPlatforms(PlatformIdentifierEnum.OPENCTI);
+  const { platforms } = useRegisteredPlatforms(PlatformIdentifierEnum.OPENCTI, {
+    onlyActiveTrials: true,
+  });
   const { platformToBeUpdated, incompatiblePlatformsCount } =
     useBuildCompatibilityTranslationKey({
       platforms,

--- a/apps/portal-front/src/components/service/document/one-click-deploy/one-click-deploy.tsx
+++ b/apps/portal-front/src/components/service/document/one-click-deploy/one-click-deploy.tsx
@@ -30,7 +30,9 @@ const OneClickDeploy = ({
 }: OneClickDeployProps) => {
   const t = useTranslations();
   const platformIdentifier = getPlatformIdentifier(documentData.type);
-  const { platforms } = useRegisteredPlatforms(platformIdentifier);
+  const { platforms } = useRegisteredPlatforms(platformIdentifier, {
+    onlyActiveTrials: true,
+  });
 
   const SendOneClickDeployTelemetryMutation = graphql`
     mutation oneClickDeployMutation($input: OneClickDeployInput!) {

--- a/apps/portal-front/src/components/ui/shareable-resource/card-design/shareable-resource-card-version.tsx
+++ b/apps/portal-front/src/components/ui/shareable-resource/card-design/shareable-resource-card-version.tsx
@@ -2,7 +2,12 @@ import { useBuildCompatibilityTranslationKey } from '@/hooks/useBuildCompatibili
 import { useRegisteredPlatforms } from '@/hooks/useRegisteredPlatforms';
 import { cn } from '@/lib/utils';
 import { CheckIndeterminateIcon } from '@filigran/icon';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@filigran/ui/clients';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@filigran/ui/clients';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { useTranslations } from 'next-intl';
 import { FunctionComponent } from 'react';
@@ -17,7 +22,9 @@ export const ShareableResourceCardVersion: FunctionComponent<
   ShareableResourceCardVersionProps
 > = ({ requiredProductVersion, product_version, className }) => {
   const t = useTranslations();
-  const { platforms } = useRegisteredPlatforms(PlatformIdentifierEnum.OPENCTI);
+  const { platforms } = useRegisteredPlatforms(PlatformIdentifierEnum.OPENCTI, {
+    onlyActiveTrials: true,
+  });
   const { platformToBeUpdated, incompatiblePlatformsCount } =
     useBuildCompatibilityTranslationKey({
       platforms,

--- a/apps/portal-front/src/components/ui/shareable-resource/product-version-filter.tsx
+++ b/apps/portal-front/src/components/ui/shareable-resource/product-version-filter.tsx
@@ -16,7 +16,9 @@ export const ProductVersionFilter: React.FC<Props> = ({
   platformIdentifier,
 }) => {
   const t = useTranslations();
-  const { platforms } = useRegisteredPlatforms(platformIdentifier);
+  const { platforms } = useRegisteredPlatforms(platformIdentifier, {
+    onlyActiveTrials: true,
+  });
 
   const options = useMemo(() => {
     return platforms

--- a/apps/portal-front/src/hooks/useRegisteredPlatforms.tsx
+++ b/apps/portal-front/src/hooks/useRegisteredPlatforms.tsx
@@ -20,14 +20,21 @@ export const UseRegisteredPlatformsQuery = graphql`
   }
 `;
 
+interface UseRegisteredPlatformsOptions {
+  onlyActiveTrials?: boolean;
+}
+
 export const useRegisteredPlatforms = (
-  platformIdentifier: PlatformIdentifierEnum
+  platformIdentifier: PlatformIdentifierEnum,
+  options: UseRegisteredPlatformsOptions = {}
 ) => {
+  const { onlyActiveTrials = false } = options;
   const queryData = useLazyLoadQuery<useRegisteredPlatformsFragmentQuery>(
     UseRegisteredPlatformsQuery,
     {
       input: {
         identifier: platformIdentifier,
+        onlyActiveTrials,
       },
     }
   );


### PR DESCRIPTION
# Context
Platforms with non-active trials (cancelled, expired, provisioning, queued, failed) were appearing in the Platform filter list in the Integrations Library. Users should only see platforms with active trials as selectable options when filtering integrations.

This PR adds an optional `onlyActiveTrials` parameter to the `registeredPlatforms` query. 
When set to `true`, only platforms with active trials (or platforms without any trial/deployment request) are returned.

The filter is applied in:
- Platform version filter (Integrations Library)
- One-click deploy platform selection
- Compatibility version checks on cards and connector details

The homepage and other areas that need to display all trial states remain unaffected (default behavior).

## How to test
1. Create a free trial
2. Wait for it to go through different states (pending, provisioning, active, or cancel it)
3. Go to the Integrations Library
4. Open the Platform filter dropdown
5. **Expected**: Only platforms with active trials should appear in the filter options
6. Go to the homepage
7. **Expected**: All trials (including non-active ones) should still be visible in the services list

## Related issues

- Related to #1567

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests
