### PR TITLE
[backend] fix(auth0): update all user profiles matching email for SAML support

### DIFF
--- a/apps/portal-api/src/thirdparty/auth0/implementation.ts
+++ b/apps/portal-api/src/thirdparty/auth0/implementation.ts
@@ -25,21 +25,25 @@ export const auth0ClientImplementation: Auth0Client = {
     const users_response = await managementClient.usersByEmail.getByEmail({
       email: user.email,
     });
-    const auth0_user = users_response.data[0];
-    if (!auth0_user) {
+    const auth0_users = users_response.data;
+    if (auth0_users.length === 0) {
       throw new Error('AUTH0_USER_NOT_FOUND_ERROR');
     }
 
-    await managementClient.users.update(
-      { id: auth0_user.user_id },
-      {
-        given_name: user.first_name,
-        family_name: user.last_name,
-        user_metadata: {
-          country: user.country,
-        },
-        picture: user.picture,
-      }
+    await Promise.all(
+      auth0_users.map((auth0_user) =>
+        managementClient.users.update(
+          { id: auth0_user.user_id },
+          {
+            given_name: user.first_name,
+            family_name: user.last_name,
+            user_metadata: {
+              country: user.country,
+            },
+            picture: user.picture,
+          }
+        )
+      )
     );
   },
   updateUserRBACInstance: async (
@@ -49,14 +53,18 @@ export const auth0ClientImplementation: Auth0Client = {
     const users_response = await managementClient.usersByEmail.getByEmail({
       email,
     });
-    const auth0_user = users_response.data[0];
-    if (!auth0_user) {
+    const auth0_users = users_response.data;
+    if (auth0_users.length === 0) {
       throw new Error('AUTH0_USER_NOT_FOUND_ERROR');
     }
 
-    await managementClient.users.update(
-      { id: auth0_user.user_id },
-      buildUserMetadataUpdate(auth0_user, userRBACInstance)
+    await Promise.all(
+      auth0_users.map((auth0_user) =>
+        managementClient.users.update(
+          { id: auth0_user.user_id },
+          buildUserMetadataUpdate(auth0_user, userRBACInstance)
+        )
+      )
     );
   },
   resetPassword: async (email: string): Promise<void> => {


### PR DESCRIPTION
# Context

Uploading a profile picture was not working correctly for users with SAML authentication enabled.

Since the recent SAML integration with Auth0, users can have multiple identities (profiles) associated with the same email address (e.g., one for password authentication and one for SAML). The previous implementation only updated the first Auth0 profile found, leaving the other profiles out of sync.

This fix ensures that all Auth0 profiles matching the user's email are updated when modifying user data (profile picture, name, country, RBAC instances, etc.).

## How to test

1. Have a user with both password and SAML profiles in Auth0
2. Log in and go to the profile page
3. Upload a new profile picture
4. Verify in Auth0 that both user profiles have the updated picture

## Related issues

- Related to #1579

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests
