### PR TITLE
[fronend] fix(homepage): display OpenAEV trial card in owned services

### DIFF
--- a/apps/portal-front/src/components/service/home/owned-services.tsx
+++ b/apps/portal-front/src/components/service/home/owned-services.tsx
@@ -38,17 +38,13 @@ const OwnedServices = ({
     ),
   ].sort((a, b) => a!.ordering - b!.ordering);
 
-  const freeTrialsSkeletonDataCards = availableTrials
-    .filter(
-      (platformIdentifier) =>
-        platformIdentifier !== PlatformIdentifierEnum.OPENAEV
-    )
-    .map((platformIdentifier) =>
+  const freeTrialsSkeletonDataCards = availableTrials.map(
+    (platformIdentifier) =>
       freeTrialSkeletonToServiceInstanceCardData(
         platformIdentifier as PlatformIdentifierEnum,
         t
       )
-    );
+  );
 
   if (sortedServices.length > 0) {
     return (


### PR DESCRIPTION
# Context
The OpenAEV free trial card was not showing up on the services home page.

**Root cause:** In `owned-services.tsx`, a `.filter()` was explicitly excluding `PlatformIdentifierEnum.OPENAEV` from the available trials list before generating the cards. 

**Fix:** Removed the filter so that all returned trials generate their card.

## How to test
1. Log in with an organization eligible for the OpenAEV free trial
2. Go to the services home page
3. Verify that the OpenAEV free trial card appears alongside the OpenCTI free trial card
4. Click on the OpenAEV card and verify that it redirects to `/app/service/openaev-free-trial`

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests
