### PR TITLE
[frontend] fix(layout): prevent horizontal overflow on trials for small screens (#1855)

### DIFF
--- a/apps/portal-front/app/(application)/app/layout.tsx
+++ b/apps/portal-front/app/(application)/app/layout.tsx
@@ -63,7 +63,7 @@ const RootLayout: FunctionComponent<RootLayoutProps> = async ({ children }) => {
             <TryFiligranProductsBanner />
             <div className="flex flex-row flex-grow min-h-0">
               <Menu />
-              <div className="flex flex-col w-full h-full min-h-0">
+              <div className="flex flex-col w-full h-full min-h-0 min-w-0">
                 <HeaderComponent />
                 <ContentLayout>{children}</ContentLayout>
               </div>


### PR DESCRIPTION
# Context

Fix double scrollbar (horizontal + vertical) appearing on trial pages when viewed on small screens. 
The wide `DataTable` was causing the entire page to overflow horizontally instead of being contained within the content area.

**Root cause:** In the app layout, the content wrapper `div` is a flex child inside a `flex-row`, but was missing `min-w-0`. By default, flex items have `min-width: auto`, which prevents them from shrinking below their content's intrinsic width. The DataTable (with many columns) pushed this div wider than the viewport, bubbling the overflow up to the page level.

**Fix:** Added `min-w-0` to the flex child so it can shrink properly. The `main` element in `ContentLayout` already has `overflow-y-auto` (which implicitly sets `overflow-x: auto` per the CSS spec), so once the parent is correctly constrained, horizontal overflow is handled within the content area.

## How to test

1. Navigate to any trial page (e.g. **Admin → OpenCTI Trials**)
2. Resize the browser window to a small width (~800px or less)
3. **Before:** Two scrollbars appear, one global horizontal scrollbar on the page, and vertical scrolling is also affected
4. **After:** No global horizontal scrollbar. The content area handles overflow internally

## Related issues

- Related to #1855

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests
