### PR TITLE
[frontend] fix(public): remove sticky footer on mobile, keep sticky header (#1611)

### DIFF
--- a/apps/portal-front/app/(public)/layout.tsx
+++ b/apps/portal-front/app/(public)/layout.tsx
@@ -18,9 +18,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col h-screen">
+    <div className="md:flex md:flex-col md:h-screen">
       <PublicTryOpenCTIBanner />
-      <header className="flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between">
+      <header className="max-md:sticky max-md:top-0 max-md:z-20 flex h-16 w-full flex-shrink-0 items-center border-b bg-page-background dark:bg-background px-4 justify-between">
         <Link href="/">
           <LogoXTMDark className="text-primary mr-2 w-[10rem] h-auto py-l" />
           <span className="sr-only">XTM Hub by Filigran</span>


### PR DESCRIPTION
# Context
Fix footer behavior on mobile devices. 
The footer was sticky due to `h-screen` on the layout container, which caused it to hide half of the phone screen. 

Changes:
- Removed flex layout on mobile (only applied on `md:` and up)
- Made header sticky only on mobile (`max-md:sticky`)

## How to test
1. Go to any public page (e.g. `/login`)
2. On mobile viewport: scroll down - header should stay sticky at top, footer should scroll with content
3. On desktop viewport: layout should behave as before with footer at bottom of screen

## Related issues

- Related to #1611

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests
