### PR TITLE
[frontend] fix(trials): update reach out to sales dialog UX (#1900)

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -960,7 +960,7 @@
       "NeedSupport": "Need support",
       "ReachOutToSalesSuccessTitle": "Thank you!",
       "ReachOutToSalesSuccessMessage": "Thank you for reaching out, we'll get back to you shortly.",
-      "ReachOutToSalesDefaultMessage": "Please contact me about the {platform} free trial",
+      "ReachOutToSalesDefaultMessage": "Type your message to request help",
       "Cancellation": {
         "Toast": {
           "NoNewTrialPossible": "Thank you, your OpenCTI free trial was cancelled successfully. Please note that new openCTI trials can’t be requested.",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -981,7 +981,7 @@
       "NeedSupport": "Besoin d'aide",
       "ReachOutToSalesSuccessTitle": "Merci !",
       "ReachOutToSalesSuccessMessage": "Merci de nous avoir contactés, nous vous répondrons dans les plus brefs délais.",
-      "ReachOutToSalesDefaultMessage": "Veuillez me contacter au sujet de la version d'essai gratuite d'{platform}",
+      "ReachOutToSalesDefaultMessage": "Tapez votre message pour demander de l'aide",
       "Cancellation": {
         "Toast": {
           "NoNewTrialPossible": "Merci, votre essai gratuit d'OpenCTI a été annulé avec succès. Veuillez noter qu'il n'est pas possible de demander de nouveaux essais OpenCTI.",

--- a/apps/portal-front/src/components/service/trial-instances/reach-sales/reach-sales-dialog-form.tsx
+++ b/apps/portal-front/src/components/service/trial-instances/reach-sales/reach-sales-dialog-form.tsx
@@ -30,20 +30,18 @@ export const ReachSalesDialogForm: React.FC<Props> = ({
   isDialogOpen,
   setIsDialogOpen,
   onSubmit,
-  platformIdentifier,
+  platformIdentifier: _platformIdentifier,
 }) => {
   const t = useTranslations();
+
   const form = useForm<z.infer<typeof reachSalesSchema>>({
     resolver: zodResolver(reachSalesSchema),
     defaultValues: {
-      message: t(`Service.Trials.ReachOutToSalesDefaultMessage`, {
-        platform:
-          platformIdentifier === PlatformIdentifierEnum.OPENCTI
-            ? 'OpenCTI'
-            : 'OpenAEV',
-      }),
+      message: '',
     },
   });
+
+  const message = form.watch('message');
 
   const handleSubmit = (values: z.infer<typeof reachSalesSchema>) => {
     onSubmit(values.message);
@@ -55,30 +53,29 @@ export const ReachSalesDialogForm: React.FC<Props> = ({
       AlertTitle={t('Service.Trials.ReachOutToSales')}
       onClickContinue={form.handleSubmit(handleSubmit)}
       onOpenChange={setIsDialogOpen}
-      isOpen={isDialogOpen}>
+      isOpen={isDialogOpen}
+      continueButtonDisabled={!message.trim()}>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)}>
           <FormField
             control={form.control}
             name="message"
-            render={({ field }) => {
-              return (
-                <FormItem>
-                  <FormLabel>
-                    {t('Service.Trials.ReachOutToSalesMessagePlaceholder')}
-                  </FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder={t(
-                        'Service.Trials.ReachOutToSalesMessagePlaceholder'
-                      )}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              );
-            }}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('Service.Trials.ReachOutToSalesMessagePlaceholder')}
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder={t(
+                      'Service.Trials.ReachOutToSalesDefaultMessage'
+                    )}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
           />
         </form>
       </Form>

--- a/apps/portal-front/src/components/ui/alert-dialog.tsx
+++ b/apps/portal-front/src/components/ui/alert-dialog.tsx
@@ -24,6 +24,7 @@ interface AlertDialogProps {
   actionButtonText?: string;
   children: ReactNode;
   onClickContinue: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  continueButtonDisabled?: boolean;
   variantName?:
     | 'default'
     | 'destructive'
@@ -70,6 +71,7 @@ export const AlertDialogComponent: FunctionComponent<AlertDialogProps> = ({
   children,
   onClickContinue,
   variantName = 'default',
+  continueButtonDisabled = false,
 }) => {
   const t = useTranslations();
 
@@ -94,6 +96,7 @@ export const AlertDialogComponent: FunctionComponent<AlertDialogProps> = ({
           )}
           <AlertDialogAction
             onClick={onClickContinue}
+            disabled={continueButtonDisabled}
             className={buttonVariants({ variant: variantName })}>
             {actionButtonText}
           </AlertDialogAction>


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.

Fix issue #1900: improve the UX of the "Reach out to Sales" dialog.

- Removed the pre-filled message (counter-intuitive for the user)
- Replaced the placeholder "Your message" with "Type your message to request help"
- Disabled the "Continue" button when the message field is empty

<img width="1858" height="1835" alt="image" src="https://github.com/user-attachments/assets/bb7218e4-3855-43d7-8d60-f4f74bab16b9" />


<img width="1858" height="1835" alt="image" src="https://github.com/user-attachments/assets/8909776f-1617-4179-970f-68b7916e5250" />


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. Go to the OpenCTI free trial page
2. Click "Reach out to Sales"
3. Verify the field is empty with the new placeholder text in grey
4. Verify the "Continue" button is disabled
5. Type a message and verify the button becomes active
6. Clear the field and verify the button is disabled again

## Related issues

- Related to #1900

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.

`AlertDialogComponent` was extended with a new optional prop `continueButtonDisabled`
to support this use case. Default value is `false`, so existing usages are unaffected.