### PR TITLE
[frontend] feat(XTMSuiteRoadmap): Add the filter in the URL (#2033)

### DIFF
--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -99,18 +99,18 @@ type Query {
   organization(id: ID!): Organization
   organizations(first: Int = 50, after: ID, orderBy: OrganizationOrdering!, orderMode: OrderingMode!, searchTerm: String): OrganizationConnection!
   userOrganizations: [Organization!]!
-  documentExists(documentName: String, service_instance_id: String): Boolean
-  publicDocuments(slug: String!, first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: ID!): DocumentConnection!
-  publicDocumentsByServiceSlug(serviceInstanceSlug: String!): [Document!]!
-  publicDocumentBySlug(serviceInstanceId: ID!, slug: String!): Document
-  documents(first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: String, parentsOnly: Boolean): DocumentConnection!
-  document(documentId: ID, serviceInstanceId: ID): Document
   openCTIPlatformRegistrationStatus(input: OpenCTIPlatformRegistrationStatusInput!): OpenCTIPlatformRegistrationStatusResponse! @deprecated(reason: "Use `refreshPlatformRegistrationConnectivityStatus` instead. This field is no longer used in the OpenCTI platform due to refactoring and the addition of a version value in the endpoint.")
   isPlatformRegistered(input: IsPlatformRegisteredInput!): IsPlatformRegisteredResponse!
   canUnregisterPlatform(input: CanUnregisterPlatformInput!): CanUnregisterResponse!
   registeredPlatform(input: RegisteredPlatformInput!): RegisteredPlatform
   registeredPlatforms(input: RegisteredPlatformsInput): [RegisteredPlatform!]!
   platformAssociatedOrganization(platformId: String!): Organization
+  documentExists(documentName: String, service_instance_id: String): Boolean
+  publicDocuments(slug: String!, first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: ID!): DocumentConnection!
+  publicDocumentsByServiceSlug(serviceInstanceSlug: String!): [Document!]!
+  publicDocumentBySlug(serviceInstanceId: ID!, slug: String!): Document
+  documents(first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: String, parentsOnly: Boolean): DocumentConnection!
+  document(documentId: ID, serviceInstanceId: ID): Document
   publicServiceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!): ServiceConnection!
   serviceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!, searchTerm: String, filters: [ServiceInstanceFilter!]): ServiceConnection!
   serviceInstanceLinksByTags(tags: [ServiceInstanceTag!]!): [SeoServiceInstance!]!
@@ -149,15 +149,15 @@ type Mutation {
   addOrganization(input: OrganizationInput!): Organization
   editOrganization(id: ID!, input: OrganizationInput!): Organization
   deleteOrganization(id: ID!): Organization
-  createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
-  updateDocument(documentId: ID!, input: UpdateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!], existingImageIds: [ID!]): Document!
-  deleteDocument(documentId: ID, service_instance_id: String, forceDelete: Boolean): Document!
-  incrementShareNumberDocument(documentId: ID): Document!
   registerPlatform(input: RegisterPlatformInput!): RegistrationResponse!
   unregisterPlatform(input: UnregisterPlatformInput): Success!
   refreshUserPlatformToken: RefreshUserPlatformTokenResponse!
   refreshPlatformRegistrationConnectivityStatus(input: RefreshPlatformRegistrationConnectivityStatusInput!): RefreshPlatformRegistrationConnectivityStatusResponse!
   autoRegisterPlatform(platform: PlatformInput @deprecated(reason: "Use input instead"), input: AutoRegisterPlatformInput): Success!
+  createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
+  updateDocument(documentId: ID!, input: UpdateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!], existingImageIds: [ID!]): Document!
+  deleteDocument(documentId: ID, service_instance_id: String, forceDelete: Boolean): Document!
+  incrementShareNumberDocument(documentId: ID): Document!
   addServicePicture(serviceInstanceId: ID!, document: Upload, isLogo: Boolean): ServiceInstance
   updatePlatformServiceMetadata(input: UpdatePlatformServiceMetadataInput!, document: Upload): RegisteredPlatform
   addSubscription(service_instance_id: String): ServiceInstance
@@ -507,14 +507,137 @@ input OrganizationInput {
   domains: [String!]
 }
 
