### PR TITLE
[backend] fix: send trial registered email only when request is active

### DIFF
--- a/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.test.ts
@@ -26,7 +26,9 @@ import {
 import DeploymentRequest, {
   DeploymentRequestId,
 } from '../../../model/kanel/public/DeploymentRequest';
-import ServiceInstance from '../../../model/kanel/public/ServiceInstance';
+import ServiceInstance, {
+  ServiceInstanceId,
+} from '../../../model/kanel/public/ServiceInstance';
 import { SYSTEM_USER_UUID, XTM_HUB_SUPPORT_EMAIL } from '../../../portal.const';
 import * as mailService from '../../../server/mail-service';
 import {
@@ -49,6 +51,7 @@ import { MockInstance } from '@vitest/spy';
 import { db } from '../../../../knexfile';
 import { requestContext } from '../../../context/request.context';
 import DeploymentRequestQuota from '../../../model/kanel/public/DeploymentRequestQuota';
+import { serviceContractDomain } from '../contract/service-configuration.domain';
 import {
   deleteServiceInstanceBy,
   loadServiceInstanceBy,
@@ -798,6 +801,42 @@ describe('Deployment app', () => {
           actual_state: DeploymentRequestPlatformState.Provisioning,
         });
 
+        expect(mockSendMail).not.toHaveBeenCalled();
+      });
+
+      it('should send a mail in case deployment request is in active (only first time)', async () => {
+        vi.spyOn(
+          serviceContractDomain,
+          'loadConfigurationByPlatform'
+        ).mockResolvedValue({
+          service_instance_id: uuidv4() as ServiceInstanceId,
+          config: { platform_url: 'http://example.com' },
+          status: DeploymentRequestPlatformState.Active,
+        });
+        await DeploymentsApp.updateDeploymentRequest({
+          id: initialDeployment?.id as string,
+          start_date: new Date(2025, 12, 1),
+          end_date: new Date(2026, 1, 1),
+          actual_state: DeploymentRequestPlatformState.Active,
+        });
+
+        expect(mockSendMail).toHaveBeenCalledWith({
+          to: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+          template: 'opencti_free_trial_registered',
+          params: {
+            firstName: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+            platformUrl: 'http://example.com',
+          },
+        });
+
+        mockSendMail.mockClear();
+
+        await DeploymentsApp.updateDeploymentRequest({
+          id: initialDeployment?.id as string,
+          start_date: new Date(2025, 12, 1),
+          end_date: new Date(2026, 1, 1),
+          actual_state: DeploymentRequestPlatformState.Active,
+        });
         expect(mockSendMail).not.toHaveBeenCalled();
       });
     });

--- a/apps/portal-api/src/modules/services/deployments/deployments.app.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.app.ts
@@ -49,6 +49,7 @@ import {
   buildUpdateDeploymentEvent,
 } from '../../telemetry/telemetry.helper';
 import { loadUser } from '../../users/users.domain';
+import { serviceContractDomain } from '../contract/service-configuration.domain';
 import { updateServiceInstance } from '../service-instance.domain';
 import {
   assertFreeTrialsLimit,
@@ -363,6 +364,40 @@ export const DeploymentsApp = {
     } catch (error) {
       logApp.error('Unable to send mail', {
         error,
+        deploymentRequestId: deploymentRequest.id,
+      });
+    }
+
+    try {
+      if (
+        newStatus === DeploymentRequestHubStatus.Active &&
+        newStatus !== deploymentRequest.hub_status
+      ) {
+        const [user] = await loadUser({
+          id: deploymentRequest.user_requester_id,
+        });
+
+        const serviceConfiguration =
+          await serviceContractDomain.loadConfigurationByPlatform(
+            deploymentRequest.platform_id
+          );
+
+        const parsedConfig = JSON.parse(
+          JSON.stringify(serviceConfiguration.config)
+        );
+
+        void sendMail({
+          to: user.email,
+          template: 'opencti_free_trial_registered',
+          params: {
+            firstName: formatName(user.first_name ?? ''),
+            platformUrl: parsedConfig.platform_url,
+          },
+        });
+      }
+    } catch (error) {
+      logApp.error('Unable to send mail after deployment request is active', {
+        error: error,
         deploymentRequestId: deploymentRequest.id,
       });
     }

--- a/apps/portal-api/src/modules/services/group/service-group.graphql
+++ b/apps/portal-api/src/modules/services/group/service-group.graphql
@@ -19,5 +19,6 @@ type Query {
 }
 
 type Mutation {
-  updateServiceGroups(input: UpdateServiceGroupsInput!): Success @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
+  updateServiceGroups(input: UpdateServiceGroupsInput!): Success
+    @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
 }

--- a/apps/portal-api/src/modules/services/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.test.ts
@@ -46,7 +46,6 @@ import Subscription, {
 
 import { UserLoadUserBy } from '../../../model/user';
 import * as authHelper from '../../../security/auth.helper';
-import * as mailService from '../../../server/mail-service';
 import {
   BadRequestErrorCode,
   ErrorCode,
@@ -946,26 +945,6 @@ describe('Registration app', () => {
           source: TELEMETRY_SOURCE,
           target_product: 'open-cti',
           user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
-        });
-      });
-    });
-    describe('sendMail', () => {
-      it('should send a mail when platform is autoregistered', async () => {
-        const mockSendMail = vi.spyOn(mailService, 'sendMail');
-
-        await registrationApp.autoRegisterPlatform(
-          deploymentRequest.platform_token as string,
-          platformConfiguration
-        );
-
-        expect(mockSendMail).toHaveBeenCalledExactlyOnceWith({
-          to: 'user@second-orga.com',
-          template: 'opencti_free_trial_registered',
-          params: {
-            firstName:
-              TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.FIRST_NAME,
-            platformUrl: 'http://example.com',
-          },
         });
       });
     });

--- a/apps/portal-api/src/modules/services/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/services/registration/registration.app.ts
@@ -50,7 +50,6 @@ import { loadSubscriptionBy } from '../../subcription/subscription.domain';
 import { telemetryApp } from '../../telemetry/telemetry.app';
 import { buildRegisterEvent } from '../../telemetry/telemetry.helper';
 import {
-  loadUser,
   loadUsersByCapabilitiesInOrganization,
   updateUser,
 } from '../../users/users.domain';
@@ -493,25 +492,6 @@ export const registrationApp = {
     } catch (error) {
       logApp.error('Unable to send telemetry event for registration', {
         error,
-      });
-    }
-    try {
-      const [user] = await loadUser({
-        id: deploymentRequest.user_requester_id,
-      });
-
-      void sendMail({
-        to: user.email,
-        template: 'opencti_free_trial_registered',
-        params: {
-          firstName: formatName(user.first_name ?? ''),
-          platformUrl: platform.url,
-        },
-      });
-    } catch (error) {
-      logApp.error('Unable to send mail after autoRegistration', {
-        error: error,
-        deploymentRequestId: deploymentRequest.id,
       });
     }
   },

--- a/apps/portal-api/src/modules/services/service-instance.graphql
+++ b/apps/portal-api/src/modules/services/service-instance.graphql
@@ -98,12 +98,12 @@ type Mutation {
     document: Upload
     isLogo: Boolean
   ): ServiceInstance
-  @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_SUBSCRIPTION])
+    @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_SUBSCRIPTION])
   updatePlatformServiceMetadata(
     input: UpdatePlatformServiceMetadataInput!
     document: Upload
   ): RegisteredPlatform
-  @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
+    @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
 }
 
 type Query {

--- a/apps/portal-api/src/modules/users/users.domain.ts
+++ b/apps/portal-api/src/modules/users/users.domain.ts
@@ -6,8 +6,8 @@ import {
   OrganizationCapability,
   QueryUsersArgs,
   Subscription,
-  User as UserGenerated,
   UserConnection,
+  User as UserGenerated,
 } from '../../__generated__/resolvers-types';
 import { requestContext } from '../../context/request.context';
 import { OrganizationId } from '../../model/kanel/public/Organization';


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

This PR moves the trial registered email sending from autoregister to `updateDeploymentRequest` while verifying if the new hub status has changed and is active.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- create deployment request
- auto register it
- update deployment request with active status
- check email is sent
- update deployment request with active status again
- check email is not sent

## Related issues

- Related to #1669 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.