### PR TITLE
[backend] feat: add directive to encode/decode relay id (#2034)

### DIFF
--- a/apps/portal-api/codegen.yml
+++ b/apps/portal-api/codegen.yml
@@ -13,3 +13,8 @@ generates:
       inputMaybeValue: T | null
       makeResolverTypeCallable: true
       contextType: "../model/portal-context.js#PortalContext"
+    scalars:
+      ServiceInstanceId: "../model/kanel/public/ServiceInstance.js#ServiceInstanceId"
+      OrganizationId: "../model/kanel/public/Organization.js#OrganizationId"
+      DeploymentRequestId: "../model/kanel/public/DeploymentRequest.js#DeploymentRequestId"
+

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -17,7 +17,10 @@ export type Scalars = {
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
   Date: { input: any; output: any; }
+  DeploymentRequestId: { input: any; output: any; }
   JSON: { input: any; output: any; }
+  OrganizationId: { input: any; output: any; }
+  ServiceInstanceId: { input: any; output: any; }
   Upload: { input: any; output: any; }
 };
 
@@ -308,14 +311,14 @@ export type DeploymentRequest = Node & {
   job_title?: Maybe<DeploymentRequestJobTitle>;
   ordering: Scalars['Int']['output'];
   organization_name?: Maybe<Scalars['String']['output']>;
-  organization_requester_id: Scalars['ID']['output'];
+  organization_requester_id: Scalars['OrganizationId']['output'];
   platform_id?: Maybe<Scalars['String']['output']>;
   platform_identifier: PlatformIdentifier;
   platform_url?: Maybe<Scalars['String']['output']>;
   region: DeploymentRequestPlatformRegion;
   request_date: Scalars['Date']['output'];
   requester_email?: Maybe<Scalars['String']['output']>;
-  service_instance_id: Scalars['ID']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   start_date?: Maybe<Scalars['Date']['output']>;
   type: DeploymentRequestDeploymentType;
   use_case?: Maybe<DeploymentRequestUseCase>;
@@ -875,7 +878,7 @@ export type MutationAdminAddUserArgs = {
 
 
 export type MutationAdminCancelDeploymentRequestArgs = {
-  deploymentRequestId?: InputMaybe<Scalars['ID']['input']>;
+  deploymentRequestId?: InputMaybe<Scalars['DeploymentRequestId']['input']>;
 };
 
 
@@ -903,7 +906,7 @@ export type MutationBulkRemovePendingUserFromOrganizationArgs = {
 
 export type MutationCancelDeploymentRequestArgs = {
   cancellationReason?: InputMaybe<Scalars['String']['input']>;
-  deploymentRequestId: Scalars['ID']['input'];
+  deploymentRequestId: Scalars['DeploymentRequestId']['input'];
 };
 
 
@@ -1214,11 +1217,6 @@ export type OrganizationEdge = {
   node: Organization;
 };
 
-export type OrganizationId = Node & {
-  __typename?: 'OrganizationId';
-  id: Scalars['ID']['output'];
-};
-
 export type OrganizationInput = {
   domains?: InputMaybe<Array<Scalars['String']['input']>>;
   name: Scalars['String']['input'];
@@ -1227,6 +1225,11 @@ export type OrganizationInput = {
 export enum OrganizationOrdering {
   Name = 'name'
 }
+
+export type OrganizationRef = Node & {
+  __typename?: 'OrganizationRef';
+  id: Scalars['ID']['output'];
+};
 
 export type PageInfo = {
   __typename?: 'PageInfo';
@@ -1687,7 +1690,7 @@ export enum ReorderDeploymentRequestInQueueDirection {
 
 export type ReorderDeploymentRequestInQueueInput = {
   direction: ReorderDeploymentRequestInQueueDirection;
-  id: Scalars['ID']['input'];
+  id: Scalars['DeploymentRequestId']['input'];
 };
 
 export type RolePortal = Node & {
@@ -2239,7 +2242,7 @@ export enum UserOrdering {
 export type UserPendingSubscription = {
   __typename?: 'UserPendingSubscription';
   delete?: Maybe<User>;
-  invalidate?: Maybe<OrganizationId>;
+  invalidate?: Maybe<OrganizationRef>;
 };
 
 export type UserService = Node & {
@@ -2392,7 +2395,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   Document: ( Connector ) | ( CsvFeed ) | ( CustomDashboard ) | ( DefaultDocument ) | ( IntegrationHack ) | ( OpenAevScenario ) | ( RssFeed ) | ( Stream ) | ( TaxiiFeed ) | ( ThirdPartyIntegration );
   Integration: ( Connector ) | ( CsvFeed ) | ( IntegrationHack ) | ( RssFeed ) | ( Stream ) | ( TaxiiFeed ) | ( ThirdPartyIntegration );
-  Node: ( Capability ) | ( Competitor ) | ( Connector ) | ( CsvFeed ) | ( CustomDashboard ) | ( DefaultDocument ) | ( DeploymentRequest ) | ( Omit<Epic, 'document'> & { document?: Maybe<_RefType['Document']> } ) | ( GenericServiceCapability ) | ( IntegrationHack ) | ( IsPlatformRegisteredOrganization ) | ( MergeEvent ) | ( OpenAevScenario ) | ( Organization ) | ( OrganizationCapabilities ) | ( OrganizationId ) | ( RegisteredPlatform ) | ( RolePortal ) | ( RssFeed ) | ( SeoServiceInstance ) | ( ServiceCapability ) | ( ServiceDefinition ) | ( ServiceGroup ) | ( ServiceInstance ) | ( ServiceLink ) | ( Stream ) | ( SubscriptionCapability ) | ( SubscriptionModel ) | ( TaxiiFeed ) | ( ThirdPartyIntegration ) | ( UseCase ) | ( User ) | ( UserService ) | ( UserServiceCapability ) | ( UserServiceDeleted );
+  Node: ( Capability ) | ( Competitor ) | ( Connector ) | ( CsvFeed ) | ( CustomDashboard ) | ( DefaultDocument ) | ( DeploymentRequest ) | ( Omit<Epic, 'document'> & { document?: Maybe<_RefType['Document']> } ) | ( GenericServiceCapability ) | ( IntegrationHack ) | ( IsPlatformRegisteredOrganization ) | ( MergeEvent ) | ( OpenAevScenario ) | ( Organization ) | ( OrganizationCapabilities ) | ( OrganizationRef ) | ( RegisteredPlatform ) | ( RolePortal ) | ( RssFeed ) | ( SeoServiceInstance ) | ( ServiceCapability ) | ( ServiceDefinition ) | ( ServiceGroup ) | ( ServiceInstance ) | ( ServiceLink ) | ( Stream ) | ( SubscriptionCapability ) | ( SubscriptionModel ) | ( TaxiiFeed ) | ( ThirdPartyIntegration ) | ( UseCase ) | ( User ) | ( UserService ) | ( UserServiceCapability ) | ( UserServiceDeleted );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -2432,6 +2435,7 @@ export type ResolversTypes = ResolversObject<{
   DeploymentRequestFilter: DeploymentRequestFilter;
   DeploymentRequestFilterKey: DeploymentRequestFilterKey;
   DeploymentRequestHubStatus: DeploymentRequestHubStatus;
+  DeploymentRequestId: ResolverTypeWrapper<Scalars['DeploymentRequestId']['output']>;
   DeploymentRequestJobTitle: DeploymentRequestJobTitle;
   DeploymentRequestOrdering: DeploymentRequestOrdering;
   DeploymentRequestPlatformRegion: DeploymentRequestPlatformRegion;
@@ -2486,9 +2490,10 @@ export type ResolversTypes = ResolversObject<{
   OrganizationCapability: OrganizationCapability;
   OrganizationConnection: ResolverTypeWrapper<OrganizationConnection>;
   OrganizationEdge: ResolverTypeWrapper<OrganizationEdge>;
-  OrganizationId: ResolverTypeWrapper<OrganizationId>;
+  OrganizationId: ResolverTypeWrapper<Scalars['OrganizationId']['output']>;
   OrganizationInput: OrganizationInput;
   OrganizationOrdering: OrganizationOrdering;
+  OrganizationRef: ResolverTypeWrapper<OrganizationRef>;
   PageInfo: ResolverTypeWrapper<PageInfo>;
   PlatformContract: PlatformContract;
   PlatformDeploymentRequest: ResolverTypeWrapper<PlatformDeploymentRequest>;
@@ -2526,6 +2531,7 @@ export type ResolversTypes = ResolversObject<{
   ServiceInstanceEdge: ResolverTypeWrapper<ServiceInstanceEdge>;
   ServiceInstanceFilter: ServiceInstanceFilter;
   ServiceInstanceFilterKey: ServiceInstanceFilterKey;
+  ServiceInstanceId: ResolverTypeWrapper<Scalars['ServiceInstanceId']['output']>;
   ServiceInstanceJoinType: ServiceInstanceJoinType;
   ServiceInstanceOrdering: ServiceInstanceOrdering;
   ServiceInstanceSubscription: ResolverTypeWrapper<ServiceInstanceSubscription>;
@@ -2613,6 +2619,7 @@ export type ResolversParentTypes = ResolversObject<{
   DeploymentRequestConnection: DeploymentRequestConnection;
   DeploymentRequestEdge: DeploymentRequestEdge;
   DeploymentRequestFilter: DeploymentRequestFilter;
+  DeploymentRequestId: Scalars['DeploymentRequestId']['output'];
   Document: ResolversInterfaceTypes<ResolversParentTypes>['Document'];
   DocumentConnection: Omit<DocumentConnection, 'edges'> & { edges: Array<ResolversParentTypes['DocumentEdge']> };
   DocumentEdge: Omit<DocumentEdge, 'node'> & { node: ResolversParentTypes['Document'] };
@@ -2648,8 +2655,9 @@ export type ResolversParentTypes = ResolversObject<{
   OrganizationCapabilitiesInput: OrganizationCapabilitiesInput;
   OrganizationConnection: OrganizationConnection;
   OrganizationEdge: OrganizationEdge;
-  OrganizationId: OrganizationId;
+  OrganizationId: Scalars['OrganizationId']['output'];
   OrganizationInput: OrganizationInput;
+  OrganizationRef: OrganizationRef;
   PageInfo: PageInfo;
   PlatformDeploymentRequest: PlatformDeploymentRequest;
   PlatformDeploymentRequestConnection: PlatformDeploymentRequestConnection;
@@ -2677,6 +2685,7 @@ export type ResolversParentTypes = ResolversObject<{
   ServiceInstance: ServiceInstance;
   ServiceInstanceEdge: ServiceInstanceEdge;
   ServiceInstanceFilter: ServiceInstanceFilter;
+  ServiceInstanceId: Scalars['ServiceInstanceId']['output'];
   ServiceInstanceSubscription: ServiceInstanceSubscription;
   ServiceLink: ServiceLink;
   Settings: Settings;
@@ -2730,6 +2739,12 @@ export type AuthDirectiveArgs = {
 };
 
 export type AuthDirectiveResolver<Result, Parent, ContextType = PortalContext, Args = AuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type IdDirectiveArgs = {
+  type: Scalars['String']['input'];
+};
+
+export type IdDirectiveResolver<Result, Parent, ContextType = PortalContext, Args = IdDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type Platform_TokenDirectiveArgs = { };
 
@@ -2929,14 +2944,14 @@ export type DeploymentRequestResolvers<ContextType = PortalContext, ParentType e
   job_title?: Resolver<Maybe<ResolversTypes['DeploymentRequestJobTitle']>, ParentType, ContextType>;
   ordering?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   organization_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  organization_requester_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  organization_requester_id?: Resolver<ResolversTypes['OrganizationId'], ParentType, ContextType>;
   platform_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_identifier?: Resolver<ResolversTypes['PlatformIdentifier'], ParentType, ContextType>;
   platform_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   region?: Resolver<ResolversTypes['DeploymentRequestPlatformRegion'], ParentType, ContextType>;
   request_date?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   requester_email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   start_date?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   type?: Resolver<ResolversTypes['DeploymentRequestDeploymentType'], ParentType, ContextType>;
   use_case?: Resolver<Maybe<ResolversTypes['DeploymentRequestUseCase']>, ParentType, ContextType>;
@@ -2955,6 +2970,10 @@ export type DeploymentRequestEdgeResolvers<ContextType = PortalContext, ParentTy
   node?: Resolver<ResolversTypes['DeploymentRequest'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface DeploymentRequestIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DeploymentRequestId'], any> {
+  name: 'DeploymentRequestId';
+}
 
 export type DocumentResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['Document'] = ResolversParentTypes['Document']> = ResolversObject<{
   __resolveType: TypeResolveFn<'Connector' | 'CsvFeed' | 'CustomDashboard' | 'DefaultDocument' | 'IntegrationHack' | 'OpenAEVScenario' | 'RssFeed' | 'Stream' | 'TaxiiFeed' | 'ThirdPartyIntegration', ParentType, ContextType>;
@@ -3179,7 +3198,7 @@ export type MutationResolvers<ContextType = PortalContext, ParentType extends Re
 }>;
 
 export type NodeResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Capability' | 'Competitor' | 'Connector' | 'CsvFeed' | 'CustomDashboard' | 'DefaultDocument' | 'DeploymentRequest' | 'Epic' | 'GenericServiceCapability' | 'IntegrationHack' | 'IsPlatformRegisteredOrganization' | 'MergeEvent' | 'OpenAEVScenario' | 'Organization' | 'OrganizationCapabilities' | 'OrganizationId' | 'RegisteredPlatform' | 'RolePortal' | 'RssFeed' | 'SeoServiceInstance' | 'ServiceCapability' | 'ServiceDefinition' | 'ServiceGroup' | 'ServiceInstance' | 'ServiceLink' | 'Stream' | 'SubscriptionCapability' | 'SubscriptionModel' | 'TaxiiFeed' | 'ThirdPartyIntegration' | 'UseCase' | 'User' | 'UserService' | 'UserServiceCapability' | 'UserServiceDeleted', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'Capability' | 'Competitor' | 'Connector' | 'CsvFeed' | 'CustomDashboard' | 'DefaultDocument' | 'DeploymentRequest' | 'Epic' | 'GenericServiceCapability' | 'IntegrationHack' | 'IsPlatformRegisteredOrganization' | 'MergeEvent' | 'OpenAEVScenario' | 'Organization' | 'OrganizationCapabilities' | 'OrganizationRef' | 'RegisteredPlatform' | 'RolePortal' | 'RssFeed' | 'SeoServiceInstance' | 'ServiceCapability' | 'ServiceDefinition' | 'ServiceGroup' | 'ServiceInstance' | 'ServiceLink' | 'Stream' | 'SubscriptionCapability' | 'SubscriptionModel' | 'TaxiiFeed' | 'ThirdPartyIntegration' | 'UseCase' | 'User' | 'UserService' | 'UserServiceCapability' | 'UserServiceDeleted', ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
@@ -3243,7 +3262,11 @@ export type OrganizationEdgeResolvers<ContextType = PortalContext, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type OrganizationIdResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['OrganizationId'] = ResolversParentTypes['OrganizationId']> = ResolversObject<{
+export interface OrganizationIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['OrganizationId'], any> {
+  name: 'OrganizationId';
+}
+
+export type OrganizationRefResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['OrganizationRef'] = ResolversParentTypes['OrganizationRef']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -3491,6 +3514,10 @@ export type ServiceInstanceEdgeResolvers<ContextType = PortalContext, ParentType
   node?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface ServiceInstanceIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ServiceInstanceId'], any> {
+  name: 'ServiceInstanceId';
+}
 
 export type ServiceInstanceSubscriptionResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['ServiceInstanceSubscription'] = ResolversParentTypes['ServiceInstanceSubscription']> = ResolversObject<{
   add?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
@@ -3751,7 +3778,7 @@ export type UserEdgeResolvers<ContextType = PortalContext, ParentType extends Re
 
 export type UserPendingSubscriptionResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['UserPendingSubscription'] = ResolversParentTypes['UserPendingSubscription']> = ResolversObject<{
   delete?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  invalidate?: Resolver<Maybe<ResolversTypes['OrganizationId']>, ParentType, ContextType>;
+  invalidate?: Resolver<Maybe<ResolversTypes['OrganizationRef']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3818,6 +3845,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   DeploymentRequest?: DeploymentRequestResolvers<ContextType>;
   DeploymentRequestConnection?: DeploymentRequestConnectionResolvers<ContextType>;
   DeploymentRequestEdge?: DeploymentRequestEdgeResolvers<ContextType>;
+  DeploymentRequestId?: GraphQLScalarType;
   Document?: DocumentResolvers<ContextType>;
   DocumentConnection?: DocumentConnectionResolvers<ContextType>;
   DocumentEdge?: DocumentEdgeResolvers<ContextType>;
@@ -3840,7 +3868,8 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   OrganizationCapabilities?: OrganizationCapabilitiesResolvers<ContextType>;
   OrganizationConnection?: OrganizationConnectionResolvers<ContextType>;
   OrganizationEdge?: OrganizationEdgeResolvers<ContextType>;
-  OrganizationId?: OrganizationIdResolvers<ContextType>;
+  OrganizationId?: GraphQLScalarType;
+  OrganizationRef?: OrganizationRefResolvers<ContextType>;
   PageInfo?: PageInfoResolvers<ContextType>;
   PlatformDeploymentRequest?: PlatformDeploymentRequestResolvers<ContextType>;
   PlatformDeploymentRequestConnection?: PlatformDeploymentRequestConnectionResolvers<ContextType>;
@@ -3861,6 +3890,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   ServiceGroup?: ServiceGroupResolvers<ContextType>;
   ServiceInstance?: ServiceInstanceResolvers<ContextType>;
   ServiceInstanceEdge?: ServiceInstanceEdgeResolvers<ContextType>;
+  ServiceInstanceId?: GraphQLScalarType;
   ServiceInstanceSubscription?: ServiceInstanceSubscriptionResolvers<ContextType>;
   ServiceLink?: ServiceLinkResolvers<ContextType>;
   Settings?: SettingsResolvers<ContextType>;
@@ -3895,6 +3925,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
 
 export type DirectiveResolvers<ContextType = PortalContext> = ResolversObject<{
   auth?: AuthDirectiveResolver<any, any, ContextType>;
+  id?: IdDirectiveResolver<any, any, ContextType>;
   platform_token?: Platform_TokenDirectiveResolver<any, any, ContextType>;
   service_capa?: Service_CapaDirectiveResolver<any, any, ContextType>;
   system_token?: System_TokenDirectiveResolver<any, any, ContextType>;

--- a/apps/portal-api/src/modules/organizations/organizations.graphql
+++ b/apps/portal-api/src/modules/organizations/organizations.graphql
@@ -2,7 +2,9 @@ enum OrganizationOrdering {
   name
 }
 
-type OrganizationId implements Node {
+scalar OrganizationId
+
+type OrganizationRef implements Node {
   id: ID!
 }
 

--- a/apps/portal-api/src/modules/services/deployments/deployments.graphql
+++ b/apps/portal-api/src/modules/services/deployments/deployments.graphql
@@ -1,3 +1,5 @@
+scalar DeploymentRequestId
+
 enum DeploymentRequestPlatformRegion {
   eu_west
   us_east
@@ -119,8 +121,8 @@ type DeploymentRequest implements Node {
   hub_status: DeploymentRequestHubStatus!
   ordering: Int!
   requester_email: String
-  organization_requester_id: ID!
-  service_instance_id: ID!
+  organization_requester_id: OrganizationId! @id(type: "Organization")
+  service_instance_id: ServiceInstanceId! @id(type: "ServiceInstance")
   organization_name: String
   request_date: Date!
   counts_in_orga_quota: Boolean!
@@ -249,7 +251,7 @@ enum ReorderDeploymentRequestInQueueDirection {
 }
 
 input ReorderDeploymentRequestInQueueInput {
-  id: ID!
+  id: DeploymentRequestId! @id(type: "DeploymentRequest")
   direction: ReorderDeploymentRequestInQueueDirection!
 }
 
@@ -301,12 +303,13 @@ extend type Mutation {
     input: ReorderDeploymentRequestInQueueInput!
   ): Success! @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
   cancelDeploymentRequest(
-    deploymentRequestId: ID!
+    deploymentRequestId: DeploymentRequestId! @id(type: "DeploymentRequest")
     cancellationReason: String
   ): DeploymentRequest
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
-  adminCancelDeploymentRequest(deploymentRequestId: ID): DeploymentRequest
-    @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
+  adminCancelDeploymentRequest(
+    deploymentRequestId: DeploymentRequestId @id(type: "DeploymentRequest")
+  ): DeploymentRequest @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
   updateDeploymentQuotaCapacity(
     input: UpdateDeploymentQuotaCapacityInput!
   ): Success! @auth(portalCapa: [BYPASS, MODIFY_TRIALS_QUOTA])

--- a/apps/portal-api/src/modules/services/deployments/deployments.resolver.ts
+++ b/apps/portal-api/src/modules/services/deployments/deployments.resolver.ts
@@ -1,4 +1,3 @@
-import { toGlobalId } from 'graphql-relay/node/node.js';
 import {
   DeploymentAvailability,
   DeploymentRequestConnection,
@@ -6,26 +5,12 @@ import {
   QueryDeploymentRequestsListArgs,
   Resolvers,
 } from '../../../__generated__/resolvers-types';
-import { DeploymentRequestId } from '../../../model/kanel/public/DeploymentRequest';
 import { UnknownErrorCode } from '../../../utils/error/error.code';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
-import { extractId } from '../../../utils/utils';
 import { DeploymentsApp } from './deployments.app';
 import { DeploymentRequestDomain } from './deployments.domain';
 
 const resolvers: Resolvers = {
-  DeploymentRequest: {
-    service_instance_id: ({ service_instance_id }) => {
-      if (service_instance_id) {
-        return toGlobalId('ServiceInstance', service_instance_id);
-      }
-    },
-    organization_requester_id: ({ organization_requester_id }) => {
-      if (organization_requester_id) {
-        return toGlobalId('Organization', organization_requester_id);
-      }
-    },
-  },
   Query: {
     deploymentRequests: async (_, args: QueryDeploymentRequestsArgs) => {
       try {
@@ -106,7 +91,7 @@ const resolvers: Resolvers = {
     ) => {
       try {
         return await DeploymentsApp.cancelDeploymentRequest(
-          extractId<DeploymentRequestId>(deploymentRequestId),
+          deploymentRequestId,
           false,
           cancellationReason
         );
@@ -120,7 +105,7 @@ const resolvers: Resolvers = {
     adminCancelDeploymentRequest: async (_, { deploymentRequestId }) => {
       try {
         return await DeploymentsApp.cancelDeploymentRequest(
-          extractId<DeploymentRequestId>(deploymentRequestId),
+          deploymentRequestId,
           true
         );
       } catch (error) {
@@ -133,10 +118,7 @@ const resolvers: Resolvers = {
 
     reorderDeploymentRequestInQueue: async (_, { input }) => {
       try {
-        return await DeploymentsApp.reorderDeploymentRequestInQueue({
-          ...input,
-          id: extractId<DeploymentRequestId>(input.id),
-        });
+        return await DeploymentsApp.reorderDeploymentRequestInQueue(input);
       } catch (error) {
         throw mapToGraphQLError(error);
       }

--- a/apps/portal-api/src/modules/services/service-instance.graphql
+++ b/apps/portal-api/src/modules/services/service-instance.graphql
@@ -1,3 +1,5 @@
+scalar ServiceInstanceId
+
 enum ServiceInstanceOrdering {
   name
   description

--- a/apps/portal-api/src/modules/users/users.graphql
+++ b/apps/portal-api/src/modules/users/users.graphql
@@ -176,7 +176,7 @@ type MeUserSubscription {
 
 type UserPendingSubscription {
   delete: User
-  invalidate: OrganizationId
+  invalidate: OrganizationRef
 }
 
 type Subscription {

--- a/apps/portal-api/src/nodes/node.graphql
+++ b/apps/portal-api/src/nodes/node.graphql
@@ -2,7 +2,9 @@ directive @system_token repeatable on OBJECT | FIELD_DEFINITION
 
 directive @platform_token repeatable on OBJECT | FIELD_DEFINITION
 
-directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @id(
+  type: String!
+) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @auth(
   portalCapa: [PortalCapability] = []

--- a/apps/portal-api/src/nodes/node.graphql
+++ b/apps/portal-api/src/nodes/node.graphql
@@ -2,6 +2,8 @@ directive @system_token repeatable on OBJECT | FIELD_DEFINITION
 
 directive @platform_token repeatable on OBJECT | FIELD_DEFINITION
 
+directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 directive @auth(
   portalCapa: [PortalCapability] = []
   orgaCapa: [OrganizationCapability] = []

--- a/apps/portal-api/src/security/directive-graphql/id-directive.transformer.test.ts
+++ b/apps/portal-api/src/security/directive-graphql/id-directive.transformer.test.ts
@@ -1,0 +1,529 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import * as relayNode from 'graphql-relay/node/node.js';
+import { toGlobalId } from 'graphql-relay/node/node.js';
+import { describe, expect, it, vi } from 'vitest';
+import { idDirectiveTransformer } from './id-directive.transformer';
+
+const schemaDefinition = `
+  directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+  scalar DeploymentRequestId
+
+  type DeploymentRequest {
+    service_instance_id: ID! @id(type: "ServiceInstance")
+  }
+
+  input ReorderInput {
+    id: DeploymentRequestId! @id(type: "DeploymentRequest")
+  }
+
+  input NestedInnerInput {
+    deploymentRequestId: ID! @id(type: "DeploymentRequest")
+  }
+
+  input NestedOuterInput {
+    nested: NestedInnerInput!
+  }
+
+  type Query {
+    deploymentRequest(id: DeploymentRequestId! @id(type: "DeploymentRequest")): DeploymentRequest!
+    deploymentRequests(ids: [ID!]! @id(type: "DeploymentRequest")): [String!]!
+    encodedServiceInstanceId: ID! @id(type: "ServiceInstance")
+    encodedServiceInstanceIds: [ID!]! @id(type: "ServiceInstance")
+    nullableDecodedArg(id: ID @id(type: "DeploymentRequest")): String!
+    nullableEncodedServiceInstanceId: ID @id(type: "ServiceInstance")
+    mixedFlow(id: ID! @id(type: "DeploymentRequest")): ID! @id(type: "ServiceInstance")
+    passthrough(id: ID!, label: String!): String!
+  }
+
+  type Mutation {
+    reorder(input: ReorderInput!): String!
+    nestedDecode(input: NestedOuterInput!): String!
+  }
+`;
+
+describe('idDirectiveTransformer', () => {
+  it('throws when @id is applied on id field of a Node implementor to prevent double encoding', () => {
+    const invalidSchemaDefinition = `
+      directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+      interface Node {
+        id: ID!
+      }
+
+      type Organization implements Node {
+        id: ID! @id(type: "Organization")
+      }
+
+      type Query {
+        organization: Organization!
+      }
+    `;
+
+    const schema = makeExecutableSchema({
+      typeDefs: invalidSchemaDefinition,
+      resolvers: {
+        Query: {
+          organization: () => ({ id: 'org-1' }),
+        },
+      },
+    });
+
+    expect(() => idDirectiveTransformer(schema)).toThrow(
+      'Invalid @id usage on Organization.id: Node ids are already globally encoded by the Node.id resolver.'
+    );
+  });
+
+  it('decodes a directive annotated argument before resolver execution', async () => {
+    const resolverSpy = vi
+      .fn()
+      .mockReturnValue({ service_instance_id: 'svc-1' });
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            deploymentRequest: (_root: unknown, args: { id: string }) => {
+              resolverSpy(args.id);
+              return { service_instance_id: 'svc-1' };
+            },
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().deploymentRequest;
+
+    // Given
+    const args = { id: toGlobalId('DeploymentRequest', 'dep-1') };
+
+    // When
+    const result = await queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(result).toMatchObject({ service_instance_id: 'svc-1' });
+    expect(resolverSpy).toHaveBeenCalledOnce();
+    expect(resolverSpy).toHaveBeenCalledWith('dep-1');
+  });
+
+  it('throws a bad request error when global id parsing fails for an @id argument', async () => {
+    const fromGlobalIdSpy = vi
+      .spyOn(relayNode, 'fromGlobalId')
+      .mockImplementationOnce(() => {
+        throw new Error('invalid global id payload');
+      });
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            deploymentRequest: () => ({ service_instance_id: 'svc-1' }),
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().deploymentRequest;
+
+    // Given
+    const args = { id: 'malformed-global-id' };
+
+    // When
+    const call = queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    await expect(call).rejects.toThrow(
+      'Invalid global id for type DeploymentRequest'
+    );
+
+    fromGlobalIdSpy.mockRestore();
+  });
+
+  it('rejects mismatched global id type for a directive annotated argument', async () => {
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            deploymentRequest: () => ({ service_instance_id: 'svc-1' }),
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().deploymentRequest;
+
+    // Given
+    const args = { id: toGlobalId('Organization', 'org-1') };
+
+    // When
+    const call = queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    await expect(call).rejects.toThrow(
+      'Expected global id of type DeploymentRequest'
+    );
+  });
+
+  it('decodes list argument values for a directive annotated argument list', async () => {
+    const resolverSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            deploymentRequests: (_root: unknown, args: { ids: string[] }) => {
+              resolverSpy(args.ids);
+              return args.ids;
+            },
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().deploymentRequests;
+
+    // Given
+    const args = {
+      ids: [
+        toGlobalId('DeploymentRequest', 'dep-1'),
+        toGlobalId('DeploymentRequest', 'dep-2'),
+      ],
+    };
+
+    // When
+    const result = await queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(result).toMatchObject(['dep-1', 'dep-2']);
+    expect(resolverSpy).toHaveBeenCalledWith(['dep-1', 'dep-2']);
+  });
+
+  it('encodes list field results for a directive annotated field list', async () => {
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            encodedServiceInstanceIds: () => ['svc-1', 'svc-2'],
+          },
+        },
+      })
+    );
+
+    const queryField = schema
+      .getQueryType()
+      ?.getFields().encodedServiceInstanceIds;
+
+    // When
+    const result = await queryField?.resolve?.({}, {}, {}, {} as never);
+
+    // Then
+    expect(result).toMatchObject([
+      toGlobalId('ServiceInstance', 'svc-1'),
+      toGlobalId('ServiceInstance', 'svc-2'),
+    ]);
+  });
+
+  it('decodes directive annotated input object fields recursively', async () => {
+    const mutationSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Mutation: {
+            nestedDecode: (
+              _root: unknown,
+              args: { input: { nested: { deploymentRequestId: string } } }
+            ) => {
+              mutationSpy(args.input.nested.deploymentRequestId);
+              return 'ok';
+            },
+          },
+        },
+      })
+    );
+
+    const mutationField = schema.getMutationType()?.getFields().nestedDecode;
+
+    // Given
+    const args = {
+      input: {
+        nested: {
+          deploymentRequestId: toGlobalId('DeploymentRequest', 'dep-99'),
+        },
+      },
+    };
+
+    // When
+    const result = await mutationField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(result).toBe('ok');
+    expect(mutationSpy).toHaveBeenCalledWith('dep-99');
+  });
+
+  it('keeps nullable @id argument and nullable @id field as null', async () => {
+    const argSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            nullableDecodedArg: (
+              _root: unknown,
+              args: { id: string | null }
+            ) => {
+              argSpy(args.id);
+              return 'ok';
+            },
+            nullableEncodedServiceInstanceId: () => null,
+          },
+        },
+      })
+    );
+
+    const nullableArgField = schema
+      .getQueryType()
+      ?.getFields().nullableDecodedArg;
+    const nullableField = schema
+      .getQueryType()
+      ?.getFields().nullableEncodedServiceInstanceId;
+
+    // When
+    const argResult = await nullableArgField?.resolve?.(
+      {},
+      { id: null },
+      {},
+      {} as never
+    );
+    const fieldResult = await nullableField?.resolve?.({}, {}, {}, {} as never);
+
+    // Then
+    expect(argResult).toBe('ok');
+    expect(fieldResult).toBeNull();
+    expect(argSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('supports decode+encode flow in the same resolver for @id argument and @id field', async () => {
+    const resolverSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            mixedFlow: (_root: unknown, args: { id: string }) => {
+              resolverSpy(args.id);
+              return `svc-for-${args.id}`;
+            },
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().mixedFlow;
+
+    // Given
+    const args = { id: toGlobalId('DeploymentRequest', 'dep-7') };
+
+    // When
+    const result = await queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(resolverSpy).toHaveBeenCalledWith('dep-7');
+    expect(result).toBe(toGlobalId('ServiceInstance', 'svc-for-dep-7'));
+  });
+
+  it('does not transform values for non-annotated arguments or fields', async () => {
+    const resolverSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            passthrough: (
+              _root: unknown,
+              args: { id: string; label: string }
+            ) => {
+              resolverSpy(args);
+              return `${args.id}:${args.label}`;
+            },
+          },
+        },
+      })
+    );
+
+    const queryField = schema.getQueryType()?.getFields().passthrough;
+
+    // Given
+    const encodedId = toGlobalId('DeploymentRequest', 'dep-55');
+    const args = { id: encodedId, label: 'stable' };
+
+    // When
+    const result = await queryField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(resolverSpy).toHaveBeenCalledWith({
+      id: encodedId,
+      label: 'stable',
+    });
+    expect(result).toBe(`${encodedId}:stable`);
+  });
+
+  it('encodes a directive annotated field result as a relay global id', async () => {
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Query: {
+            encodedServiceInstanceId: () => 'svc-1',
+          },
+        },
+      })
+    );
+
+    const queryField = schema
+      .getQueryType()
+      ?.getFields().encodedServiceInstanceId;
+
+    // When
+    const encodedResult = await queryField?.resolve?.({}, {}, {}, {} as never);
+
+    // Then
+    expect(encodedResult).toBe(toGlobalId('ServiceInstance', 'svc-1'));
+  });
+
+  it('decodes directive annotated input object fields', async () => {
+    const mutationSpy = vi.fn().mockImplementation((_id: string) => 'ok');
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: schemaDefinition,
+        resolvers: {
+          Mutation: {
+            reorder: (_root: unknown, args: { input: { id: string } }) => {
+              mutationSpy(args.input.id);
+              return 'ok';
+            },
+          },
+        },
+      })
+    );
+
+    const mutationField = schema.getMutationType()?.getFields().reorder;
+
+    // Given
+    const args = {
+      input: {
+        id: toGlobalId('DeploymentRequest', 'dep-99'),
+      },
+    };
+
+    // When
+    const result = await mutationField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(result).toBe('ok');
+    expect(mutationSpy).toHaveBeenCalledWith('dep-99');
+  });
+
+  it('decodes nested @id fields when input object types are mutually referential', async () => {
+    const circularSchemaDefinition = `
+      directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+      input CircularAInput {
+        label: String!
+        b: CircularBInput!
+      }
+
+      input CircularBInput {
+        deploymentRequestId: ID! @id(type: "DeploymentRequest")
+        a: CircularAInput
+      }
+
+      type Mutation {
+        circularDecode(input: CircularAInput!): String!
+      }
+
+      type Query {
+        _noop: String
+      }
+    `;
+
+    const mutationSpy = vi.fn();
+
+    const schema = idDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: circularSchemaDefinition,
+        resolvers: {
+          Mutation: {
+            circularDecode: (
+              _root: unknown,
+              args: {
+                input: {
+                  label: string;
+                  b: {
+                    deploymentRequestId: string;
+                    a: {
+                      label: string;
+                      b: {
+                        deploymentRequestId: string;
+                      };
+                    };
+                  };
+                };
+              }
+            ) => {
+              mutationSpy(args.input);
+              return 'ok';
+            },
+          },
+        },
+      })
+    );
+
+    const mutationField = schema.getMutationType()?.getFields().circularDecode;
+
+    // Given
+    const args = {
+      input: {
+        label: 'root',
+        b: {
+          deploymentRequestId: toGlobalId('DeploymentRequest', 'dep-1'),
+          a: {
+            label: 'child',
+            b: {
+              deploymentRequestId: toGlobalId('DeploymentRequest', 'dep-2'),
+            },
+          },
+        },
+      },
+    };
+
+    // When
+    const result = await mutationField?.resolve?.({}, args, {}, {} as never);
+
+    // Then
+    expect(result).toBe('ok');
+    expect(mutationSpy).toHaveBeenCalledOnce();
+    expect(mutationSpy.mock.calls[0]![0]).toMatchObject({
+      label: 'root',
+      b: {
+        deploymentRequestId: 'dep-1',
+        a: {
+          label: 'child',
+          b: {
+            deploymentRequestId: 'dep-2',
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/portal-api/src/security/directive-graphql/id-directive.transformer.ts
+++ b/apps/portal-api/src/security/directive-graphql/id-directive.transformer.ts
@@ -1,0 +1,390 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
+import {
+  defaultFieldResolver,
+  GraphQLFieldConfig,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLOutputType,
+  GraphQLSchema,
+  GraphQLType,
+  isInputObjectType,
+  isListType,
+  isNonNullType,
+  isObjectType,
+} from 'graphql';
+import { fromGlobalId, toGlobalId } from 'graphql-relay/node/node.js';
+import { BadRequestError } from '../../utils/error/error.util';
+
+export const ID_DIRECTIVE_NAME = 'id';
+
+type IdDirective = {
+  type: string;
+};
+
+type InputIdFieldInfo = {
+  fieldName: string;
+  idDirective: IdDirective;
+  fieldType: GraphQLInputType;
+};
+type InputTypeIdFieldInfo = Record<string, InputIdFieldInfo[]>;
+
+/**
+ * Recursively traverses a GraphQL output value, handling NonNull and List wrappers.
+ * Calls the provided onLeaf handler for each leaf value.
+ * Used to encode field results as Relay global ids.
+ */
+const traverseOutputValue = (
+  value: unknown,
+  type: GraphQLOutputType,
+  onLeaf: (v: unknown) => unknown
+): unknown => {
+  if (value === null || value === undefined) return value;
+  if (isNonNullType(type))
+    return traverseOutputValue(value, type.ofType, onLeaf);
+  if (isListType(type))
+    return Array.isArray(value)
+      ? value.map((v) => traverseOutputValue(v, type.ofType, onLeaf))
+      : value;
+  return onLeaf(value);
+};
+
+interface TraversalContext {
+  isIdField: boolean;
+  idDirective?: IdDirective;
+  fieldType?: GraphQLInputType;
+}
+
+/**
+ * Recursively traverses a GraphQL input value, handling NonNull, List, and InputObject wrappers.
+ * For each field annotated with @id, calls the handler with isIdField=true.
+ * For nested input objects, recurses into their fields.
+ * Used to decode arguments containing global ids before resolver execution.
+ */
+const traverseInputValue = (
+  value: unknown,
+  type: GraphQLInputType,
+  idFields: InputTypeIdFieldInfo,
+  handler: (v: unknown, ctx: TraversalContext) => unknown
+): unknown => {
+  if (value === null || value === undefined) return value;
+  if (isNonNullType(type))
+    return traverseInputValue(value, type.ofType, idFields, handler);
+  if (isListType(type))
+    return Array.isArray(value)
+      ? value.map((v) => traverseInputValue(v, type.ofType, idFields, handler))
+      : value;
+  const inputObjType = getInputObjectType(type);
+  if (inputObjType && typeof value === 'object' && !Array.isArray(value)) {
+    const copy = { ...(value as Record<string, unknown>) };
+    // Handle all direct @id fields for this input object type
+    const idFieldArr = idFields[inputObjType.name] || [];
+    for (const { fieldName, idDirective, fieldType } of idFieldArr) {
+      if (Object.prototype.hasOwnProperty.call(copy, fieldName)) {
+        copy[fieldName] = handler(copy[fieldName], {
+          isIdField: true,
+          idDirective,
+          fieldType,
+        });
+      }
+    }
+    // Recurse into all nested input objects
+    for (const [fieldName, field] of Object.entries(inputObjType.getFields())) {
+      if (!Object.prototype.hasOwnProperty.call(copy, fieldName)) continue;
+      const nestedInputType = getInputObjectType(field.type);
+      if (nestedInputType) {
+        copy[fieldName] = traverseInputValue(
+          copy[fieldName],
+          field.type,
+          idFields,
+          handler
+        );
+      }
+    }
+    return copy;
+  }
+  // Not an input object: call handler for leaf value
+  return handler(value, { isIdField: false });
+};
+
+/** Reads the first `@id` directive attached to any schema element (field, arg, input field). */
+const getIdDirective = (
+  schema: GraphQLSchema,
+  target: unknown
+): IdDirective | undefined => {
+  return getDirective(schema, target, ID_DIRECTIVE_NAME)?.[0] as
+    | IdDirective
+    | undefined;
+};
+
+/** Unwraps NonNull/List layers and returns the underlying InputObjectType, or null if the leaf is a scalar/enum. */
+const getInputObjectType = (
+  inputType: GraphQLInputType
+): GraphQLInputObjectType | null => {
+  let unwrapped: GraphQLType = inputType;
+  while (isNonNullType(unwrapped) || isListType(unwrapped)) {
+    unwrapped = unwrapped.ofType;
+  }
+  return isInputObjectType(unwrapped) ? unwrapped : null;
+};
+
+/**
+ * Collects information about all input object types that have fields annotated with @id,
+ * and determines which input types (directly or transitively) contain any @id field.
+ * This is used to efficiently identify which arguments need global id decoding.
+ * Handles cycles in the input type graph (e.g., mutually referential input types).
+ */
+const getInputIdFieldInfo = (
+  schema: GraphQLSchema
+): {
+  inputTypeIdFieldInfo: InputTypeIdFieldInfo;
+  inputTypesWithAnyIdField: Set<string>;
+} => {
+  const inputTypeIdFieldInfo: InputTypeIdFieldInfo = {};
+  const inputTypesWithAnyIdField = new Set<string>();
+  // Track DFS state to avoid infinite recursion on cycles
+  const state = new Map<string, 'visiting' | 'visited'>();
+  const stack: string[] = [];
+
+  // First pass: collect all fields with a direct @id directive for each input object type
+  for (const type of Object.values(schema.getTypeMap())) {
+    if (!isInputObjectType(type) || type.name.startsWith('__')) continue;
+    const fields: InputIdFieldInfo[] = [];
+    for (const [fieldName, field] of Object.entries(type.getFields())) {
+      const idDirective = getIdDirective(schema, field);
+      if (idDirective) {
+        fields.push({ fieldName, idDirective, fieldType: field.type });
+      }
+    }
+    if (fields.length > 0) {
+      inputTypeIdFieldInfo[type.name] = fields;
+    }
+  }
+
+  /**
+   * Second pass: DFS to find all input types that (directly or transitively) contain any @id field.
+   * Handles cycles by marking types as 'visiting' and using a stack to propagate the presence of @id fields.
+   * If a cycle is detected and any type in the stack has an @id field, all types in the cycle are marked.
+   */
+  const dfs = (type: GraphQLInputObjectType) => {
+    const curState = state.get(type.name);
+    if (curState === 'visiting') {
+      // Cycle detected: if any type in stack has an id field, mark all
+      if (stack.some((t) => inputTypesWithAnyIdField.has(t))) {
+        stack.forEach((t) => inputTypesWithAnyIdField.add(t));
+      }
+      return;
+    }
+    if (curState === 'visited') return;
+    state.set(type.name, 'visiting');
+    stack.push(type.name);
+
+    let found = false;
+    // If this type has a direct @id field, mark as found
+    if (inputTypeIdFieldInfo[type.name]?.length) {
+      found = true;
+    }
+    // Recurse into all nested input object fields
+    for (const field of Object.values(type.getFields())) {
+      const nested = getInputObjectType(field.type);
+      if (nested) {
+        dfs(nested);
+        if (inputTypesWithAnyIdField.has(nested.name)) found = true;
+      }
+    }
+    // If found, mark all types in the current stack as containing an @id field
+    if (found) stack.forEach((t) => inputTypesWithAnyIdField.add(t));
+    stack.pop();
+    state.set(type.name, 'visited');
+  };
+
+  // Run DFS for all input object types
+  for (const type of Object.values(schema.getTypeMap())) {
+    if (isInputObjectType(type) && !type.name.startsWith('__')) {
+      dfs(type);
+    }
+  }
+
+  return { inputTypeIdFieldInfo, inputTypesWithAnyIdField };
+};
+
+/**
+ * Decodes a Relay global id and asserts its type prefix matches the expected type.
+ * Throws a BadRequestError if the id is invalid or the type does not match.
+ */
+const decodeGlobalId = (encodedId: string, expectedType: string): string => {
+  let parsedGlobalId: { type: string; id: string };
+
+  try {
+    parsedGlobalId = fromGlobalId(encodedId);
+  } catch (_error) {
+    throw BadRequestError(`Invalid global id for type ${expectedType}`);
+  }
+
+  if (parsedGlobalId.type !== expectedType) {
+    throw BadRequestError(
+      `Expected global id of type ${expectedType}, got ${parsedGlobalId.type}`
+    );
+  }
+
+  return parsedGlobalId.id;
+};
+
+/**
+ * Decodes a value (or nested structure) by type, recursively decoding all @id fields.
+ * If a field is annotated with @id, decodes it as a global id and recurses if needed.
+ * Used for both direct arguments and nested input object fields.
+ */
+const decodeValueByType = (
+  encodedValue: unknown,
+  inputType: GraphQLInputType,
+  expectedType: string,
+  idFields: InputTypeIdFieldInfo
+): unknown =>
+  traverseInputValue(encodedValue, inputType, idFields, (v, ctx) =>
+    ctx.isIdField && ctx.idDirective && ctx.fieldType
+      ? decodeValueByType(v, ctx.fieldType, ctx.idDirective.type, idFields)
+      : decodeGlobalId(String(v), expectedType)
+  );
+
+const encodeValueByType = (
+  value: unknown,
+  outputType: GraphQLOutputType,
+  expectedType: string
+): unknown =>
+  traverseOutputValue(value, outputType, (v) =>
+    v == null ? v : toGlobalId(expectedType, String(v))
+  );
+
+/**
+ * Decodes all @id-annotated arguments of a field, replacing Relay global IDs with raw DB ids.
+ * Handles both scalar arguments with a direct @id directive and input object arguments
+ * whose fields carry @id directives (recursively).
+ */
+const decodeArgIdDirectives = (
+  args: Record<string, unknown>,
+  fieldConfig: GraphQLFieldConfig<unknown, unknown>,
+  schema: GraphQLSchema,
+  inputTypeIdFieldInfo: InputTypeIdFieldInfo
+): Record<string, unknown> => {
+  const parsedArgs: Record<string, unknown> = { ...args };
+  for (const [argName, argConfig] of Object.entries(fieldConfig.args ?? {})) {
+    const argValue = parsedArgs[argName];
+    const idDirective = getIdDirective(schema, argConfig);
+    if (idDirective) {
+      parsedArgs[argName] = decodeValueByType(
+        argValue,
+        argConfig.type,
+        idDirective.type,
+        inputTypeIdFieldInfo
+      );
+      continue;
+    }
+    const inputObjectType = getInputObjectType(argConfig.type);
+    if (!inputObjectType) {
+      parsedArgs[argName] = argValue;
+      continue;
+    }
+    parsedArgs[argName] = traverseInputValue(
+      argValue,
+      argConfig.type,
+      inputTypeIdFieldInfo,
+      (v, ctx) =>
+        ctx.isIdField && ctx.idDirective && ctx.fieldType
+          ? decodeValueByType(
+              v,
+              ctx.fieldType,
+              ctx.idDirective.type,
+              inputTypeIdFieldInfo
+            )
+          : v
+    );
+  }
+  return parsedArgs;
+};
+
+const isNodeIdFieldWithIdDirective = (
+  schema: GraphQLSchema,
+  fieldName: string,
+  typeName: string | undefined,
+  idDirective: IdDirective | undefined
+): boolean => {
+  if (!idDirective || fieldName !== 'id' || !typeName) {
+    return false;
+  }
+
+  const parentType = schema.getType(typeName);
+  if (!isObjectType(parentType)) {
+    return false;
+  }
+
+  return parentType
+    .getInterfaces()
+    .some((interfaceType) => interfaceType.name === 'Node');
+};
+
+/**
+ * Schema transformer for the `@id` directive.
+ *
+ * For every object field in the schema it:
+ * 1. Decodes `@id`-annotated arguments (Relay global ID → raw DB id) before the resolver runs.
+ * 2. Encodes the resolver's return value as a Relay global ID when the field itself carries `@id`.
+ */
+export const idDirectiveTransformer = (
+  schema: GraphQLSchema
+): GraphQLSchema => {
+  const { inputTypeIdFieldInfo, inputTypesWithAnyIdField } =
+    getInputIdFieldInfo(schema);
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig, fieldName, typeName) => {
+      const idDirective = getIdDirective(schema, fieldConfig);
+
+      if (
+        isNodeIdFieldWithIdDirective(schema, fieldName, typeName, idDirective)
+      ) {
+        throw new Error(
+          `Invalid @id usage on ${typeName}.id: Node ids are already globally encoded by the Node.id resolver.`
+        );
+      }
+
+      const argumentConfigs = Object.values(fieldConfig.args ?? {});
+      const hasArgumentDirective = argumentConfigs.some((argConfig) =>
+        Boolean(getIdDirective(schema, argConfig))
+      );
+      const hasInputObjectArgumentWithId = argumentConfigs.some((argConfig) => {
+        const inputObj = getInputObjectType(argConfig.type);
+        return inputObj && inputTypesWithAnyIdField.has(inputObj.name);
+      });
+      const shouldDecodeArguments =
+        hasArgumentDirective || hasInputObjectArgumentWithId;
+
+      if (!idDirective && !shouldDecodeArguments) {
+        return fieldConfig;
+      }
+
+      const { resolve = defaultFieldResolver } = fieldConfig;
+      fieldConfig.resolve = async (source, args, context, info) => {
+        const rawArgs = (args as Record<string, unknown> | undefined) ?? {};
+        const hasAnyArgValue = Object.keys(rawArgs).length > 0;
+        const parsedArgs =
+          shouldDecodeArguments && hasAnyArgValue
+            ? decodeArgIdDirectives(
+                rawArgs,
+                fieldConfig,
+                schema,
+                inputTypeIdFieldInfo
+              )
+            : rawArgs;
+
+        const result = await resolve(source, parsedArgs, context, info);
+
+        if (!idDirective) {
+          return result;
+        }
+
+        return encodeValueByType(result, fieldConfig.type, idDirective.type);
+      };
+
+      return fieldConfig;
+    },
+  });
+};

--- a/apps/portal-api/src/server/graphql-schema.ts
+++ b/apps/portal-api/src/server/graphql-schema.ts
@@ -25,6 +25,7 @@ import usersResolver from '../modules/users/users.resolver';
 import xtmSuiteRoadmapResolver from '../modules/xtm-suite-roadmap/epic.resolver';
 import nodesResolver from '../nodes/nodes.resolver';
 import { authDirectiveTransformer } from '../security/directive-graphql/directive-auth';
+import { idDirectiveTransformer } from '../security/directive-graphql/id-directive.transformer';
 
 const getGlobContent = async (pattern: string) => {
   const globFiles = await glob(pattern);
@@ -65,7 +66,8 @@ const createSchema = () => {
     resolvers,
     inheritResolversFromInterfaces: true,
   });
-  return authDirectiveTransformer(graphQLSchema);
+  const schemaWithIdDirective = idDirectiveTransformer(graphQLSchema);
+  return authDirectiveTransformer(schemaWithIdDirective);
 };
 
 export default createSchema;

--- a/apps/portal-api/vitest.config.ts
+++ b/apps/portal-api/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^graphql$/,
+        replacement: 'graphql/index.js',
+      },
+    ],
+  },
   test: {
     globals: true,
     globalSetup: './tests/config-test.ts',

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -2,6 +2,8 @@ directive @system_token repeatable on OBJECT | FIELD_DEFINITION
 
 directive @platform_token repeatable on OBJECT | FIELD_DEFINITION
 
+directive @id(type: String!) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 directive @auth(portalCapa: [PortalCapability] = [], orgaCapa: [OrganizationCapability] = []) repeatable on OBJECT | FIELD_DEFINITION
 
 directive @service_capa(requires: [ServiceRestriction] = []) repeatable on OBJECT | FIELD_DEFINITION
@@ -102,8 +104,8 @@ type Mutation {
   createDeploymentRequest(input: CreateDeploymentRequestInput): DeploymentRequest!
   updateDeploymentRequest(input: UpdateDeploymentRequestInput!): PlatformDeploymentRequest!
   reorderDeploymentRequestInQueue(input: ReorderDeploymentRequestInQueueInput!): Success!
-  cancelDeploymentRequest(deploymentRequestId: ID!, cancellationReason: String): DeploymentRequest
-  adminCancelDeploymentRequest(deploymentRequestId: ID): DeploymentRequest
+  cancelDeploymentRequest(deploymentRequestId: DeploymentRequestId!, cancellationReason: String): DeploymentRequest
+  adminCancelDeploymentRequest(deploymentRequestId: DeploymentRequestId): DeploymentRequest
   updateDeploymentQuotaCapacity(input: UpdateDeploymentQuotaCapacityInput!): Success!
   createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
   updateDocument(documentId: ID!, input: UpdateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!], existingImageIds: [ID!]): Document!
@@ -154,7 +156,9 @@ enum OrganizationOrdering {
   name
 }
 
-type OrganizationId implements Node {
+scalar OrganizationId
+
+type OrganizationRef implements Node {
   id: ID!
 }
 
@@ -254,6 +258,8 @@ type ServiceDefinition implements Node {
   identifier: ServiceDefinitionIdentifier!
   service_capability: [ServiceCapability]
 }
+
+scalar DeploymentRequestId
 
 enum DeploymentRequestPlatformRegion {
   eu_west
@@ -376,8 +382,8 @@ type DeploymentRequest implements Node {
   hub_status: DeploymentRequestHubStatus!
   ordering: Int!
   requester_email: String
-  organization_requester_id: ID!
-  service_instance_id: ID!
+  organization_requester_id: OrganizationId!
+  service_instance_id: ServiceInstanceId!
   organization_name: String
   request_date: Date!
   counts_in_orga_quota: Boolean!
@@ -507,7 +513,7 @@ enum ReorderDeploymentRequestInQueueDirection {
 }
 
 input ReorderDeploymentRequestInQueueInput {
-  id: ID!
+  id: DeploymentRequestId!
   direction: ReorderDeploymentRequestInQueueDirection!
 }
 
@@ -1122,6 +1128,8 @@ input AutoRegisterPlatformInput {
   existing_users_count: Int
 }
 
+scalar ServiceInstanceId
+
 enum ServiceInstanceOrdering {
   name
   description
@@ -1535,7 +1543,7 @@ type MeUserSubscription {
 
 type UserPendingSubscription {
   delete: User
-  invalidate: OrganizationId
+  invalidate: OrganizationRef
 }
 
 enum FiligranProduct {

--- a/apps/portal-front/src/components/service/trial-instances/trial-instances.graphql.ts
+++ b/apps/portal-front/src/components/service/trial-instances/trial-instances.graphql.ts
@@ -27,7 +27,7 @@ export const DeploymentRequestsAvailableQuery = graphql`
 
 export const CancelDeploymentRequestMutation = graphql`
   mutation trialInstancesCancelDeploymentRequestMutation(
-    $deploymentRequestId: ID!
+    $deploymentRequestId: DeploymentRequestId!
     $cancellationReason: String
   ) {
     cancelDeploymentRequest(

--- a/apps/portal-front/src/components/trials/trials.graphql.ts
+++ b/apps/portal-front/src/components/trials/trials.graphql.ts
@@ -68,7 +68,7 @@ export const TrialsReorderRequestInQueueMutation = graphql`
 
 export const TrialsAdminCancelDeploymentRequestMutation = graphql`
   mutation trialsAdminCancelDeploymentRequestMutation(
-    $deploymentRequestId: ID!
+    $deploymentRequestId: DeploymentRequestId!
     $removeConnections: [ID!]!
   ) {
     adminCancelDeploymentRequest(deploymentRequestId: $deploymentRequestId) {


### PR DESCRIPTION
# Context
in order to avoid manually encoding/decoding relay ids, we can use a `@id` directive that will automatically manage this, and cast to the right type. 
This can only apply to Id that are not directly the node `ID`. 
Implement a first use case on deployment Request. 

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
- test there is no regression on deployment Requests.

## Related issues

- Related to #2034

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.