-type RolePortal implements Node {
+input OpenCTIPlatformRegistrationStatusInput {
+  platformId: String!
+  token: String!
+}
+
+type OpenCTIPlatformRegistrationStatusResponse {
+  status: PlatformRegistrationConnectivityStatus!
+}
+
+enum PlatformContract {
+  CE
+  EE
+  trial
+}
+
+type RegisteredPlatform implements Node {
   id: ID!
-  name: String!
+  url: String!
+  title: String!
+  contract: PlatformContract!
+  platform_id: String!
+  identifier: ServiceDefinitionIdentifier!
+  version: String
+  illustration_document_id: String
+  deployment_request: DeploymentRequest
+  subscription: SubscriptionModel
+}
+
+input PlatformInput {
+  id: ID!
+  url: String!
+  title: String!
+  contract: PlatformContract!
+  version: String
+}
+
+enum PlatformIdentifier {
+  opencti
+  openaev
+}
+
+input RegisterPlatformInput {
+  organizationId: ID!
+  platform: PlatformInput!
+  identifier: PlatformIdentifier!
+}
+
+input CanUnregisterPlatformInput {
+  platformId: String!
+}
+
+type RegistrationResponse {
+  token: String!
+}
+
+enum PlatformRegistrationStatus {
+  registered
+  unregistered
+  never_registered
+}
+
+input IsPlatformRegisteredInput {
+  platformId: String!
+}
+
+type IsPlatformRegisteredOrganization implements Node {
+  id: ID!
+}
+
+type IsPlatformRegisteredResponse {
+  status: PlatformRegistrationStatus!
+  platformTitle: String
+  organization: IsPlatformRegisteredOrganization
+}
+
+type CanUnregisterResponse {
+  isPlatformRegistered: Boolean!
+  isAllowed: Boolean
+  isInOrganization: Boolean
+  organizationId: ID
+}
+
+input UnregisterPlatformInput {
+  platformId: String!
+  identifier: PlatformIdentifier!
+}
+
+enum PlatformRegistrationConnectivityStatus {
+  active
+  inactive
+  not_found
+}
+
+input RefreshPlatformRegistrationConnectivityStatusInput {
+  platformId: String!
+  token: String!
+  platformVersion: String!
+  platformIdentifier: PlatformIdentifier
+}
+
+type RefreshPlatformRegistrationConnectivityStatusResponse {
+  status: PlatformRegistrationConnectivityStatus!
+}
+
+type RefreshUserPlatformTokenResponse {
+  token: String!
+}
+
+input RegisteredPlatformsInput {
+  identifier: PlatformIdentifier
+  onlyActive: Boolean
+  onlyTrial: Boolean
+}
+
+input RegisteredPlatformInput {
+  service_instance_id: ID!
+}
+
+input AutoRegisterPlatformInput {
+  platform: PlatformInput!
+  existing_users_count: Int
 }
 
 enum ServiceConfigurationStatus {
   active
   inactive
+}
+
+type RolePortal implements Node {
+  id: ID!
+  name: String!
 }
 
 enum ServiceDefinitionIdentifier {
@@ -997,129 +1120,6 @@ type ServiceLink implements Node {
   service_instance_id: ID
   url: String
   name: String
-}
-
-input OpenCTIPlatformRegistrationStatusInput {
-  platformId: String!
-  token: String!
-}
-
-type OpenCTIPlatformRegistrationStatusResponse {
-  status: PlatformRegistrationConnectivityStatus!
-}
-
-enum PlatformContract {
-  CE
-  EE
-  trial
-}
-
-type RegisteredPlatform implements Node {
-  id: ID!
-  url: String!
-  title: String!
-  contract: PlatformContract!
-  platform_id: String!
-  identifier: ServiceDefinitionIdentifier!
-  version: String
-  illustration_document_id: String
-  deployment_request: DeploymentRequest
-  subscription: SubscriptionModel
-}
-
-input PlatformInput {
-  id: ID!
-  url: String!
-  title: String!
-  contract: PlatformContract!
-  version: String
-}
-
-enum PlatformIdentifier {
-  opencti
-  openaev
-}
-
-input RegisterPlatformInput {
-  organizationId: ID!
-  platform: PlatformInput!
-  identifier: PlatformIdentifier!
-}
-
-input CanUnregisterPlatformInput {
-  platformId: String!
-}
-
-type RegistrationResponse {
-  token: String!
-}
-
-enum PlatformRegistrationStatus {
-  registered
-  unregistered
-  never_registered
-}
-
-input IsPlatformRegisteredInput {
-  platformId: String!
-}
-
-type IsPlatformRegisteredOrganization implements Node {
-  id: ID!
-}
-
-type IsPlatformRegisteredResponse {
-  status: PlatformRegistrationStatus!
-  platformTitle: String
-  organization: IsPlatformRegisteredOrganization
-}
-
-type CanUnregisterResponse {
-  isPlatformRegistered: Boolean!
-  isAllowed: Boolean
-  isInOrganization: Boolean
-  organizationId: ID
-}
-
-input UnregisterPlatformInput {
-  platformId: String!
-  identifier: PlatformIdentifier!
-}
-
-enum PlatformRegistrationConnectivityStatus {
-  active
-  inactive
-  not_found
-}
-
-input RefreshPlatformRegistrationConnectivityStatusInput {
-  platformId: String!
-  token: String!
-  platformVersion: String!
-  platformIdentifier: PlatformIdentifier
-}
-
-type RefreshPlatformRegistrationConnectivityStatusResponse {
-  status: PlatformRegistrationConnectivityStatus!
-}
-
-type RefreshUserPlatformTokenResponse {
-  token: String!
-}
-
-input RegisteredPlatformsInput {
-  identifier: PlatformIdentifier
-  onlyActive: Boolean
-  onlyTrial: Boolean
-}
-
-input RegisteredPlatformInput {
-  service_instance_id: ID!
-}
-
-input AutoRegisterPlatformInput {
-  platform: PlatformInput!
-  existing_users_count: Int
 }
 
 enum ServiceInstanceOrdering {

--- a/apps/portal-front/src/components/epic/epic-form-sheet.tsx
+++ b/apps/portal-front/src/components/epic/epic-form-sheet.tsx
@@ -5,6 +5,7 @@ import {
   UpdateEpicMutation,
 } from '@/components/epic/epic.graphql';
 import { SheetWithPreventingDialog } from '@/components/ui/sheet-with-preventing-dialog';
+import { useEpicFilter } from '@/hooks/useEpicFilter';
 import { useEpicListContext } from '@/hooks/useEpicListContext';
 import { fileListToUploadableMap } from '@/relay/environment/fetchFormData';
 import { Button, useToast } from '@filigran/ui';
@@ -34,7 +35,8 @@ export const EpicFormSheet = ({
   const [commitEpicMutation] = useMutation(CreateEpicMutation);
   const [updateEpicMutation] = useMutation(UpdateEpicMutation);
   const { toast } = useToast();
-  const { connectionID, filterByProduct } = useEpicListContext();
+  const { connectionID } = useEpicListContext();
+  const { setSelectedProduct } = useEpicFilter();
   const openSheet =
     externalOpen !== undefined ? externalOpen : internalOpenSheet;
   const setOpenSheet =
@@ -54,7 +56,7 @@ export const EpicFormSheet = ({
       uploadables,
       onCompleted: () => {
         setOpenSheet(false);
-        filterByProduct(inputValues.product);
+        setSelectedProduct(inputValues.product);
         toast({
           title: t('Utils.Success'),
           description: t('Utils.Success'),

--- a/apps/portal-front/src/components/epic/epic-page.tsx
+++ b/apps/portal-front/src/components/epic/epic-page.tsx
@@ -1,11 +1,9 @@
 'use client';
-import { EpicFilterType } from '@/components/epic/epic-filter';
 import { EpicList } from '@/components/epic/epic-list';
+import { useEpicFilter } from '@/hooks/useEpicFilter';
 import { EpicListContext } from '@/hooks/useEpicListContext';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
-import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
-import { useState } from 'react';
 
 interface EpicPageProps {
   epics: epic_fragment$data[];
@@ -18,14 +16,10 @@ export const EpicPage = ({
   serviceInstance,
   connectionID,
 }: EpicPageProps) => {
-  const [selectedProduct, setSelectedProduct] = useState<EpicFilterType>('all');
-
-  const filterByProduct = (product: FiligranProductEnum) => {
-    setSelectedProduct(product);
-  };
+  const { selectedProduct, setSelectedProduct } = useEpicFilter();
 
   return (
-    <EpicListContext.Provider value={{ connectionID, filterByProduct }}>
+    <EpicListContext.Provider value={{ connectionID }}>
       <EpicList
         epics={epics}
         serviceInstance={serviceInstance}

--- a/apps/portal-front/src/components/epic/public-epic-list.tsx
+++ b/apps/portal-front/src/components/epic/public-epic-list.tsx
@@ -1,16 +1,15 @@
-import { EpicFilterType } from '@/components/epic/epic-filter';
 import { EpicList } from '@/components/epic/epic-list';
 import {
   EpicListQuery,
   epicsListFragment,
 } from '@/components/epic/epic.graphql';
+import { useEpicFilter } from '@/hooks/useEpicFilter';
 import { EpicListContext } from '@/hooks/useEpicListContext';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { epicsList_epics$key } from '@generated/epicsList_epics.graphql';
 import { epicsQuery } from '@generated/epicsQuery.graphql';
-import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
-import React, { useState } from 'react';
+import React from 'react';
 import {
   PreloadedQuery,
   usePreloadedQuery,
@@ -30,11 +29,7 @@ const PublicEpicList: React.FC<Props> = ({ queryRef, serviceInstance }) => {
     queryData
   );
 
-  const [selectedProduct, setSelectedProduct] = useState<EpicFilterType>('all');
-
-  const filterByProduct = (product: FiligranProductEnum) => {
-    setSelectedProduct(product);
-  };
+  const { selectedProduct, setSelectedProduct } = useEpicFilter();
 
   const epics = data.epics!.edges.map(
     (edge) => edge.node as epic_fragment$data
@@ -42,7 +37,7 @@ const PublicEpicList: React.FC<Props> = ({ queryRef, serviceInstance }) => {
 
   const connectionID = data.epics!.__id;
   return (
-    <EpicListContext.Provider value={{ connectionID, filterByProduct }}>
+    <EpicListContext.Provider value={{ connectionID }}>
       <EpicList
         epics={epics}
         serviceInstance={serviceInstance}

--- a/apps/portal-front/src/hooks/useEpicFilter.test.ts
+++ b/apps/portal-front/src/hooks/useEpicFilter.test.ts
@@ -1,0 +1,40 @@
+import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
+import { renderHook } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEpicFilter } from './useEpicFilter';
+
+vi.mock('next/navigation');
+
+describe('useEpicFilter', () => {
+  const mockReplace = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(usePathname).mockReturnValue('/epics');
+    vi.mocked(useRouter).mockReturnValue({
+      replace: mockReplace,
+    } as never);
+  });
+
+  it.each`
+    searchQuery                                       | expectedSelectedProduct
+    ${''}                                             | ${'all'}
+    ${`product=${FiligranProductEnum.OPENCTI}`}       | ${FiligranProductEnum.OPENCTI}
+    ${'product=unknown'}                              | ${'all'}
+    ${'product='}                                     | ${'all'}
+    ${`page=2&product=${FiligranProductEnum.XTMHUB}`} | ${FiligranProductEnum.XTMHUB}
+  `(
+    'should expose "$expectedSelectedProduct" from "$searchQuery"',
+    ({ searchQuery, expectedSelectedProduct }) => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams(searchQuery) as never
+      );
+
+      const { result } = renderHook(() => useEpicFilter());
+
+      expect(result.current.selectedProduct).toBe(expectedSelectedProduct);
+    }
+  );
+});

--- a/apps/portal-front/src/hooks/useEpicFilter.ts
+++ b/apps/portal-front/src/hooks/useEpicFilter.ts
@@ -1,0 +1,36 @@
+'use client';
+import { EpicFilterType } from '@/components/epic/epic-filter';
+import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+
+const PRODUCT_PARAM = 'product';
+
+export const useEpicFilter = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const rawParam = searchParams.get(PRODUCT_PARAM);
+  const selectedProduct: EpicFilterType =
+    rawParam &&
+    Object.values(FiligranProductEnum).includes(rawParam as FiligranProductEnum)
+      ? (rawParam as FiligranProductEnum)
+      : 'all';
+
+  const setSelectedProduct = useCallback(
+    (filter: EpicFilterType) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (filter === 'all') {
+        params.delete(PRODUCT_PARAM);
+      } else {
+        params.set(PRODUCT_PARAM, filter);
+      }
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    },
+    [searchParams, router, pathname]
+  );
+
+  return { selectedProduct, setSelectedProduct };
+};

--- a/apps/portal-front/src/hooks/useEpicListContext.tsx
+++ b/apps/portal-front/src/hooks/useEpicListContext.tsx
@@ -1,8 +1,6 @@
-import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { createContext, useContext } from 'react';
 export interface EpicListConnectionContextType {
   connectionID: string;
-  filterByProduct: (product: FiligranProductEnum) => void;
 }
 export const useEpicListContext = (): EpicListConnectionContextType => {
   const context = useContext(EpicListContext);


### PR DESCRIPTION
# Context
> Handle the Epic filter within the URL

## How to test
- Connect to XTM Hub and go on the XTM Suite Roadmap service  (please think about getting this service public)
- Play with the filter. You should see the URL adapted : http://localhost:3002/app/service/xtm_suite_roadmap/U2VydmljZUluc3RhbmNlOjk5ZjZjZjg4LTJmN2UtNDVjZS1hNDJlLWRmZmYxMDc1MzVjYg==?product=xtmhub 
- You can directly change the URL : it changes the filter. 
- Add a new epic : it updates the filter with the current product. 

## Related issues

- Related to #2033 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests