### PR TITLE
[frontend] feat(epic): add draft badge on epic tiles (#1885)

### DIFF
--- a/apps/portal-e2e-tests/tests/model/xtm-suite-roadmap.pageModel.ts
+++ b/apps/portal-e2e-tests/tests/model/xtm-suite-roadmap.pageModel.ts
@@ -101,10 +101,18 @@ export default class XTMSuiteRoadmapPage {
       await this.page.getByRole('option', { name: timeline }).click();
     }
     if (!draft) {
-      await this.page.getByRole('checkbox', { name: 'Active' }).check();
+      await this.page
+        .getByRole('checkbox', {
+          name: 'Is this EPIC published? (By default your EPIC is in draft mode)',
+        })
+        .check();
     }
     if (draft) {
-      await this.page.getByRole('checkbox', { name: 'Active' }).uncheck();
+      await this.page
+        .getByRole('checkbox', {
+          name: 'Is this EPIC published? (By default your EPIC is in draft mode)',
+        })
+        .uncheck();
     }
     await this.page.getByRole('button', { name: 'Update' }).click();
   }

--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -114,7 +114,7 @@
       "FiligranProduct": "Product",
       "FiligranProductPlaceholder": "OpenCTI",
       "Timeline": "Timeline",
-      "IsActive": "Active",
+      "IsActive": "Is this EPIC published? (By default your EPIC is in draft mode)",
       "Integration": "Is an integration"
     },
     "EpicActions": {

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -135,7 +135,7 @@
       "FiligranProduct": "Produit",
       "FiligranProductPlaceholder": "OpenCTI",
       "Timeline": "Ligne de temps",
-      "IsActive": "Actif",
+      "IsActive": "Cet EPIC est-il publié ? (Par défaut votre EPIC est en mode brouillon)",
       "Integration": "Est une intégration"
     },
     "EpicActions": {

--- a/apps/portal-front/src/components/epic/epic-item/epic-item-card.tsx
+++ b/apps/portal-front/src/components/epic/epic-item/epic-item-card.tsx
@@ -61,7 +61,7 @@ export const EpicItemCard = ({
           {!epic.active && (
             <Badge
               variant="warning"
-              className="font-semibold">
+              className="font-semibold mr-s">
               {t('Epic.Timeline.draft')}
             </Badge>
           )}

--- a/apps/portal-front/src/components/epic/epic-item/epic-item-card.tsx
+++ b/apps/portal-front/src/components/epic/epic-item/epic-item-card.tsx
@@ -7,6 +7,7 @@ import { MoreVertIcon } from '@filigran/icon';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { Badge } from '@filigran/ui';
 
 interface EpicItemCardProps {
   epic: epic_fragment$data;
@@ -57,6 +58,13 @@ export const EpicItemCard = ({
           onClick={(e) => {
             e.stopPropagation();
           }}>
+          {!epic.active && (
+            <Badge
+              variant="warning"
+              className="font-semibold">
+              {t('Epic.Timeline.draft')}
+            </Badge>
+          )}
           {(userCanDelete || userCanUpdate) && (
             <IconActions
               icon={


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Add a "Draft" badge on epic tiles to visually indicate when an epic is inactive (draft status).
The badge is displayed in the bottom-right corner of the card, next to the action menu.

<img width="1115" height="689" alt="image" src="https://github.com/user-attachments/assets/221d32ac-84ca-4c6c-82e8-7b25119ddd11" />




## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. Connect as a user with subscription to serviceInstance PublicRoadMap
2. Navigate to the roadmap page (`/app/service/xtm_suite_roadmap/...`)
3. Check that epics with `active = false` display an orange "Draft" badge
   in the bottom-right corner of the tile, next to the three-dot menu
4. Check that active epics (Now / Next / Under consideration) do NOT display the badge

## Related issues

- Related to #1885

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.