### PR TITLE
[backend] feat(free trials): clean groups after trial expiry (#1958)

### DIFF
--- a/apps/portal-api/src/crons.ts
+++ b/apps/portal-api/src/crons.ts
@@ -1,6 +1,7 @@
 import cron, { ScheduledTask } from 'node-cron';
 import { requestContext } from './context/request.context';
 import { DeploymentApp } from './modules/deployment/deployment.app';
+import { ServiceGroupApp } from './modules/deployment/group/service-group.app';
 import { UsersOrganizationApp } from './modules/users/users.organization.app';
 import { EpicApp } from './modules/xtm-suite-roadmap/epic.app';
 import { SYSTEM_USER_CONTEXT } from './portal.const';
@@ -38,6 +39,16 @@ const sendPublicRoadmapMonthlyReminder = async (): Promise<void> => {
   }
 };
 
+const cleanExpiredTrialGroups = async (): Promise<void> => {
+  logApp.info('Running cleanExpiredTrialGroups job');
+  requestContext.set(SYSTEM_USER_CONTEXT);
+  try {
+    await ServiceGroupApp.removeExpiredGroups();
+  } catch (error) {
+    logApp.error('cleanExpiredTrialGroups job failed:', { error });
+  }
+};
+
 export const initCronJobs = () => {
   logApp.info('Initializing cron jobs');
   scheduledTasks.push(cron.schedule('0 2 * * *', expireTrials));
@@ -45,6 +56,7 @@ export const initCronJobs = () => {
   scheduledTasks.push(
     cron.schedule('0 8 1 * *', sendPublicRoadmapMonthlyReminder)
   );
+  scheduledTasks.push(cron.schedule('0 3 * * *', cleanExpiredTrialGroups));
 };
 
 export const stopCronJobs = () => {

--- a/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
@@ -7,6 +7,7 @@ import {
   expect,
   it,
   vi,
+  type MockInstance,
 } from 'vitest';
 import { db } from '../../../../knexfile';
 import {
@@ -16,6 +17,7 @@ import {
 } from '../../../../tests/tests.const';
 import {
   DeploymentRequestDeploymentType,
+  DeploymentRequestHubStatus,
   DeploymentRequestPlatformRegion,
   PlatformIdentifier,
   ServiceConfigurationStatus,
@@ -36,8 +38,12 @@ import Subscription, {
   SubscriptionId,
 } from '../../../model/kanel/public/Subscription';
 import * as mailService from '../../../server/mail-service';
+import { auth0ClientMock } from '../../../thirdparty/auth0/mock';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { formatName } from '../../../utils/format';
+
+import { deleteServiceInstanceBy } from '../../services/service-instance.domain';
+import { insertDeploymentRequest } from '../deployment.test.utils';
 import { ServiceGroupApp } from './service-group.app';
 
 describe('ServiceGroupApp', () => {
@@ -406,6 +412,175 @@ describe('ServiceGroupApp', () => {
 
         expect(sendMailSpy).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('removeExpiredGroups', () => {
+    let auth0Spy: MockInstance;
+    const trackedServiceInstanceIds: ServiceInstanceId[] = [];
+
+    beforeEach(() => {
+      auth0Spy = vi.spyOn(auth0ClientMock, 'updateUserRBACInstance');
+    });
+
+    afterEach(async () => {
+      vi.restoreAllMocks();
+      if (trackedServiceInstanceIds.length > 0) {
+        await db('DeploymentRequest')
+          .whereIn('service_instance_id', trackedServiceInstanceIds)
+          .delete();
+        await db('Subscription')
+          .whereIn('service_instance_id', trackedServiceInstanceIds)
+          .delete();
+        await db('ServiceGroup')
+          .whereIn('service_instance_id', trackedServiceInstanceIds)
+          .delete();
+        for (const id of trackedServiceInstanceIds) {
+          await deleteServiceInstanceBy({ id });
+        }
+        trackedServiceInstanceIds.length = 0;
+      }
+    });
+
+    it.each([
+      DeploymentRequestHubStatus.Expired,
+      DeploymentRequestHubStatus.Cancelled,
+    ])('should remove users from groups for a %s trial', async (hub_status) => {
+      // Given
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() - 8);
+      const platformId = uuidv4();
+
+      const deploymentRequest = await insertDeploymentRequest({
+        hub_status,
+        end_date: endDate,
+        platform_id: platformId,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+      const groupId = uuidv4() as ServiceGroupId;
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: groupId,
+        name: 'Admin',
+        service_instance_id: deploymentRequest.service_instance_id,
+      });
+      await db<ServiceGroupUser>('ServiceGroup_User').insert({
+        group_id: groupId,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+      });
+
+      // When
+      await ServiceGroupApp.removeExpiredGroups();
+
+      // Then
+      const usersInGroup = await db<ServiceGroupUser>('ServiceGroup_User')
+        .where('group_id', groupId)
+        .select('*');
+      expect(usersInGroup).toEqual([]);
+
+      const groups = await db<ServiceGroup>('ServiceGroup')
+        .where('id', groupId)
+        .select('*');
+      expect(groups).toEqual([]);
+    });
+
+    it('should call auth0 with empty groups for each affected user', async () => {
+      // Given
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() - 8);
+      const platformId = uuidv4();
+
+      const deploymentRequest = await insertDeploymentRequest({
+        hub_status: DeploymentRequestHubStatus.Expired,
+        end_date: endDate,
+        platform_id: platformId,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+      const groupId = uuidv4() as ServiceGroupId;
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: groupId,
+        name: 'Admin',
+        service_instance_id: deploymentRequest.service_instance_id,
+      });
+      await db<ServiceGroupUser>('ServiceGroup_User').insert([
+        {
+          group_id: groupId,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        },
+        {
+          group_id: groupId,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
+        },
+      ]);
+
+      // When
+      await ServiceGroupApp.removeExpiredGroups();
+
+      // Then
+      expect(auth0Spy).toHaveBeenCalledTimes(2);
+      expect(auth0Spy).toHaveBeenCalledWith(
+        TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+        { [platformId]: { groups: [] } }
+      );
+      expect(auth0Spy).toHaveBeenCalledWith(
+        TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL,
+        { [platformId]: { groups: [] } }
+      );
+    });
+
+    it('should not remove users from DB when auth0 call fails', async () => {
+      // Given
+      auth0Spy.mockRejectedValue(new Error('Auth0 failure'));
+
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() - 8);
+      const platformId = uuidv4();
+
+      const deploymentRequest = await insertDeploymentRequest({
+        hub_status: DeploymentRequestHubStatus.Expired,
+        end_date: endDate,
+        platform_id: platformId,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+      const groupId = uuidv4() as ServiceGroupId;
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: groupId,
+        name: 'Admin',
+        service_instance_id: deploymentRequest.service_instance_id,
+      });
+      await db<ServiceGroupUser>('ServiceGroup_User').insert({
+        group_id: groupId,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+      });
+
+      // When
+      await ServiceGroupApp.removeExpiredGroups();
+
+      // Then
+      const usersInGroup = await db<ServiceGroupUser>('ServiceGroup_User')
+        .where('group_id', groupId)
+        .select('*');
+      expect(usersInGroup).toMatchObject([
+        {
+          group_id: groupId,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        },
+      ]);
+
+      const groups = await db<ServiceGroup>('ServiceGroup')
+        .where('id', groupId)
+        .select('*');
+      expect(groups).toHaveLength(1);
+    });
+
+    it('should not call auth0 when there are no expired groups', async () => {
+      // When
+      await ServiceGroupApp.removeExpiredGroups();
+
+      // Then
+      expect(auth0Spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/portal-api/src/modules/deployment/group/service-group.app.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.app.ts
@@ -136,6 +136,47 @@ export const ServiceGroupApp = {
       success: true,
     };
   },
+  removeExpiredGroups: async (): Promise<void> => {
+    const rows = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+    const byServiceInstance = rows.reduce<
+      Map<
+        ServiceInstanceId,
+        { deploymentRequestId: string; groupIds: ServiceGroupId[] }
+      >
+    >((acc, row) => {
+      const entry = acc.get(row.serviceInstanceId) ?? {
+        deploymentRequestId: row.deploymentRequestId,
+        groupIds: [],
+      };
+      entry.groupIds.push(row.groupId);
+      acc.set(row.serviceInstanceId, entry);
+      return acc;
+    }, new Map());
+
+    for (const [
+      serviceInstanceId,
+      { deploymentRequestId, groupIds },
+    ] of byServiceInstance) {
+      logApp.info('Removing users from expired trial groups', {
+        deploymentRequestId,
+        groupCount: groupIds.length,
+      });
+      try {
+        const oldUsers =
+          await ServiceGroupDomain.loadServiceInstanceGroupUsers(
+            serviceInstanceId
+          );
+        await updateAuth0Groups(oldUsers, [], serviceInstanceId);
+        await ServiceGroupDomain.deleteGroups(groupIds);
+      } catch (error) {
+        logApp.error('Failed to clean up expired trial groups', {
+          deploymentRequestId,
+          error,
+        });
+      }
+    }
+  },
 };
 
 const updateAuth0Groups = async (

--- a/apps/portal-api/src/modules/deployment/group/service-group.domain.test.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.domain.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { db } from '../../../../knexfile';
 import { SERVICES, TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
 import {
+  DeploymentRequestHubStatus,
   ServiceInstanceCreationStatus,
   ServiceInstanceJoinType,
 } from '../../../__generated__/resolvers-types';
@@ -11,6 +12,8 @@ import ServiceGroup, {
 } from '../../../model/kanel/public/ServiceGroup';
 import ServiceGroupUser from '../../../model/kanel/public/ServiceGroupUser';
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
+import { deleteServiceInstanceBy } from '../../services/service-instance.domain';
+import { insertDeploymentRequest } from '../deployment.test.utils';
 import { ServiceGroupDomain } from './service-group.domain';
 
 describe('ServiceGroupDomain', () => {
@@ -148,6 +151,160 @@ describe('ServiceGroupDomain', () => {
             TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID
         )
       );
+    });
+  });
+
+  describe('loadGroupsForExpiredTrials', () => {
+    const trackedServiceInstanceIds: ServiceInstanceId[] = [];
+
+    afterEach(async () => {
+      await db('DeploymentRequest')
+        .whereIn('service_instance_id', trackedServiceInstanceIds)
+        .delete();
+      await db('Subscription')
+        .whereIn('service_instance_id', trackedServiceInstanceIds)
+        .delete();
+      for (const id of trackedServiceInstanceIds) {
+        await deleteServiceInstanceBy({ id });
+      }
+      trackedServiceInstanceIds.length = 0;
+    });
+
+    it.each([
+      DeploymentRequestHubStatus.Expired,
+      DeploymentRequestHubStatus.Cancelled,
+    ])(
+      'should return groups for a %s trial expired more than 7 days ago',
+      async (hub_status) => {
+        // Given
+        const endDate = new Date();
+        endDate.setDate(endDate.getDate() - 8);
+        const deploymentRequest = await insertDeploymentRequest({
+          hub_status,
+          end_date: endDate,
+        });
+        trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+        const groupId = uuidv4() as ServiceGroupId;
+        await db<ServiceGroup>('ServiceGroup').insert({
+          id: groupId,
+          name: 'Admin',
+          service_instance_id: deploymentRequest.service_instance_id,
+        });
+
+        // When
+        const result = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+        // Then
+        expect(result).toMatchObject([
+          {
+            deploymentRequestId: deploymentRequest.id,
+            serviceInstanceId: deploymentRequest.service_instance_id,
+            groupId,
+          },
+        ]);
+      }
+    );
+
+    it('should not return groups for a trial expired less than 7 days ago', async () => {
+      // Given
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() - 6);
+      const deploymentRequest = await insertDeploymentRequest({
+        hub_status: DeploymentRequestHubStatus.Expired,
+        end_date: endDate,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: uuidv4() as ServiceGroupId,
+        name: 'Admin',
+        service_instance_id: deploymentRequest.service_instance_id,
+      });
+
+      // When
+      const result = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+      // Then
+      expect(result).toEqual([]);
+    });
+
+    it.each([
+      DeploymentRequestHubStatus.Active,
+      DeploymentRequestHubStatus.Pending,
+    ])(
+      'should not return groups for a trial with hub_status %s',
+      async (hub_status) => {
+        // Given
+        const endDate = new Date();
+        endDate.setDate(endDate.getDate() - 8);
+        const deploymentRequest = await insertDeploymentRequest({
+          hub_status,
+          end_date: endDate,
+        });
+        trackedServiceInstanceIds.push(deploymentRequest.service_instance_id);
+
+        await db<ServiceGroup>('ServiceGroup').insert({
+          id: uuidv4() as ServiceGroupId,
+          name: 'Admin',
+          service_instance_id: deploymentRequest.service_instance_id,
+        });
+
+        // When
+        const result = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+        // Then
+        expect(result).toEqual([]);
+      }
+    );
+
+    it('should return groups from all expired trials when multiple exist', async () => {
+      // Given
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() - 8);
+
+      const deploymentRequest1 = await insertDeploymentRequest({
+        hub_status: DeploymentRequestHubStatus.Expired,
+        end_date: endDate,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest1.service_instance_id);
+
+      const groupId1 = uuidv4() as ServiceGroupId;
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: groupId1,
+        name: 'Admin',
+        service_instance_id: deploymentRequest1.service_instance_id,
+      });
+
+      const deploymentRequest2 = await insertDeploymentRequest({
+        hub_status: DeploymentRequestHubStatus.Cancelled,
+        end_date: endDate,
+      });
+      trackedServiceInstanceIds.push(deploymentRequest2.service_instance_id);
+
+      const groupId2 = uuidv4() as ServiceGroupId;
+      await db<ServiceGroup>('ServiceGroup').insert({
+        id: groupId2,
+        name: 'Admin',
+        service_instance_id: deploymentRequest2.service_instance_id,
+      });
+
+      // When
+      const result = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+      // Then
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.deploymentRequestId)).toEqual(
+        expect.arrayContaining([deploymentRequest1.id, deploymentRequest2.id])
+      );
+    });
+
+    it('should return empty array when no expired trials exist', async () => {
+      // When
+      const result = await ServiceGroupDomain.loadGroupsForExpiredTrials();
+
+      // Then
+      expect(result).toEqual([]);
     });
   });
 });

--- a/apps/portal-api/src/modules/deployment/group/service-group.domain.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.domain.ts
@@ -1,5 +1,10 @@
 import { db } from '../../../../knexfile';
-import { PlatformIdentifier } from '../../../__generated__/resolvers-types';
+import {
+  DeploymentRequestDeploymentType,
+  DeploymentRequestHubStatus,
+  PlatformIdentifier,
+} from '../../../__generated__/resolvers-types';
+import { DeploymentRequestId } from '../../../model/kanel/public/DeploymentRequest';
 import ServiceGroup, {
   ServiceGroupId,
   ServiceGroupMutator,
@@ -109,6 +114,52 @@ export const ServiceGroupDomain = {
     }
 
     await db('ServiceGroup_User').del().whereIn('group_id', groupIds);
+  },
+
+  deleteGroups: async (groupIds: ServiceGroupId[]) => {
+    if (!groupIds.length) {
+      return;
+    }
+
+    await db('ServiceGroup').del().whereIn('id', groupIds);
+  },
+
+  loadGroupsForExpiredTrials: async (): Promise<
+    {
+      deploymentRequestId: DeploymentRequestId;
+      groupId: ServiceGroupId;
+      serviceInstanceId: ServiceInstanceId;
+    }[]
+  > => {
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    return db<{
+      groupId: ServiceGroupId;
+      deploymentRequestId: DeploymentRequestId;
+      serviceInstanceId: ServiceInstanceId;
+    }>('ServiceGroup')
+      .join(
+        'DeploymentRequest',
+        'DeploymentRequest.service_instance_id',
+        '=',
+        'ServiceGroup.service_instance_id'
+      )
+      .where(
+        'DeploymentRequest.type',
+        '=',
+        DeploymentRequestDeploymentType.Trial
+      )
+      .whereIn('DeploymentRequest.hub_status', [
+        DeploymentRequestHubStatus.Expired,
+        DeploymentRequestHubStatus.Cancelled,
+      ])
+      .where('DeploymentRequest.end_date', '<', sevenDaysAgo)
+      .select(
+        'ServiceGroup.id as groupId',
+        'DeploymentRequest.id as deploymentRequestId',
+        'ServiceGroup.service_instance_id as serviceInstanceId'
+      );
   },
 
   loadServiceInstanceGroupUsers: async (


### PR DESCRIPTION
# Context
Add a cronjob that removes service groups 7 days after trials is removed, and update auth0 accordingly.

## How to test
- make a trial expire (or cancel after activation)
- Check the users having access to the trial don't reference the trial in auth0 anymore
- Check the service groups don't exist anymore in DB.

## Related issues

- Related to #1958

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.