### PR TITLE
[backend] chore(Tests): Remove contextAdminByDefault (#2066)

### DIFF
--- a/apps/portal-api/eslint.config.mjs
+++ b/apps/portal-api/eslint.config.mjs
@@ -25,6 +25,19 @@ export default defineConfig([
     files: ['**/*.test.ts', '**/*.test.utils.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/tests.const', '**/tests.ts'],
+              importNames: ['requestContextAdminUser', 'contextBypassUser'],
+              message:
+                'Use a dedicated test context helper instead of bypass/admin shared contexts.',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/apps/portal-api/src/modules/deployment/deployment.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.app.test.ts
@@ -9,8 +9,12 @@ import {
   vi,
 } from 'vitest';
 import {
+  contextBypassUser,
+  contextRegistererUserSecondOrga,
   contextSimpleUserSecondOrga,
   requestContextAdminSecondOrga,
+  requestContextAdminUser,
+  requestContextRegistererUserSecondOrga,
   requestContextSimpleUserSecondOrga,
   TEST_DEPLOYMENT,
   TEST_ORGANIZATIONS,
@@ -104,6 +108,8 @@ describe('Deployment app', () => {
   describe('createDeploymentRequest', () => {
     it('should create a deployment request with associated registration', async () => {
       // Given
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       vi.spyOn(DeploymentQuotaDomain, 'reservePlace').mockResolvedValue({
         isPlaceAvailable: true,
       });
@@ -128,7 +134,7 @@ describe('Deployment app', () => {
           DeploymentRequestActivitySector.ComputerNetworkSecurity,
         id: expect.any(String),
         job_title: DeploymentRequestJobTitle.CLevel,
-        organization_requester_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organization_requester_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform_identifier: PlatformIdentifier.Opencti,
         platform_token: expect.any(String),
         region: DeploymentRequestPlatformRegion.UsEast,
@@ -148,6 +154,8 @@ describe('Deployment app', () => {
     });
     it('should create a deployment request with queued status when there is no space available', async () => {
       // Given
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       vi.spyOn(DeploymentQuotaDomain, 'reservePlace').mockResolvedValue({
         isPlaceAvailable: false,
       });
@@ -173,7 +181,7 @@ describe('Deployment app', () => {
           DeploymentRequestActivitySector.ComputerNetworkSecurity,
         id: expect.any(String),
         job_title: DeploymentRequestJobTitle.CLevel,
-        organization_requester_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organization_requester_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform_identifier: PlatformIdentifier.Opencti,
         platform_token: expect.any(String),
         region: DeploymentRequestPlatformRegion.UsEast,
@@ -243,6 +251,8 @@ describe('Deployment app', () => {
 
     it('should allow deployment when organization domain is not blacklisted', async () => {
       // Given
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       await TestHelper.competitor.create({
         name: 'NotBlocked',
         domain: 'not-blocked.com',
@@ -256,6 +266,8 @@ describe('Deployment app', () => {
     });
 
     it('should allow deployment when no competitors exist', async () => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       const deployment =
         await DeploymentApp.createDeploymentRequest(TEST_DEPLOYMENT);
 
@@ -273,6 +285,8 @@ describe('Deployment app', () => {
       `(
         'should send a telemetry event when trial for $product platform is launched',
         async ({ product, targetProduct, source, telemetrySource }) => {
+          requestContext.set(requestContextRegistererUserSecondOrga);
+
           vi.useFakeTimers();
           const date = new Date(Date.UTC(2025, 1, 3, 13, 12, 15));
           vi.setSystemTime(date);
@@ -291,13 +305,15 @@ describe('Deployment app', () => {
           expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
             '@timestamp': '2025-02-03T13:12:15.000Z',
             event_type: TelemetryEventType.CREATE_DEPLOYMENT,
-            organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-            organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+            organization_id:
+              contextRegistererUserSecondOrga.user.organizations[0]!.id,
+            organization_name:
+              contextRegistererUserSecondOrga.user.organizations[0]!.name,
             organization_type: TelemetryOrganizationType.PROFESSIONAL,
             source: telemetrySource,
-            email: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            email: contextRegistererUserSecondOrga.user.email,
             job_title: DeploymentRequestJobTitle.CLevel,
-            user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+            user_id: contextRegistererUserSecondOrga.user.id,
             deployment_id: deployment.id,
             region: DeploymentRequestPlatformRegion.UsEast,
             use_case: DeploymentRequestUseCase.ThreatHunting,
@@ -310,6 +326,8 @@ describe('Deployment app', () => {
         }
       );
       it('should not throw when an error is thrown by telemetry', async () => {
+        requestContext.set(requestContextRegistererUserSecondOrga);
+
         vi.useFakeTimers();
         const date = new Date(Date.UTC(2025, 1, 3, 13, 12, 15));
         vi.setSystemTime(date);
@@ -325,6 +343,7 @@ describe('Deployment app', () => {
     describe('mail', () => {
       describe('development environment', () => {
         it('should send a mail if status is pending to dev team', async () => {
+          requestContext.set(requestContextAdminUser);
           await DeploymentApp.createDeploymentRequest(TEST_DEPLOYMENT);
 
           expect(mockSendMail).toHaveBeenCalledTimes(2);
@@ -356,6 +375,8 @@ describe('Deployment app', () => {
         });
 
         it('should send a mail if there is no space available', async () => {
+          requestContext.set(requestContextRegistererUserSecondOrga);
+
           vi.spyOn(DeploymentQuotaDomain, 'reservePlace').mockResolvedValue({
             isPlaceAvailable: false,
           });
@@ -364,10 +385,10 @@ describe('Deployment app', () => {
           expect(mockSendMail).toHaveBeenCalledTimes(2);
 
           expect(mockSendMail).toHaveBeenNthCalledWith(1, {
-            to: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            to: contextRegistererUserSecondOrga.user.email,
             template: 'free_trial_queued',
             params: {
-              firstName: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+              firstName: contextRegistererUserSecondOrga.user.first_name,
               platformIdentifier: PlatformIdentifier.Opencti,
             },
           });
@@ -379,12 +400,13 @@ describe('Deployment app', () => {
               activitySector:
                 DeploymentRequestActivitySector.ComputerNetworkSecurity,
               deploymentType: 'Trial',
-              organizationName: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+              organizationName:
+                contextRegistererUserSecondOrga.user.organizations[0]!.name,
               platformIdentifier: PlatformIdentifier.Opencti,
               region: 'us_east',
               useCase: DeploymentRequestUseCase.ThreatHunting,
-              userEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
-              userName: `${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME} ${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME}`,
+              userEmail: contextRegistererUserSecondOrga.user.email,
+              userName: `${contextRegistererUserSecondOrga.user.first_name} ${contextRegistererUserSecondOrga.user.last_name}`,
             },
           });
         });
@@ -403,15 +425,17 @@ describe('Deployment app', () => {
         });
 
         it('should send a mail if status is pending to dev team', async () => {
+          requestContext.set(requestContextAdminUser);
+
           await DeploymentApp.createDeploymentRequest(TEST_DEPLOYMENT);
 
           expect(mockSendMail).toHaveBeenCalledTimes(2);
 
           expect(mockSendMail).toHaveBeenNthCalledWith(1, {
-            to: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            to: contextBypassUser.user.email,
             template: 'free_trial_requested',
             params: {
-              firstName: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+              firstName: contextBypassUser.user.first_name,
               platformIdentifier: PlatformIdentifier.Opencti,
             },
           });
@@ -423,17 +447,19 @@ describe('Deployment app', () => {
               activitySector:
                 DeploymentRequestActivitySector.ComputerNetworkSecurity,
               deploymentType: 'Trial',
-              organizationName: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+              organizationName: contextBypassUser.user.organizations[0]!.name,
               platformIdentifier: PlatformIdentifier.Opencti,
               region: DeploymentRequestPlatformRegion.UsEast,
               useCase: DeploymentRequestUseCase.ThreatHunting,
-              userEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
-              userName: `${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME} ${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME}`,
+              userEmail: contextBypassUser.user.email,
+              userName: `${contextBypassUser.user.first_name} ${contextBypassUser.user.last_name}`,
             },
           });
         });
 
         it('should send a mail if there is no space available', async () => {
+          requestContext.set(requestContextRegistererUserSecondOrga);
+
           vi.spyOn(DeploymentQuotaDomain, 'reservePlace').mockResolvedValue({
             isPlaceAvailable: false,
           });
@@ -442,10 +468,12 @@ describe('Deployment app', () => {
           expect(mockSendMail).toHaveBeenCalledTimes(2);
 
           expect(mockSendMail).toHaveBeenNthCalledWith(1, {
-            to: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            to: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.EMAIL,
             template: 'free_trial_queued',
             params: {
-              firstName: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+              firstName:
+                TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER
+                  .FIRST_NAME,
               platformIdentifier: PlatformIdentifier.Opencti,
             },
           });
@@ -457,12 +485,13 @@ describe('Deployment app', () => {
               activitySector:
                 DeploymentRequestActivitySector.ComputerNetworkSecurity,
               deploymentType: 'Trial',
-              organizationName: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+              organizationName: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.NAME,
               platformIdentifier: PlatformIdentifier.Opencti,
               region: 'us_east',
               useCase: DeploymentRequestUseCase.ThreatHunting,
-              userEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
-              userName: `${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME} ${TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME}`,
+              userEmail:
+                TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.EMAIL,
+              userName: `${TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.FIRST_NAME} ${TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.LAST_NAME}`,
             },
           });
         });
@@ -1298,7 +1327,7 @@ describe('Deployment app', () => {
           target_state: target_state,
           counts_in_orga_quota,
           cancellation_date: expect.any(Date),
-          cancellation_user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          cancellation_user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           cancellation_reason: isAdmin ? null : cancellationReason,
         });
 
@@ -1384,7 +1413,7 @@ describe('Deployment app', () => {
         organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
         organization_type: TelemetryOrganizationType.PROFESSIONAL,
         source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
         deployment_id: deployment.id,
         deployment_type: DeploymentRequestDeploymentType.Trial,
         status: DeploymentRequestHubStatus.Cancelled,
@@ -1615,7 +1644,7 @@ describe('Deployment app', () => {
           organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           source: TelemetrySource.XTMHUB,
-          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           deployment_id: queuedRequestId1!,
           deployment_type: DeploymentRequestDeploymentType.Trial,
           platform_id: null,
@@ -1630,7 +1659,7 @@ describe('Deployment app', () => {
           organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           source: TelemetrySource.XTMHUB,
-          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           deployment_id: queuedRequestId2!,
           deployment_type: DeploymentRequestDeploymentType.Trial,
           platform_id: null,
@@ -1844,7 +1873,7 @@ describe('Deployment app', () => {
           organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           source: TelemetrySource.XTMHUB,
-          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           deployment_id: pendingRequestId1!,
           deployment_type: DeploymentRequestDeploymentType.Trial,
           platform_id: null,
@@ -1859,7 +1888,7 @@ describe('Deployment app', () => {
           organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           source: TelemetrySource.XTMHUB,
-          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           deployment_id: pendingRequestId2!,
           deployment_type: DeploymentRequestDeploymentType.Trial,
           platform_id: null,
@@ -2154,7 +2183,7 @@ describe('Deployment app', () => {
           organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           source: TelemetrySource.XTMHUB,
-          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+          user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           deployment_id: queuedDeploymentRequest!.id,
           deployment_type: DeploymentRequestDeploymentType.Trial,
           platform_id: queuedDeploymentRequest!.platform_id,

--- a/apps/portal-api/src/modules/deployment/deployment.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.app.test.ts
@@ -9,10 +9,12 @@ import {
   vi,
 } from 'vitest';
 import {
+  // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
   contextRegistererUserSecondOrga,
   contextSimpleUserSecondOrga,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   requestContextRegistererUserSecondOrga,
   requestContextSimpleUserSecondOrga,

--- a/apps/portal-api/src/modules/deployment/deployment.resolver.test.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.resolver.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../../../knexfile';
-import { TEST_ORGANIZATIONS } from '../../../tests/tests.const';
+import {
+  requestContextRegistererUserSecondOrga,
+  TEST_ORGANIZATIONS,
+} from '../../../tests/tests.const';
 import {
   DeploymentRequestActivitySector,
   DeploymentRequestDeploymentType,
@@ -12,6 +15,7 @@ import {
   DeploymentRequestUseCase,
   PlatformIdentifier,
 } from '../../__generated__/resolvers-types';
+import { requestContext } from '../../context/request.context';
 import DeploymentRequestQuota from '../../model/kanel/public/DeploymentRequestQuota';
 import { ErrorCode } from '../../utils/error/error.code';
 import { deleteServiceInstanceBy } from '../services/service-instance.domain';
@@ -27,6 +31,9 @@ describe('Deployment resolver', () => {
     await deleteSubscription({});
   });
   describe('createDeploymentRequest', () => {
+    beforeEach(() => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+    });
     it('should return the deployment request created', async () => {
       const deployment = await resolver.Mutation.createDeploymentRequest(
         undefined,
@@ -59,6 +66,9 @@ describe('Deployment resolver', () => {
   });
 
   describe('updateDeploymentRequest', () => {
+    beforeEach(() => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+    });
     it('should return the updated deployment request', async () => {
       const initialDeployment = await DeploymentApp.createDeploymentRequest({
         activity_sector:
@@ -129,15 +139,16 @@ describe('Deployment resolver', () => {
         end_date: new Date(2025, 2, 3),
         platform_id: 'fake product instance id',
         failure_reason: 'not failed',
-        organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+        organization_name: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.NAME,
         organization_domains: [
-          TEST_ORGANIZATIONS.FILIGRAN.DOMAINS.FIRST,
-          TEST_ORGANIZATIONS.FILIGRAN.DOMAINS.SECOND,
+          TEST_ORGANIZATIONS.SECOND_ORGANIZATION.DOMAINS.FIRST.NAME,
         ],
-        requester_email: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+        requester_email:
+          TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.EMAIL,
         requester_first_name:
-          TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
-        requester_last_name: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME,
+          TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.FIRST_NAME,
+        requester_last_name:
+          TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.LAST_NAME,
       });
     });
     it('should return an error when status transition is not allowed', async () => {

--- a/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
@@ -12,6 +12,7 @@ import {
 import { db } from '../../../../knexfile';
 import {
   requestContextAdminSecondOrga,
+  requestContextAdminUser,
   SERVICES,
   TEST_ORGANIZATIONS,
 } from '../../../../tests/tests.const';
@@ -181,6 +182,8 @@ describe('ServiceGroupApp', () => {
     });
 
     it('should allow bypass user to update groups in another organization', async () => {
+      requestContext.set(requestContextAdminUser);
+
       await db<Subscription>('Subscription').insert({
         id: uuidv4() as SubscriptionId,
         service_instance_id: serviceInstanceId2,
@@ -215,6 +218,8 @@ describe('ServiceGroupApp', () => {
     });
 
     it('should update groups with new user list and remove old ones', async () => {
+      requestContext.set(requestContextAdminUser);
+
       await db<ServiceGroupUser>('ServiceGroup_User').insert({
         group_id: analystGroupId,
         user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
@@ -326,15 +331,15 @@ describe('ServiceGroupApp', () => {
 
         expect(sendMailSpy).toHaveBeenCalledTimes(2);
         expect(sendMailSpy).toHaveBeenCalledWith({
-          to: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+          to: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL,
           template: 'free_trial_user_added',
           params: {
             firstName: formatName(
-              TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME
+              TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.FIRST_NAME
             ),
             platformUrl,
             platformIdentifier: PlatformIdentifier.Opencti,
-            adminEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            adminEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL,
             trialEndDate: expectedTrialEndDate,
           },
         });
@@ -347,7 +352,7 @@ describe('ServiceGroupApp', () => {
             ),
             platformUrl,
             platformIdentifier: PlatformIdentifier.Opencti,
-            adminEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            adminEmail: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL,
             trialEndDate: expectedTrialEndDate,
           },
         });

--- a/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
@@ -12,6 +12,7 @@ import {
 import { db } from '../../../../knexfile';
 import {
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   SERVICES,
   TEST_ORGANIZATIONS,

--- a/apps/portal-api/src/modules/document/document.app.test.ts
+++ b/apps/portal-api/src/modules/document/document.app.test.ts
@@ -74,7 +74,7 @@ describe('DocumentApp', () => {
   const documentData = {
     short_description: 'short_description',
     slug: 'slug',
-    uploader_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+    uploader_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
     name: 'name',
     description: 'description',
     active: true,
@@ -237,7 +237,7 @@ describe('DocumentApp', () => {
         organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
         organization_type: 'Professional',
         source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
         service: TelemetryEventService.CUSTOM_DASHBOARDS_LIBRARY,
         resource_id: expect.any(String),
         resource_title: documentData.name,

--- a/apps/portal-api/src/modules/document/domain/document.domain.test.ts
+++ b/apps/portal-api/src/modules/document/domain/document.domain.test.ts
@@ -70,7 +70,9 @@ describe('Document domain', () => {
 
       expect(document).toBeDefined();
       expect(document!.active).toBe(false);
-      expect(document!.remover_id).toBe(ADMIN_UUID);
+      expect(document!.remover_id).toBe(
+        TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID
+      );
     });
   });
 
@@ -451,7 +453,7 @@ describe('Document domain', () => {
           name: docData.name,
           type: docData.type,
           slug: docData.slug,
-          uploader_id: ADMIN_UUID,
+          uploader_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
           uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
           active: true,
         };

--- a/apps/portal-api/src/modules/organization-management/organizations/organizations.app.test.ts
+++ b/apps/portal-api/src/modules/organization-management/organizations/organizations.app.test.ts
@@ -43,7 +43,7 @@ describe('organizationsApp', () => {
         organization_name: 'new OrgaName',
         organization_type: 'Professional',
         source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
         domains: [
           TEST_ORGANIZATIONS.SECOND_ORGANIZATION.DOMAINS.FIRST.NAME,
           TEST_ORGANIZATIONS.SECOND_ORGANIZATION.DOMAINS.SECOND.NAME,
@@ -73,7 +73,7 @@ describe('organizationsApp', () => {
         organization_name: 'test.com',
         organization_type: 'Professional',
         source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
         domains: ['test.com', 'test.fr'],
       });
     });

--- a/apps/portal-api/src/modules/organization-management/users/user-domain/users.domain.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/user-domain/users.domain.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserSecondOrga,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   requestContextSimpleUserSecondOrga,
   TEST_ORGANIZATIONS,

--- a/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
@@ -15,10 +15,12 @@ import {
 import { SubscriptionSpy } from '../../../../tests/test-utils';
 import {
   contextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
   contextSimpleUserFiligran2,
   contextSimpleUserSecondOrga,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   requestContextSimpleUserSecondOrga,
   SERVICES,
@@ -32,13 +34,13 @@ import {
   OrganizationCapability,
   UserOrdering,
 } from '../../../__generated__/resolvers-types';
-import { loginFromProvider } from '../../security-management/authentication/auth-user';
 import { requestContext } from '../../../context/request.context';
 import { SubscriptionId } from '../../../model/kanel/public/Subscription';
 import { UserId } from '../../../model/kanel/public/User';
 import { UserLoadUserBy } from '../../../model/user';
 import { auth0ClientMock } from '../../../thirdparty/auth0/mock';
 import * as UserOrganizationDomain from '../../common/user-organization.domain';
+import { loginFromProvider } from '../../security-management/authentication/auth-user';
 import {
   deleteSubscription,
   insertSubscription,

--- a/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
@@ -16,6 +16,7 @@ import { SubscriptionSpy } from '../../../../tests/test-utils';
 import {
   contextAdminSecondOrga,
   contextBypassUser,
+  contextSimpleUserFiligran2,
   contextSimpleUserSecondOrga,
   requestContextAdminSecondOrga,
   requestContextAdminUser,
@@ -431,7 +432,9 @@ describe('User mutation resolver', () => {
       let organizations: Organization[];
       let user: UserLoadUserBy;
       beforeAll(async () => {
-        const testMail = `testAddUser${uuidv4()}@test.fr`;
+        requestContext.set(requestContextAdminUser);
+
+        const testMail = `testAddUser${uuidv4()}@${TEST_ORGANIZATIONS.FILIGRAN.DOMAINS.FIRST}.fr`;
         // @ts-ignore
         response = await usersResolver.Mutation.adminAddUser(
           undefined,
@@ -968,14 +971,14 @@ describe('User mutation resolver', () => {
       const response = await usersResolver.Mutation.resetPassword(
         undefined,
         {},
-        contextBypassUser
+        contextSimpleUserFiligran2
       );
 
       // Then
       expect(response).toBeTruthy();
       expect(response.success).toBeTruthy();
       expect(auth0Spy).toBeCalledWith(
-        TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL
+        TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL
       );
     });
 

--- a/apps/portal-api/src/modules/organization-management/users/users.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.test.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   TEST_ORGANIZATIONS,
 } from '../../../../tests/tests.const';
@@ -9,8 +10,8 @@ import { requestContext } from '../../../context/request.context';
 import Organization from '../../../model/kanel/public/Organization';
 import { UserId } from '../../../model/kanel/public/User';
 import { UserLoadUserBy } from '../../../model/user';
-import { createUserOrganizationCapability } from '../../security-management/user-organization-capability/user-organization-capability.domain';
 import { createUserOrganizationRelationAndRemovePending } from '../../common/user-organization.helper';
+import { createUserOrganizationCapability } from '../../security-management/user-organization-capability/user-organization-capability.domain';
 import { telemetryApp } from '../../telemetry/telemetry.app';
 import { TelemetrySource } from '../../telemetry/telemetry.const';
 import { TelemetryEventType } from '../../telemetry/telemetry.types';

--- a/apps/portal-api/src/modules/organization-management/users/users.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.test.ts
@@ -1,7 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
+import {
+  requestContextAdminUser,
+  TEST_ORGANIZATIONS,
+} from '../../../../tests/tests.const';
 import { OrganizationCapability } from '../../../__generated__/resolvers-types';
+import { requestContext } from '../../../context/request.context';
 import Organization from '../../../model/kanel/public/Organization';
 import { UserId } from '../../../model/kanel/public/User';
 import { UserLoadUserBy } from '../../../model/user';
@@ -43,9 +47,9 @@ describe('User helpers', async () => {
         });
       expect(newUser).toBeTruthy();
       expect(newUser.selected_org_capabilities.length).toBe(1);
-      expect(newUser.organizations[0].personal_space).toBe(true);
+      expect(newUser!.organizations[0]?.personal_space).toBe(true);
       expect(newUserPendingOrg.length).toBe(1);
-      expect(newUserPendingOrg[0].organization_id).toBe(
+      expect(newUserPendingOrg[0]?.organization_id).toBe(
         TEST_ORGANIZATIONS.FILIGRAN.ID
       );
 
@@ -168,6 +172,8 @@ describe('User helpers', async () => {
       });
 
       it(`should not throw when another user in the organization has ${OrganizationCapability.AdministrateOrganization}`, async () => {
+        requestContext.set(requestContextAdminUser);
+
         const anotherUserEmail = `testLastOrganizationAdministrator-anotherUser${uuidv4()}@${organizationName}`;
         await createNewUserFromInvitation({
           email: anotherUserEmail,
@@ -185,7 +191,7 @@ describe('User helpers', async () => {
         expect(anotherUserOrgRelation).toBeTruthy();
 
         await createUserOrganizationCapability({
-          user_organization_id: anotherUserOrgRelation.id,
+          user_organization_id: anotherUserOrgRelation!.id,
           capabilities_name: [OrganizationCapability.AdministrateOrganization],
         });
 
@@ -217,6 +223,8 @@ describe('User helpers', async () => {
       });
 
       it(`should not throw when another user in the organization has ${OrganizationCapability.AdministrateOrganization} and we remove its capabilities`, async () => {
+        requestContext.set(requestContextAdminUser);
+
         const anotherUserEmail = `testLastOrganizationAdministrator-anotherUser${uuidv4()}@${organizationName}.fr`;
         await createNewUserFromInvitation({
           email: anotherUserEmail,
@@ -234,7 +242,7 @@ describe('User helpers', async () => {
         expect(anotherUserOrgRelation).toBeTruthy();
 
         await createUserOrganizationCapability({
-          user_organization_id: anotherUserOrgRelation.id,
+          user_organization_id: anotherUserOrgRelation!.id,
           capabilities_name: [OrganizationCapability.AdministrateOrganization],
         });
 

--- a/apps/portal-api/src/modules/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.test.ts
@@ -14,6 +14,7 @@ import {
   contextBypassUser,
   requestContextAdminSecondOrga,
   requestContextAdminUser,
+  requestContextRegistererUserSecondOrga,
   requestContextSimpleUserSecondOrga,
   SERVICES,
   TEST_ORGANIZATIONS,
@@ -145,15 +146,17 @@ describe('Registration app', () => {
       });
       await db<Subscription>('Subscription').insert({
         id: subscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         service_instance_id: serviceInstanceId,
       });
+
+      requestContext.set(requestContextRegistererUserSecondOrga);
 
       const result =
         await registrationApp.loadPlatformAssociatedOrganization(platformId);
 
       expect(result).toBeDefined();
-      expect(result?.id).toBe(TEST_ORGANIZATIONS.FILIGRAN.ID);
+      expect(result?.id).toBe(TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID);
     });
   });
 
@@ -207,7 +210,7 @@ describe('Registration app', () => {
       });
       await db<Subscription>('Subscription').insert({
         id: subscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         service_instance_id: serviceInstanceId,
       });
 
@@ -217,7 +220,9 @@ describe('Registration app', () => {
 
       expect(result).toBeDefined();
       expect(result.status).toBe(PlatformRegistrationStatus.Registered);
-      expect(result.organization?.id).toBe(TEST_ORGANIZATIONS.FILIGRAN.ID);
+      expect(result.organization?.id).toBe(
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
+      );
       expect(result.platformTitle).toBe(platformTitle);
     });
     it('should return unregistered when platform registration is inactive', async () => {
@@ -237,7 +242,7 @@ describe('Registration app', () => {
       });
       await db<Subscription>('Subscription').insert({
         id: subscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         service_instance_id: serviceInstanceId,
       });
 
@@ -247,7 +252,9 @@ describe('Registration app', () => {
 
       expect(result).toBeDefined();
       expect(result.status).toBe(PlatformRegistrationStatus.Unregistered);
-      expect(result.organization?.id).toBe(TEST_ORGANIZATIONS.FILIGRAN.ID);
+      expect(result.organization?.id).toBe(
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
+      );
       expect(result.platformTitle).toBe(platformTitle);
     });
   });
@@ -261,10 +268,14 @@ describe('Registration app', () => {
       version: 'X.Y.Z',
     };
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     describe('invalid configuration', async () => {
       it('should throw when platformId is not valid', async () => {
         const call = registrationApp.registerPlatform({
-          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
           platform: {
             ...platform,
             id: 'hello',
@@ -279,7 +290,7 @@ describe('Registration app', () => {
 
       it('should throw when platformUrl is not valid', async () => {
         const call = registrationApp.registerPlatform({
-          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
           platform: {
             ...platform,
             url: 'hello',
@@ -294,7 +305,7 @@ describe('Registration app', () => {
     });
 
     it('should throw when user does not belong to the organization', async () => {
-      requestContext.set(requestContextAdminSecondOrga);
+      requestContext.set(requestContextRegistererUserSecondOrga);
       const call = registrationApp.registerPlatform({
         organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
         platform,
@@ -318,8 +329,10 @@ describe('Registration app', () => {
     });
 
     it('return token when platform is registered', async () => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       const token = await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform,
         identifier: PlatformIdentifier.Opencti,
       });
@@ -327,64 +340,43 @@ describe('Registration app', () => {
       expect(token).toBeDefined();
     });
 
-    it('should send a telemetry event when opencti platform is registered', async () => {
-      vi.useFakeTimers();
-      const date = new Date(Date.UTC(2025, 1, 3, 13, 12, 15));
-      vi.setSystemTime(date);
-      const telemetrySpy = vi
-        .spyOn(telemetryApp, 'sendTelemetryEvent')
-        .mockResolvedValue();
+    it.each`
+      platformName                  | telemetryProduct
+      ${PlatformIdentifier.Opencti} | ${TelemetryTargetProduct.OPEN_CTI}
+      ${PlatformIdentifier.Openaev} | ${TelemetryTargetProduct.OPEN_AEV}
+    `(
+      'should send a telemetry event when $platformName platform is registered',
+      async ({ platformName, telemetryProduct }) => {
+        requestContext.set(requestContextRegistererUserSecondOrga);
 
-      await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        platform,
-        identifier: PlatformIdentifier.Opencti,
-      });
+        const date = new Date(Date.UTC(2025, 1, 3, 13, 12, 15));
+        vi.setSystemTime(date);
+        const telemetrySpy = vi
+          .spyOn(telemetryApp, 'sendTelemetryEvent')
+          .mockResolvedValue();
 
-      expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
-        '@timestamp': '2025-02-03T13:12:15.000Z',
-        event_type: TelemetryEventType.REGISTER,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
-        source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
-        platform_contract: 'EE',
-        platform_version: 'X.Y.Z',
-        platform_id: platform.id,
-        platform_url: platform.url,
-        target_product: TelemetryTargetProduct.OPEN_CTI,
-        organization_type: 'Professional',
-      });
-    });
-    it('should send a telemetry event when openaev platform is registered', async () => {
-      vi.useFakeTimers();
-      const date = new Date(Date.UTC(2025, 1, 3, 13, 12, 15));
-      vi.setSystemTime(date);
-      const telemetrySpy = vi
-        .spyOn(telemetryApp, 'sendTelemetryEvent')
-        .mockResolvedValue();
+        await registrationApp.registerPlatform({
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          platform,
+          identifier: platformName,
+        });
 
-      await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        platform,
-        identifier: PlatformIdentifier.Openaev,
-      });
-
-      expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
-        '@timestamp': '2025-02-03T13:12:15.000Z',
-        event_type: TelemetryEventType.REGISTER,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
-        source: TelemetrySource.XTMHUB,
-        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
-        platform_contract: 'EE',
-        platform_version: 'X.Y.Z',
-        platform_id: platform.id,
-        platform_url: platform.url,
-        target_product: TelemetryTargetProduct.OPEN_AEV,
-        organization_type: 'Professional',
-      });
-    });
+        expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
+          '@timestamp': '2025-02-03T13:12:15.000Z',
+          event_type: TelemetryEventType.REGISTER,
+          organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          organization_name: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.NAME,
+          source: TelemetrySource.XTMHUB,
+          user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
+          platform_contract: 'EE',
+          platform_version: 'X.Y.Z',
+          platform_id: platform.id,
+          platform_url: platform.url,
+          target_product: telemetryProduct,
+          organization_type: 'Professional',
+        });
+      }
+    );
   });
 
   describe('unregisterPlatform', () => {
@@ -392,6 +384,8 @@ describe('Registration app', () => {
     let platform: PlatformInput;
 
     beforeEach(() => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       platformId = uuidv4();
       platform = {
         id: platformId,
@@ -403,13 +397,15 @@ describe('Registration app', () => {
     });
 
     it('should throw when user does not belong to the organization', async () => {
+      requestContext.set(requestContextAdminUser);
+
       await registrationApp.registerPlatform({
         organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
         platform,
         identifier: PlatformIdentifier.Opencti,
       });
+      requestContext.set(requestContextRegistererUserSecondOrga);
 
-      requestContext.set(requestContextAdminSecondOrga);
       const call = registrationApp.unregisterPlatform({
         platformId,
         identifier: PlatformIdentifier.Opencti,
@@ -439,7 +435,7 @@ describe('Registration app', () => {
 
     it('should throw when identifier is not the right type', async () => {
       await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform,
         identifier: PlatformIdentifier.Opencti,
       });
@@ -454,7 +450,7 @@ describe('Registration app', () => {
 
     it('should unregister platform when the platform is still active', async () => {
       await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform,
         identifier: PlatformIdentifier.Opencti,
       });
@@ -589,6 +585,9 @@ describe('Registration app', () => {
   });
 
   describe('loadPlatformRegistrationStatus', () => {
+    beforeEach(() => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+    });
     it('should return inactive when platform is not registered', async () => {
       const result = await registrationApp.loadPlatformRegistrationStatus({
         platformId: uuidv4(),
@@ -603,7 +602,7 @@ describe('Registration app', () => {
     it('should return active when platform is registered', async () => {
       const platformId = uuidv4();
       const token = await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform: {
           id: platformId,
           url: 'http://example.com',
@@ -677,7 +676,7 @@ describe('Registration app', () => {
       it('should return active when platform is registered and update version', async () => {
         const platformId = uuidv4();
         const token = await registrationApp.registerPlatform({
-          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
           platform: {
             id: platformId,
             url: 'http://example.com',
@@ -711,7 +710,7 @@ describe('Registration app', () => {
     it('should return inactive when platform is unregistered', async () => {
       const platformId = uuidv4();
       const token = await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform: {
           id: platformId,
           url: 'http://example.com',
@@ -774,9 +773,11 @@ describe('Registration app', () => {
     };
 
     beforeEach(async () => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       const serviceInstanceId = await registrationDomain.registerNewPlatform({
         serviceDefinitionId: SERVICES.DEFINITIONS.OPENCTI_REGISTRATION.ID,
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platformIdentifier: PlatformIdentifier.Opencti,
         serviceInstanceCreationStatus: ServiceInstanceCreationStatus.Pending,
       });
@@ -786,7 +787,7 @@ describe('Registration app', () => {
           activity_sector: DeploymentRequestActivitySector.ComputerGames,
           id: uuidv4() as DeploymentRequestId,
           job_title: DeploymentRequestJobTitle.CLevel,
-          organization_requester_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          organization_requester_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
           platform_identifier: PlatformIdentifier.Opencti,
           platform_token: uuidv4(),
           region: DeploymentRequestPlatformRegion.UsEast,
@@ -799,7 +800,7 @@ describe('Registration app', () => {
           use_case: DeploymentRequestUseCase.ThreatHunting,
           service_instance_id: serviceInstanceId as ServiceInstanceId,
           user_requester_id:
-            TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+            TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
         })) as DeploymentRequest;
     });
     afterEach(async () => {
@@ -869,7 +870,8 @@ describe('Registration app', () => {
           platform_title: platformConfiguration.title,
           platform_url: platformConfiguration.url,
           platform_version: platformConfiguration.version,
-          registerer_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          registerer_id:
+            TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
           token: deploymentRequest.platform_token,
         },
         service_instance_id: deploymentRequest.service_instance_id,
@@ -910,7 +912,8 @@ describe('Registration app', () => {
           platform_title: newPlatformConfiguration.title,
           platform_url: newPlatformConfiguration.url,
           platform_version: newPlatformConfiguration.version,
-          registerer_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          registerer_id:
+            TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
           token: deploymentRequest.platform_token,
         },
         service_instance_id: deploymentRequest.service_instance_id,
@@ -936,8 +939,8 @@ describe('Registration app', () => {
         expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
           '@timestamp': '2025-02-03T13:12:15.000Z',
           event_type: TelemetryEventType.REGISTER,
-          organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-          organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+          organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          organization_name: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           platform_contract: PlatformContract.Trial,
           platform_id: platformConfiguration.id,
@@ -945,7 +948,7 @@ describe('Registration app', () => {
           platform_url: platformConfiguration.url,
           source: TelemetrySource.XTMHUB,
           target_product: 'open-cti',
-          user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
         });
       });
 
@@ -966,8 +969,8 @@ describe('Registration app', () => {
         expect(telemetrySpy).toHaveBeenCalledExactlyOnceWith({
           '@timestamp': '2025-02-03T13:12:15.000Z',
           event_type: TelemetryEventType.REGISTER,
-          organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-          organization_name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+          organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          organization_name: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.NAME,
           organization_type: TelemetryOrganizationType.PROFESSIONAL,
           platform_contract: PlatformContract.Trial,
           platform_id: platformConfiguration.id,
@@ -975,7 +978,7 @@ describe('Registration app', () => {
           platform_url: platformConfiguration.url,
           source: TelemetrySource.XTMHUB,
           target_product: 'open-cti',
-          user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
           existing_users_count: 42,
         });
       });

--- a/apps/portal-api/src/modules/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.test.ts
@@ -11,8 +11,10 @@ import {
 } from 'vitest';
 import { db } from '../../../knexfile';
 import {
+  // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   requestContextRegistererUserSecondOrga,
   requestContextSimpleUserSecondOrga,
@@ -49,7 +51,6 @@ import Subscription, {
 } from '../../model/kanel/public/Subscription';
 
 import { UserLoadUserBy } from '../../model/user';
-import * as authHelper from '../security-management/capability/auth.helper';
 import {
   BadRequestErrorCode,
   ErrorCode,
@@ -57,6 +58,7 @@ import {
   NotFoundErrorCode,
 } from '../../utils/error/error.code';
 import { DeploymentRequestDomain } from '../deployment/deployment.domain';
+import * as authHelper from '../security-management/capability/auth.helper';
 import * as serviceInstanceDomain from '../services/service-instance.domain';
 import {
   deleteServiceInstanceBy,

--- a/apps/portal-api/src/modules/registration/registration.deprecated.resolver.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.deprecated.resolver.test.ts
@@ -4,6 +4,7 @@ import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserSecondOrga,
+  requestContextRegistererUserSecondOrga,
   TEST_ORGANIZATIONS,
 } from '../../../tests/tests.const';
 import {
@@ -12,6 +13,7 @@ import {
   PlatformInput,
   PlatformRegistrationConnectivityStatus,
 } from '../../__generated__/resolvers-types';
+import { requestContext } from '../../context/request.context';
 import { BadRequestErrorCode } from '../../utils/error/error.code';
 import { registrationApp } from './registration.app';
 import registrationResolver from './registration.resolver';
@@ -53,6 +55,8 @@ describe('Registration query resolver', () => {
       );
     });
     it('should return active when platform is registered', async () => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       expect(
         registrationResolver.Query?.openCTIPlatformRegistrationStatus
       ).toBeDefined();
@@ -62,7 +66,7 @@ describe('Registration query resolver', () => {
 
       const platformId = uuidv4();
       const token = await registrationApp.registerPlatform({
-        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         platform: {
           id: platformId,
           url: 'http://example.com',

--- a/apps/portal-api/src/modules/registration/registration.domain.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.domain.test.ts
@@ -109,6 +109,8 @@ describe('Registration domain', () => {
       });
     });
     it('can create pending platforms', async () => {
+      requestContext.set(requestContextRegistererUserSecondOrga);
+
       const serviceInstanceId = await registrationDomain.registerNewPlatform({
         organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         serviceDefinitionId,

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.canUnregisterPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.canUnregisterPlatform.test.ts
@@ -2,7 +2,7 @@ import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  contextSimple2,
+  contextSimpleUserFiligran2,
   INFO,
   TEST_ORGANIZATIONS,
 } from '../../../../../tests/tests.const';
@@ -46,7 +46,7 @@ describe('Query.canUnregisterPlatform', () => {
       const result = await registrationResolver.Query!.canUnregisterPlatform!(
         {},
         { input },
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 
@@ -69,7 +69,7 @@ describe('Query.canUnregisterPlatform', () => {
     const result = await registrationResolver.Query!.canUnregisterPlatform!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -95,7 +95,7 @@ describe('Query.canUnregisterPlatform', () => {
       const call = registrationResolver.Query!.canUnregisterPlatform!(
         {},
         { input },
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.isPlatformRegistered.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.isPlatformRegistered.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  contextSimple2,
+  contextSimpleUserFiligran2,
   INFO,
   TEST_ORGANIZATIONS,
 } from '../../../../../tests/tests.const';
@@ -35,7 +35,7 @@ describe('Query.isPlatformRegistered', () => {
     const result = await registrationResolver.Query!.isPlatformRegistered!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -59,7 +59,7 @@ describe('Query.isPlatformRegistered', () => {
     const call = registrationResolver.Query!.isPlatformRegistered!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  contextSimple2,
+  contextSimpleUserFiligran2,
   INFO,
   TEST_ORGANIZATIONS,
 } from '../../../../../tests/tests.const';
@@ -36,7 +36,7 @@ describe('Query.platformAssociatedOrganization', () => {
       .platformAssociatedOrganization!(
       {},
       { platformId },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -63,7 +63,7 @@ describe('Query.platformAssociatedOrganization', () => {
       .platformAssociatedOrganization!(
       {},
       { platformId },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -90,7 +90,7 @@ describe('Query.platformAssociatedOrganization', () => {
       const call = registrationResolver.Query!.platformAssociatedOrganization!(
         {},
         { platformId },
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshPlatformRegistrationConnectivityStatus.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshPlatformRegistrationConnectivityStatus.test.ts
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contextSimple2, INFO } from '../../../../../tests/tests.const';
+import {
+  contextSimpleUserFiligran2,
+  INFO,
+} from '../../../../../tests/tests.const';
 import {
   PlatformIdentifier,
   PlatformRegistrationConnectivityStatus,
@@ -39,7 +42,7 @@ describe('Mutation.refreshPlatformRegistrationConnectivityStatus', () => {
         .refreshPlatformRegistrationConnectivityStatus!(
         {},
         { input },
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshUserPlatformToken.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshUserPlatformToken.test.ts
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contextSimple2, INFO } from '../../../../../tests/tests.const';
+import {
+  contextSimpleUserFiligran2,
+  INFO,
+} from '../../../../../tests/tests.const';
 import { RefreshUserPlatformTokenResponse } from '../../../../__generated__/resolvers-types';
 import { UnknownErrorCode } from '../../../../utils/error/error.code';
 import { registrationApp } from '../../registration.app';
@@ -23,11 +26,11 @@ describe('Mutation.refreshUserPlatformToken', () => {
 
     // When
     const result = await registrationResolver.Mutation!
-      .refreshUserPlatformToken!({}, {}, contextSimple2, INFO);
+      .refreshUserPlatformToken!({}, {}, contextSimpleUserFiligran2, INFO);
 
     // Then
     expect(registrationApp.refreshUserPlatformToken).toHaveBeenCalledWith(
-      contextSimple2.user.id
+      contextSimpleUserFiligran2.user.id
     );
     expect(result).toMatchObject({ token: newToken });
   });
@@ -42,7 +45,7 @@ describe('Mutation.refreshUserPlatformToken', () => {
     const call = registrationResolver.Mutation!.refreshUserPlatformToken!(
       {},
       {},
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
@@ -2,7 +2,7 @@ import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  contextSimple2,
+  contextSimpleUserFiligran2,
   INFO,
   TEST_ORGANIZATIONS,
 } from '../../../../../tests/tests.const';
@@ -45,7 +45,7 @@ describe('Mutation.registerPlatform', () => {
     const result = await registrationResolver.Mutation!.registerPlatform!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -81,7 +81,7 @@ describe('Mutation.registerPlatform', () => {
     const call = registrationResolver.Mutation!.registerPlatform!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatform.test.ts
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contextSimple2, INFO } from '../../../../../tests/tests.const';
+import {
+  contextSimpleUserFiligran2,
+  INFO,
+} from '../../../../../tests/tests.const';
 import { RegisteredPlatform } from '../../../../__generated__/resolvers-types';
 import DeploymentRequest from '../../../../model/kanel/public/DeploymentRequest';
 import { ServiceInstanceId } from '../../../../model/kanel/public/ServiceInstance';
@@ -39,7 +42,7 @@ describe('RegisteredPlatform type resolvers', () => {
         .subscription!(
         { id: serviceInstanceId } as unknown as RegisteredPlatform,
         {},
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 
@@ -47,7 +50,7 @@ describe('RegisteredPlatform type resolvers', () => {
       expect(
         loadSubscriptionByServiceInstanceAndOrganizationSpy
       ).toHaveBeenCalledWith(
-        contextSimple2.user.selected_organization_id,
+        contextSimpleUserFiligran2.user.selected_organization_id,
         serviceInstanceId
       );
       expect(result).toEqual(expectedSubscription);
@@ -71,7 +74,7 @@ describe('RegisteredPlatform type resolvers', () => {
         .deployment_request!(
         { id: serviceInstanceId } as unknown as RegisteredPlatform,
         {},
-        contextSimple2,
+        contextSimpleUserFiligran2,
         INFO
       );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
@@ -1,7 +1,10 @@
 import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contextSimple2, INFO } from '../../../../../tests/tests.const';
+import {
+  contextSimpleUserFiligran2,
+  INFO,
+} from '../../../../../tests/tests.const';
 import {
   PlatformIdentifier,
   RegisteredPlatform,
@@ -29,7 +32,7 @@ describe('Query.registeredPlatform', () => {
     const result = await registrationResolver.Query!.registeredPlatform!(
       {},
       { input: { service_instance_id: globalId } },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -60,7 +63,7 @@ describe('Query.registeredPlatforms', () => {
     const result = await registrationResolver.Query!.registeredPlatforms!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.unregisterPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.unregisterPlatform.test.ts
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contextSimple2, INFO } from '../../../../../tests/tests.const';
+import {
+  contextSimpleUserFiligran2,
+  INFO,
+} from '../../../../../tests/tests.const';
 import {
   PlatformIdentifier,
   UnregisterPlatformInput,
@@ -28,7 +31,7 @@ describe('Mutation.unregisterPlatform', () => {
     const result = await registrationResolver.Mutation!.unregisterPlatform!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 
@@ -51,7 +54,7 @@ describe('Mutation.unregisterPlatform', () => {
     const call = registrationResolver.Mutation!.unregisterPlatform!(
       {},
       { input },
-      contextSimple2,
+      contextSimpleUserFiligran2,
       INFO
     );
 

--- a/apps/portal-api/src/modules/security-management/service-capability/service-capability.app.test.ts
+++ b/apps/portal-api/src/modules/security-management/service-capability/service-capability.app.test.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../../../../knexfile';
 import {
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   requestContextSimpleUserSecondOrga,
   SERVICES,
@@ -14,8 +15,8 @@ import UserService from '../../../model/kanel/public/UserService';
 import UserServiceCapability from '../../../model/kanel/public/UserServiceCapability';
 import { createSubscription } from '../../subcription/subscription.domain';
 import { SubscriptionStatus } from '../../subscription.const';
-import { loadCapabilities } from '../user-service-capability/user-service-capability.helper';
 import { UserServiceDomain } from '../../user_service/user_service.domain';
+import { loadCapabilities } from '../user-service-capability/user-service-capability.helper';
 import { GenericServiceCapabilityName } from './generic_service_capability.const';
 import { serviceCapabilityApp } from './service-capability.app';
 

--- a/apps/portal-api/src/modules/security-management/service-capability/service-capability.app.test.ts
+++ b/apps/portal-api/src/modules/security-management/service-capability/service-capability.app.test.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../../../../knexfile';
 import {
+  requestContextAdminUser,
   requestContextSimpleUserSecondOrga,
   SERVICES,
 } from '../../../../tests/tests.const';
@@ -37,6 +38,7 @@ describe('editServiceCapability', () => {
     await db<UserService>('User_Service').del();
   });
   it('should update capability', async () => {
+    requestContext.set(requestContextAdminUser);
     const userService = await UserServiceDomain.createUserServiceAccess({
       subscription_id: subscription.id,
       user_id: requestContextSimpleUserSecondOrga.user.id,

--- a/apps/portal-api/src/modules/security-management/user-organization-capability/user-organization-capability.domain.test.ts
+++ b/apps/portal-api/src/modules/security-management/user-organization-capability/user-organization-capability.domain.test.ts
@@ -1,14 +1,20 @@
 import { v4 as uuidv4 } from 'uuid';
 import { describe, expect, it } from 'vitest';
-import { TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
+import {
+  requestContextAdminSecondOrga,
+  TEST_ORGANIZATIONS,
+} from '../../../../tests/tests.const';
 import { OrganizationCapability } from '../../../__generated__/resolvers-types';
+import { requestContext } from '../../../context/request.context';
 import { loadUserOrganizationCapabilities } from './user-organization-capability.domain';
 
 describe('UserOrganizationCapabilityDomain', () => {
   describe('loadUserOrganizationCapabilities', () => {
     it('should return the user capabilities when organization exists', async () => {
+      requestContext.set(requestContextAdminSecondOrga);
+
       const capabilities = await loadUserOrganizationCapabilities(
-        TEST_ORGANIZATIONS.FILIGRAN.ID
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
       );
 
       expect(capabilities.length).toBe(1);

--- a/apps/portal-api/src/modules/services/service-instance.domain.test.ts
+++ b/apps/portal-api/src/modules/services/service-instance.domain.test.ts
@@ -12,6 +12,7 @@ import {
 import { TestHelper } from '../../../tests/test.helper';
 import {
   contextRegistererUserSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
   SERVICES,
   TEST_ORGANIZATIONS,

--- a/apps/portal-api/src/modules/services/service-instance.domain.test.ts
+++ b/apps/portal-api/src/modules/services/service-instance.domain.test.ts
@@ -12,6 +12,7 @@ import {
 import { TestHelper } from '../../../tests/test.helper';
 import {
   contextRegistererUserSecondOrga,
+  requestContextAdminUser,
   SERVICES,
   TEST_ORGANIZATIONS,
 } from '../../../tests/tests.const';
@@ -21,6 +22,7 @@ import {
   ServiceDefinitionIdentifier,
   ServiceInstanceTag,
 } from '../../__generated__/resolvers-types';
+import { requestContext } from '../../context/request.context';
 import ServiceInstance, {
   ServiceInstanceId,
 } from '../../model/kanel/public/ServiceInstance';
@@ -595,6 +597,9 @@ describe('Service instance domain', () => {
     `(
       'should return subscriptions for searchTerm=$searchTerm',
       async ({ searchTerm, expectedNames }) => {
+        // Given
+        requestContext.set(requestContextAdminUser);
+
         // When
         const result = await loadServiceWithSubscriptions(
           serviceInstanceId,

--- a/apps/portal-api/src/modules/user_service/user-service.domain.test.ts
+++ b/apps/portal-api/src/modules/user_service/user-service.domain.test.ts
@@ -284,7 +284,9 @@ describe('UserServiceDomain', () => {
     });
 
     it('should create a new User record for an unknown email in the org domain', async () => {
-      const newEmail = `new-user-${uuidv4()}@second-orga.com`;
+      requestContext.set(requestContextAdminSecondOrga);
+
+      const newEmail = `new-user-${uuidv4()}@${TEST_ORGANIZATIONS.SECOND_ORGANIZATION.DOMAINS.FIRST.NAME}`;
       const subscription = await getSubscription();
 
       const result = await UserServiceDomain.addServiceToUsers(

--- a/apps/portal-api/src/modules/user_service/user-service.domain.test.ts
+++ b/apps/portal-api/src/modules/user_service/user-service.domain.test.ts
@@ -5,6 +5,7 @@ import {
   SERVICES,
   TEST_ORGANIZATIONS,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports
   requestContextAdminUser,
 } from '../../../tests/tests.const';
 import { requestContext } from '../../context/request.context';
@@ -19,12 +20,12 @@ import UserServiceCapability from '../../model/kanel/public/UserServiceCapabilit
 import * as mailService from '../../server/mail-service';
 import { loadUserBy } from '../organization-management/users/user-domain/users.domain';
 import { removeUser } from '../organization-management/users/users.helper';
-import { createSubscription } from '../subcription/subscription.domain';
-import { SubscriptionStatus } from '../subscription.const';
 import {
   GenericServiceCapabilityIds,
   GenericServiceCapabilityName,
 } from '../security-management/service-capability/generic_service_capability.const';
+import { createSubscription } from '../subcription/subscription.domain';
+import { SubscriptionStatus } from '../subscription.const';
 import { UserServiceDomain } from './user_service.domain';
 
 // ---------------------------------------------------------------------------

--- a/apps/portal-api/src/security/guard.test.ts
+++ b/apps/portal-api/src/security/guard.test.ts
@@ -1,14 +1,15 @@
 import { MockInstance } from '@vitest/spy';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
   requestContextAdminSecondOrga,
   TEST_ORGANIZATIONS,
 } from '../../tests/tests.const';
 import { OrganizationCapability } from '../__generated__/resolvers-types';
 import { requestContext } from '../context/request.context';
-import { ErrorCode } from '../utils/error/error.code';
 import * as authHelper from '../modules/security-management/capability/auth.helper';
+import { ErrorCode } from '../utils/error/error.code';
 import { securityGuard } from './guard';
 
 describe('Security Guard', () => {

--- a/apps/portal-api/src/thirdparty/hubspot/hubspot.test.ts
+++ b/apps/portal-api/src/thirdparty/hubspot/hubspot.test.ts
@@ -14,6 +14,7 @@ import { db } from '../../../knexfile';
 import {
   contextAdminSecondOrga,
   requestContextAdminSecondOrga,
+  TEST_ORGANIZATIONS,
 } from '../../../tests/tests.const';
 import { requestContext } from '../../context/request.context';
 import DeploymentRequest from '../../model/kanel/public/DeploymentRequest';
@@ -155,10 +156,10 @@ describe('Hubspot', () => {
         expect.objectContaining({
           body: JSON.stringify({
             type: 'reachOutSales',
-            email: 'admin@filigran.io',
-            firstname: 'Al',
-            lastname: 'Beback',
-            company: 'Filigran',
+            email: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            firstname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+            lastname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME,
+            company: TEST_ORGANIZATIONS.FILIGRAN.NAME,
             message:
               'opencti: Message sent for free trial: pending trial.\n\nPlease contact me about the OpenCTI free trial',
           }),
@@ -178,10 +179,10 @@ describe('Hubspot', () => {
         expect.objectContaining({
           body: JSON.stringify({
             type: 'reachOutSales',
-            email: 'admin@filigran.io',
-            firstname: 'Al',
-            lastname: 'Beback',
-            company: 'Filigran',
+            email: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            firstname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+            lastname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME,
+            company: TEST_ORGANIZATIONS.FILIGRAN.NAME,
             message:
               'opencti: Message sent for free trial: pending trial.\n\nPlease contact me about the OpenCTI free trial',
           }),
@@ -196,10 +197,10 @@ describe('Hubspot', () => {
         expect.objectContaining({
           body: JSON.stringify({
             type: 'reachOutSales',
-            email: 'admin@filigran.io',
-            firstname: 'Al',
-            lastname: 'Beback',
-            company: 'Filigran',
+            email: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.EMAIL,
+            firstname: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.FIRST_NAME,
+            lastname: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.LAST_NAME,
+            company: TEST_ORGANIZATIONS.FILIGRAN.NAME,
             message: 'opencti: Please contact me about the OpenCTI free trial',
           }),
         })
@@ -214,10 +215,10 @@ describe('Hubspot', () => {
         expect.objectContaining({
           body: JSON.stringify({
             type: 'reachOutSales',
-            email: 'admin@filigran.io',
-            firstname: 'Al',
-            lastname: 'Beback',
-            company: 'Filigran',
+            email: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.EMAIL,
+            firstname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.FIRST_NAME,
+            lastname: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.LAST_NAME,
+            company: TEST_ORGANIZATIONS.FILIGRAN.NAME,
             message:
               'opencti: Message sent for free trial: pending trial.\n\nPlease contact me about the OpenCTI free trial',
           }),

--- a/apps/portal-api/tests/setup-test.ts
+++ b/apps/portal-api/tests/setup-test.ts
@@ -1,7 +1,7 @@
 import { beforeAll } from 'vitest';
 import { requestContext, RequestContext } from '../src/context/request.context';
 import { closeDbTestConnection, getDbTestConnection } from './config-test';
-import { requestContextAdminUser } from './tests.const';
+import { requestContextSimple2 } from './tests.const';
 
 function isUtilOrHelper(filepath?: string) {
   if (!filepath) return true;
@@ -39,7 +39,11 @@ function mockRequestContext() {
 
   requestContext.get = vi.fn(() => {
     const testKey = getCurrentTestKey();
-    return testRequestStorage.get(testKey) || { ...requestContextAdminUser };
+    return (
+      testRequestStorage.get(testKey) || {
+        ...requestContextSimple2,
+      }
+    );
   });
 
   requestContext.require = vi.fn(() => {
@@ -53,7 +57,7 @@ function mockRequestContext() {
   requestContext.update = vi.fn((updates) => {
     const testKey = getCurrentTestKey();
     const current = testRequestStorage.get(testKey) || {
-      ...requestContextAdminUser,
+      ...requestContextSimple2,
     };
     testRequestStorage.set(testKey, { ...current, ...updates });
   });
@@ -84,7 +88,7 @@ function mockRequestContext() {
 beforeEach(() => {
   // Set fresh context for each test
   const testKey = getCurrentTestKey();
-  testRequestStorage.set(testKey, { ...requestContextAdminUser });
+  testRequestStorage.set(testKey, { ...requestContextSimple2 });
 });
 
 beforeAll(async (suite) => {

--- a/apps/portal-api/tests/setup-test.ts
+++ b/apps/portal-api/tests/setup-test.ts
@@ -1,7 +1,7 @@
 import { beforeAll } from 'vitest';
 import { requestContext, RequestContext } from '../src/context/request.context';
 import { closeDbTestConnection, getDbTestConnection } from './config-test';
-import { requestContextSimple2 } from './tests.const';
+import { requestContextSimpleUserFiligran2 } from './tests.const';
 
 function isUtilOrHelper(filepath?: string) {
   if (!filepath) return true;
@@ -41,7 +41,7 @@ function mockRequestContext() {
     const testKey = getCurrentTestKey();
     return (
       testRequestStorage.get(testKey) || {
-        ...requestContextSimple2,
+        ...requestContextSimpleUserFiligran2,
       }
     );
   });
@@ -57,7 +57,7 @@ function mockRequestContext() {
   requestContext.update = vi.fn((updates) => {
     const testKey = getCurrentTestKey();
     const current = testRequestStorage.get(testKey) || {
-      ...requestContextSimple2,
+      ...requestContextSimpleUserFiligran2,
     };
     testRequestStorage.set(testKey, { ...current, ...updates });
   });
@@ -88,7 +88,7 @@ function mockRequestContext() {
 beforeEach(() => {
   // Set fresh context for each test
   const testKey = getCurrentTestKey();
-  testRequestStorage.set(testKey, { ...requestContextSimple2 });
+  testRequestStorage.set(testKey, { ...requestContextSimpleUserFiligran2 });
 });
 
 beforeAll(async (suite) => {

--- a/apps/portal-api/tests/tests.const.ts
+++ b/apps/portal-api/tests/tests.const.ts
@@ -303,7 +303,7 @@ export const requestContextSimpleUserSecondOrga = {
   portalContext: contextSimpleUserSecondOrga,
 };
 
-export const contextSimple2: PortalContext = {
+export const contextSimpleUserFiligran2: PortalContext = {
   user: {
     id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE2.ID,
     email: 'access-subscription@filigran.io',
@@ -335,7 +335,7 @@ export const contextSimple2: PortalContext = {
   },
 } as PortalContext;
 
-export const requestContextSimple2 = {
-  user: contextSimple2.user,
-  portalContext: contextSimple2,
+export const requestContextSimpleUserFiligran2 = {
+  user: contextSimpleUserFiligran2.user,
+  portalContext: contextSimpleUserFiligran2,
 };


### PR DESCRIPTION
# Context
> This PR remove the test setup with adminBypass context to a context for a simple user with no rights. Then, it fixes all the related tests. 

## How to test
- All backend tests must pass

## Related issues

- Related to #2066 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [X] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.