### PR TITLE
[backend] chore(competitor): remove domains_backlist env variable #1819

### DIFF
--- a/apps/portal-api/config/custom-environment-variables.json
+++ b/apps/portal-api/config/custom-environment-variables.json
@@ -53,6 +53,5 @@
   "system_token_salt": "SYSTEM_TOKEN_SALT",
   "session_store": {
     "type": "SESSION_STORE_TYPE"
-  },
-  "domains_blacklist": "DOMAINS_BLACKLIST"
+  }
 }

--- a/apps/portal-api/config/default.json
+++ b/apps/portal-api/config/default.json
@@ -105,6 +105,5 @@
   "session_store": {
     "type": "postgresql",
     "cleanup_interval_minutes": 60
-  },
-  "domains_blacklist": ""
+  }
 }

--- a/apps/portal-api/src/modules/services/competitor/competitor.app.test.ts
+++ b/apps/portal-api/src/modules/services/competitor/competitor.app.test.ts
@@ -1,6 +1,5 @@
-import config from 'config';
 import { toGlobalId } from 'graphql-relay';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { db } from '../../../../knexfile';
 import { TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
 import { CompetitorTier } from '../../../__generated__/resolvers-types';
@@ -148,25 +147,6 @@ describe('CompetitorApp', () => {
       });
       const result = await CompetitorApp.isOrganizationBlacklisted(org);
       expect(result).toBe(false);
-    });
-
-    it('should return true if org is blacklisted from settings', async () => {
-      const originalConfigGet = config.get;
-
-      vi.spyOn(config, 'get').mockImplementation((key: string) => {
-        if (key === 'domains_blacklist') {
-          return TEST_ORGANIZATIONS.FILIGRAN.DOMAINS.FIRST;
-        }
-        return originalConfigGet.call(config, key);
-      });
-
-      const org = await loadOrganizationBy({
-        id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-      });
-      const result = await CompetitorApp.isOrganizationBlacklisted(org);
-      expect(result).toBe(true);
-
-      vi.mocked(config.get).mockImplementation(originalConfigGet);
     });
   });
 });

--- a/apps/portal-api/src/modules/services/competitor/competitor.app.ts
+++ b/apps/portal-api/src/modules/services/competitor/competitor.app.ts
@@ -1,4 +1,3 @@
-import config from 'config';
 import {
   Competitor,
   CompetitorTier,
@@ -18,15 +17,6 @@ const throwIfUniqueViolation = (error: Error) => {
       detail: error,
     });
   }
-};
-
-const isOrganizationBlacklistedFromSettings = (organization: Organization) => {
-  const domainsBlacklist = (config.get<string>('domains_blacklist') ?? '')
-    .split(',')
-    .map((d) => d.trim());
-  return organization.domains.some((domain) =>
-    domainsBlacklist.includes(domain)
-  );
 };
 
 export const CompetitorApp = {
@@ -70,10 +60,6 @@ export const CompetitorApp = {
     organization: Organization
   ): Promise<boolean> {
     if (!organization.domains?.length) return false;
-    return (
-      // TODO: check from settings can be removed once we have filled the competitors table
-      isOrganizationBlacklistedFromSettings(organization) ||
-      CompetitorDomain.isAnyDomainACompetitor(organization.domains)
-    );
+    return CompetitorDomain.isAnyDomainACompetitor(organization.domains);
   },
 };


### PR DESCRIPTION
# Context
now that competitors are managed from a table, we can remove the usage of the environment variable

## How to test
Check competitors are still blacklisted without the environment variable

## Related issues

- Related to #1819

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.