### PR TITLE
[E2E] Add E2E Tests for Epics #1792

### DIFF
--- a/apps/portal-api/tests/seeds/00-seed-init-DB.js
+++ b/apps/portal-api/tests/seeds/00-seed-init-DB.js
@@ -243,11 +243,12 @@ export async function seed(knex) {
         name: 'Public Roadmap',
         description: 'Explore and follow the Filigran XTM Suite roadmap',
         creation_status: 'READY',
-        public: false,
+        public: true,
         join_type: 'JOIN_AUTO',
         tags: '{others}',
         service_definition_id: 'ecc973c4-575f-4618-b3a4-ebabb9b42a81',
         ordering: 15,
+        slug: 'xtm-suite-roadmap',
       },
     ])
     .onConflict('id')

--- a/apps/portal-e2e-tests/tests/db-utils/epic.helper.ts
+++ b/apps/portal-e2e-tests/tests/db-utils/epic.helper.ts
@@ -1,0 +1,5 @@
+import { db } from './db-connection';
+
+export const addEpic = async (epicData) => {
+  await db('Epic').insert(epicData).onConflict('id').ignore();
+};

--- a/apps/portal-e2e-tests/tests/model/login.pageModel.ts
+++ b/apps/portal-e2e-tests/tests/model/login.pageModel.ts
@@ -28,6 +28,9 @@ export default class LoginPage {
   async navigateTo() {
     await this.page.goto('/login');
   }
+  async navigateToPublicPages() {
+    await this.page.goto('/cybersecurity-solutions');
+  }
 
   async navigateToAndLogin(userEmail = 'admin@filigran.io') {
     await this.navigateTo();

--- a/apps/portal-e2e-tests/tests/model/xtm-suite-roadmap.pageModel.ts
+++ b/apps/portal-e2e-tests/tests/model/xtm-suite-roadmap.pageModel.ts
@@ -1,0 +1,154 @@
+import { Page } from '@playwright/test';
+import { expect } from '../fixtures/baseFixtures';
+
+const TEST_IMAGE_FILE = {
+  path: './tests/tests_files/assets/test.png',
+  name: 'test.png',
+};
+export default class XTMSuiteRoadmapPage {
+  constructor(private page: Page) {}
+  async addEpic({
+    epic,
+    title,
+    short_description,
+    description,
+    product = 'OpenCTI',
+    timeline = 'Now',
+    integration = false,
+    draft = true,
+  }: {
+    epic: string;
+    title: string;
+    short_description: string;
+    description: string;
+    product?: string;
+    timeline?: string;
+    integration?: boolean;
+    draft?: boolean;
+  }) {
+    await this.page.getByRole('button', { name: 'Create' }).click();
+    await this.page.getByRole('textbox', { name: 'Epic *' }).fill(epic);
+    await this.page.getByRole('textbox', { name: 'Title' }).fill(title);
+    await this.page
+      .getByRole('textbox', { name: 'Short description' })
+      .fill(short_description);
+    await this.page
+      .getByRole('textbox', { name: 'This is a paragraph to' })
+      .fill(description);
+    await this.page.getByRole('combobox', { name: 'Product' }).click();
+    await this.page.getByRole('option', { name: product }).click();
+    await this.page.getByRole('combobox', { name: 'Timeline' }).click();
+    await this.page.getByRole('option', { name: timeline }).click();
+    if (!draft) {
+      await this.page.getByRole('checkbox', { name: 'Active' }).check();
+    }
+    if (integration) {
+      await this.page
+        .getByRole('checkbox', { name: 'Is an integration' })
+        .click();
+      await this.uploadImageDocument(TEST_IMAGE_FILE.path);
+    }
+    await this.page.getByRole('button', { name: 'Create' }).click();
+  }
+
+  async deleteEpic() {
+    await this.page
+      .getByRole('button', { name: 'Open menu', exact: true })
+      .click();
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    await this.page.getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async updateEpic({
+    epic,
+    title,
+    short_description,
+    description,
+    product,
+    timeline,
+    draft,
+  }: {
+    epic?: string;
+    title?: string;
+    short_description?: string;
+    description?: string;
+    product?: string;
+    timeline?: string;
+    draft: boolean;
+  }) {
+    await this.page
+      .getByRole('button', { name: 'Open menu', exact: true })
+      .click();
+    await this.page.getByRole('menuitem', { name: 'Update' }).click();
+    if (epic)
+      await this.page.getByRole('textbox', { name: 'Epic *' }).fill(epic);
+    if (title)
+      await this.page.getByRole('textbox', { name: 'Title' }).fill(title);
+    if (short_description)
+      await this.page
+        .getByRole('textbox', { name: 'Short description' })
+        .fill(short_description);
+    if (description)
+      await this.page
+        .getByRole('textbox', { name: 'This is a paragraph to' })
+        .fill(description);
+    if (product) {
+      await this.page.getByRole('combobox', { name: 'Product' }).click();
+      await this.page.getByRole('option', { name: product }).click();
+    }
+    if (timeline) {
+      await this.page.getByRole('combobox', { name: 'Timeline' }).click();
+      await this.page.getByRole('option', { name: timeline }).click();
+    }
+    if (!draft) {
+      await this.page.getByRole('checkbox', { name: 'Active' }).check();
+    }
+    if (draft) {
+      await this.page.getByRole('checkbox', { name: 'Active' }).uncheck();
+    }
+    await this.page.getByRole('button', { name: 'Update' }).click();
+  }
+
+  async uploadImageDocument(filePath: string) {
+    await this.page.locator('input[type="file"]').setInputFiles(filePath);
+  }
+
+  async checkFilters({
+    openCTINumbers = 0,
+    openAEVNumbers = 0,
+    openGRCNumbers = 0,
+    xtmHubNumbers = 0,
+    xtmOneNumbers = 0,
+  }: {
+    openCTINumbers?: number;
+    openAEVNumbers?: number;
+    openGRCNumbers?: number;
+    xtmHubNumbers?: number;
+    xtmOneNumbers?: number;
+  }) {
+    await expect(
+      this.page.getByRole('button', {
+        name: `All products (${openCTINumbers + openAEVNumbers + openGRCNumbers + xtmHubNumbers + xtmOneNumbers})`,
+      })
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: `OpenCTI (${openCTINumbers})` })
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: `OpenAEV (${openAEVNumbers})` })
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: `OpenGRC (${openGRCNumbers})` })
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: `XTM Hub (${xtmHubNumbers})` })
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: `XTM One (${xtmOneNumbers})` })
+    ).toBeVisible();
+  }
+
+  async navigateToService() {
+    await this.page.getByRole('link', { name: 'Public Roadmap' }).click();
+  }
+}

--- a/apps/portal-e2e-tests/tests/tests_files/xtm-suite-roadmap.spec.ts
+++ b/apps/portal-e2e-tests/tests/tests_files/xtm-suite-roadmap.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from '../fixtures/baseFixtures';
+import LoginPage from '../model/login.pageModel';
+import XTMSuiteRoadmapPage from '../model/xtm-suite-roadmap.pageModel';
+import { addEpic } from '../db-utils/epic.helper';
+import { ADMIN_USER } from '../db-utils/const';
+
+test.describe('XTM Suite Roadmap', () => {
+  let loginPage: LoginPage;
+  let xtmSuiteRoadmapPage: XTMSuiteRoadmapPage;
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    xtmSuiteRoadmapPage = new XTMSuiteRoadmapPage(page);
+  });
+  test('Should allow Filigran user to perform a CRUD of an epic', async ({
+    page,
+  }) => {
+    await loginPage.navigateToAndLogin();
+    await xtmSuiteRoadmapPage.navigateToService();
+    await test.step('Add an epic', async () => {
+      await xtmSuiteRoadmapPage.addEpic({
+        epic: 'Epic',
+        title: 'Title',
+        short_description: 'Short description',
+        description: 'This is a test epic',
+      });
+      await xtmSuiteRoadmapPage.checkFilters({
+        openCTINumbers: 1,
+      });
+      await expect(page.getByText(/^Epic$/)).toBeVisible();
+    });
+    await test.step('Update an epic', async () => {
+      await xtmSuiteRoadmapPage.updateEpic({
+        epic: 'EpicModified',
+        title: 'TitleModified',
+        description: 'This is a test epicModified',
+        draft: false,
+      });
+      await xtmSuiteRoadmapPage.checkFilters({
+        openCTINumbers: 1,
+      });
+      await expect(page.getByText('EpicModified')).toBeVisible();
+    });
+    await test.step('Delete an epic', async () => {
+      await xtmSuiteRoadmapPage.deleteEpic();
+      await xtmSuiteRoadmapPage.checkFilters({});
+    });
+    await test.step('Create an epic integration', async () => {
+      await xtmSuiteRoadmapPage.addEpic({
+        epic: 'Epic integration',
+        title: 'Title integration',
+        short_description: 'Short description for an integration',
+        description: 'This is an integration epic',
+        integration: true,
+      });
+      await xtmSuiteRoadmapPage.checkFilters({
+        openCTINumbers: 1,
+      });
+    });
+    await test.step('Create an epic draft', async () => {
+      await xtmSuiteRoadmapPage.addEpic({
+        epic: 'EpicDraft',
+        title: 'TitleDraft',
+        short_description: 'Short description for a draft',
+        description: 'This is a draft epic',
+        draft: true,
+      });
+      await xtmSuiteRoadmapPage.checkFilters({
+        openCTINumbers: 2,
+      });
+    });
+  });
+
+  test('Should allow users that are not connected to view the xtm suite roadmap', async ({
+    page,
+  }) => {
+    await testXTMSuiteRoadmapForUser(page);
+  });
+
+  test('Should allow community user to view the xtm suite roadmap', async ({
+    page,
+  }) => {
+    await testXTMSuiteRoadmapForUser(page, 'user15@test.fr');
+  });
+
+  async function testXTMSuiteRoadmapForUser(page, userEmail?: string) {
+    if (userEmail) {
+      await loginPage.navigateToAndLogin(userEmail);
+    } else {
+      await loginPage.navigateToPublicPages();
+    }
+
+    await xtmSuiteRoadmapPage.navigateToService();
+
+    await addEpic({
+      epic: 'EpicDraft1',
+      title: 'TitleDraft1',
+      short_description: 'Short description for a draft',
+      description: 'This is a draft epic',
+      product: 'opencti',
+      active: false,
+      timeline: 'next',
+      uploader_id: ADMIN_USER.ID,
+    });
+    await addEpic({
+      epic: 'Epic2',
+      title: 'Title2',
+      short_description: 'Short description',
+      description: 'This is an epic',
+      product: 'opencti',
+      active: true,
+      timeline: 'next',
+      uploader_id: ADMIN_USER.ID,
+    });
+    await addEpic({
+      epic: 'Epic3',
+      title: 'Title3',
+      short_description: 'Short description for another epic',
+      description: 'This is a second epic',
+      product: 'openaev',
+      active: true,
+      timeline: 'next',
+      uploader_id: ADMIN_USER.ID,
+    });
+
+    await test.step("It should display the epics' page correctly", async () => {
+      await expect(
+        page.getByRole('button', { name: 'Create' })
+      ).not.toBeVisible();
+
+      await xtmSuiteRoadmapPage.checkFilters({
+        openCTINumbers: 1,
+        openAEVNumbers: 1,
+      });
+
+      await expect(
+        page.getByText('EpicDraft1', { exact: true })
+      ).not.toBeVisible();
+      await expect(page.getByText('Epic2', { exact: true })).toBeVisible();
+      await expect(page.getByText('Epic3', { exact: true })).toBeVisible();
+    });
+    await test.step('It should filter', async () => {
+      await page.getByRole('button', { name: 'OpenAEV (1)' }).click();
+      await expect(page.getByText('Epic2', { exact: true })).not.toBeVisible();
+      await expect(page.getByText('Epic3', { exact: true })).toBeVisible();
+    });
+
+    await test.step('It should display details', async () => {
+      await page.getByText('Epic3').click();
+      await expect(
+        page.getByText('This is a second epic', { exact: true })
+      ).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
# Context
> Add E2E tests for XTM Suite Roadmap 

## How to test
- Launch E2E test xtm-suite-roadmap
- It should be green :) 

## Related issues

- Related to #1792 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [X] E2E tests
- [ ] Local manual tests

# Additional information
<img width="400" height="165" alt="image" src="https://github.com/user-attachments/assets/04a85a9c-5e43-43b7-9051-598b3d998be7" />