### PR TITLE
[backend/frontend] chore: remove extractId for various modules (#2082)

### DIFF
--- a/apps/portal-api/codegen.yml
+++ b/apps/portal-api/codegen.yml
@@ -17,3 +17,4 @@ generates:
         ServiceInstanceId: "../model/kanel/public/ServiceInstance.js#ServiceInstanceId"
         OrganizationId: "../model/kanel/public/Organization.js#OrganizationId"
         CompetitorId: "../model/kanel/public/Competitor.js#CompetitorId"
+        DeploymentRequestId: "../model/kanel/public/DeploymentRequest.js#DeploymentRequestId"

--- a/apps/portal-api/codegen.yml
+++ b/apps/portal-api/codegen.yml
@@ -16,3 +16,4 @@ generates:
       scalars:
         ServiceInstanceId: "../model/kanel/public/ServiceInstance.js#ServiceInstanceId"
         OrganizationId: "../model/kanel/public/Organization.js#OrganizationId"
+        CompetitorId: "../model/kanel/public/Competitor.js#CompetitorId"

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1,4 +1,5 @@
 import type { CompetitorId } from '../model/kanel/public/Competitor.js';
+import type { DeploymentRequestId } from '../model/kanel/public/DeploymentRequest.js';
 import type { OrganizationId } from '../model/kanel/public/Organization.js';
 import type { ServiceInstanceId } from '../model/kanel/public/ServiceInstance.js';
 import type { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
@@ -21,6 +22,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   CompetitorId: { input: CompetitorId; output: CompetitorId; }
   Date: { input: any; output: any; }
+  DeploymentRequestId: { input: DeploymentRequestId; output: DeploymentRequestId; }
   JSON: { input: any; output: any; }
   OrganizationId: { input: OrganizationId; output: OrganizationId; }
   ServiceInstanceId: { input: ServiceInstanceId; output: ServiceInstanceId; }
@@ -890,7 +892,7 @@ export type MutationAdminAddUserArgs = {
 
 
 export type MutationAdminCancelDeploymentRequestArgs = {
-  deploymentRequestId?: InputMaybe<Scalars['ID']['input']>;
+  deploymentRequestId?: InputMaybe<Scalars['DeploymentRequestId']['input']>;
 };
 
 
@@ -918,7 +920,7 @@ export type MutationBulkRemovePendingUserFromOrganizationArgs = {
 
 export type MutationCancelDeploymentRequestArgs = {
   cancellationReason?: InputMaybe<Scalars['String']['input']>;
-  deploymentRequestId: Scalars['ID']['input'];
+  deploymentRequestId: Scalars['DeploymentRequestId']['input'];
 };
 
 
@@ -1703,7 +1705,7 @@ export enum ReorderDeploymentRequestInQueueDirection {
 
 export type ReorderDeploymentRequestInQueueInput = {
   direction: ReorderDeploymentRequestInQueueDirection;
-  id: Scalars['ID']['input'];
+  id: Scalars['DeploymentRequestId']['input'];
 };
 
 export type RolePortal = Node & {
@@ -2144,7 +2146,7 @@ export type UpdateDeploymentRequestInput = {
   actual_state?: InputMaybe<DeploymentRequestPlatformState>;
   end_date?: InputMaybe<Scalars['Date']['input']>;
   failure_reason?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['ID']['input'];
+  id: Scalars['DeploymentRequestId']['input'];
   ordering?: InputMaybe<Scalars['Int']['input']>;
   platform_id?: InputMaybe<Scalars['String']['input']>;
   start_date?: InputMaybe<Scalars['Date']['input']>;
@@ -2449,6 +2451,7 @@ export type ResolversTypes = ResolversObject<{
   DeploymentRequestFilter: DeploymentRequestFilter;
   DeploymentRequestFilterKey: DeploymentRequestFilterKey;
   DeploymentRequestHubStatus: DeploymentRequestHubStatus;
+  DeploymentRequestId: ResolverTypeWrapper<Scalars['DeploymentRequestId']['output']>;
   DeploymentRequestJobTitle: DeploymentRequestJobTitle;
   DeploymentRequestOrdering: DeploymentRequestOrdering;
   DeploymentRequestPlatformRegion: DeploymentRequestPlatformRegion;
@@ -2633,6 +2636,7 @@ export type ResolversParentTypes = ResolversObject<{
   DeploymentRequestConnection: DeploymentRequestConnection;
   DeploymentRequestEdge: DeploymentRequestEdge;
   DeploymentRequestFilter: DeploymentRequestFilter;
+  DeploymentRequestId: Scalars['DeploymentRequestId']['output'];
   Document: ResolversInterfaceTypes<ResolversParentTypes>['Document'];
   DocumentConnection: Omit<DocumentConnection, 'edges'> & { edges: Array<ResolversParentTypes['DocumentEdge']> };
   DocumentEdge: Omit<DocumentEdge, 'node'> & { node: ResolversParentTypes['Document'] };
@@ -2981,6 +2985,10 @@ export type DeploymentRequestEdgeResolvers<ContextType = PortalContext, ParentTy
   node?: Resolver<ResolversTypes['DeploymentRequest'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface DeploymentRequestIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DeploymentRequestId'], any> {
+  name: 'DeploymentRequestId';
+}
 
 export type DocumentResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['Document'] = ResolversParentTypes['Document']> = ResolversObject<{
   __resolveType: TypeResolveFn<'Connector' | 'CsvFeed' | 'CustomDashboard' | 'DefaultDocument' | 'IntegrationHack' | 'OpenAEVScenario' | 'RssFeed' | 'Stream' | 'TaxiiFeed' | 'ThirdPartyIntegration', ParentType, ContextType>;
@@ -3852,6 +3860,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   DeploymentRequest?: DeploymentRequestResolvers<ContextType>;
   DeploymentRequestConnection?: DeploymentRequestConnectionResolvers<ContextType>;
   DeploymentRequestEdge?: DeploymentRequestEdgeResolvers<ContextType>;
+  DeploymentRequestId?: GraphQLScalarType;
   Document?: DocumentResolvers<ContextType>;
   DocumentConnection?: DocumentConnectionResolvers<ContextType>;
   DocumentEdge?: DocumentEdgeResolvers<ContextType>;

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -25,6 +25,7 @@ export type Scalars = {
   DeploymentRequestId: { input: DeploymentRequestId; output: DeploymentRequestId; }
   JSON: { input: any; output: any; }
   OrganizationId: { input: OrganizationId; output: OrganizationId; }
+  ServiceGroupId: { input: any; output: any; }
   ServiceInstanceId: { input: ServiceInstanceId; output: ServiceInstanceId; }
   Upload: { input: any; output: any; }
 };
@@ -2184,7 +2185,7 @@ export type UpdateServiceGroupsInput = {
 };
 
 export type UpdateServiceGroupsInputGroup = {
-  id: Scalars['ID']['input'];
+  id: Scalars['ServiceGroupId']['input'];
   userIds: Array<Scalars['ID']['input']>;
 };
 
@@ -2542,6 +2543,7 @@ export type ResolversTypes = ResolversObject<{
   ServiceDefinition: ResolverTypeWrapper<ServiceDefinition>;
   ServiceDefinitionIdentifier: ServiceDefinitionIdentifier;
   ServiceGroup: ResolverTypeWrapper<ServiceGroup>;
+  ServiceGroupId: ResolverTypeWrapper<Scalars['ServiceGroupId']['output']>;
   ServiceInstance: ResolverTypeWrapper<ServiceInstance>;
   ServiceInstanceCreationStatus: ServiceInstanceCreationStatus;
   ServiceInstanceEdge: ResolverTypeWrapper<ServiceInstanceEdge>;
@@ -2699,6 +2701,7 @@ export type ResolversParentTypes = ResolversObject<{
   ServiceConnection: ServiceConnection;
   ServiceDefinition: ServiceDefinition;
   ServiceGroup: ServiceGroup;
+  ServiceGroupId: Scalars['ServiceGroupId']['output'];
   ServiceInstance: ServiceInstance;
   ServiceInstanceEdge: ServiceInstanceEdge;
   ServiceInstanceFilter: ServiceInstanceFilter;
@@ -3501,6 +3504,10 @@ export type ServiceGroupResolvers<ContextType = PortalContext, ParentType extend
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export interface ServiceGroupIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ServiceGroupId'], any> {
+  name: 'ServiceGroupId';
+}
+
 export type ServiceInstanceResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['ServiceInstance'] = ResolversParentTypes['ServiceInstance']> = ResolversObject<{
   capabilities?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   creation_status?: Resolver<Maybe<ResolversTypes['ServiceInstanceCreationStatus']>, ParentType, ContextType>;
@@ -3903,6 +3910,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   ServiceConnection?: ServiceConnectionResolvers<ContextType>;
   ServiceDefinition?: ServiceDefinitionResolvers<ContextType>;
   ServiceGroup?: ServiceGroupResolvers<ContextType>;
+  ServiceGroupId?: GraphQLScalarType;
   ServiceInstance?: ServiceInstanceResolvers<ContextType>;
   ServiceInstanceEdge?: ServiceInstanceEdgeResolvers<ContextType>;
   ServiceInstanceId?: GraphQLScalarType;

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -856,7 +856,7 @@ export type MutationAddSubscriptionArgs = {
 export type MutationAddSubscriptionInServiceArgs = {
   capability_ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   end_date?: InputMaybe<Scalars['Date']['input']>;
-  organization_id?: InputMaybe<Scalars['ID']['input']>;
+  organization_id?: InputMaybe<Scalars['OrganizationId']['input']>;
   service_instance_id?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
   start_date?: InputMaybe<Scalars['Date']['input']>;
 };
@@ -921,7 +921,7 @@ export type MutationCancelDeploymentRequestArgs = {
 
 
 export type MutationChangeSelectedOrganizationArgs = {
-  organization_id: Scalars['ID']['input'];
+  organization_id: Scalars['OrganizationId']['input'];
 };
 
 
@@ -1053,13 +1053,13 @@ export type MutationRegisterPlatformArgs = {
 
 
 export type MutationRemovePendingUserFromOrganizationArgs = {
-  organization_id: Scalars['ID']['input'];
+  organization_id: Scalars['OrganizationId']['input'];
   user_id: Scalars['ID']['input'];
 };
 
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  organization_id: Scalars['ID']['input'];
+  organization_id: Scalars['OrganizationId']['input'];
   user_id: Scalars['ID']['input'];
 };
 
@@ -1204,7 +1204,7 @@ export type OrganizationCapabilities = Node & {
 
 export type OrganizationCapabilitiesInput = {
   capabilities?: InputMaybe<Array<Scalars['String']['input']>>;
-  organization_id: Scalars['ID']['input'];
+  organization_id: Scalars['OrganizationId']['input'];
 };
 
 export enum OrganizationCapability {
@@ -2155,7 +2155,7 @@ export type UpdateDocumentInput = {
   short_description?: InputMaybe<Scalars['String']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   uploader_id?: InputMaybe<Scalars['String']['input']>;
-  uploader_organization_id?: InputMaybe<Scalars['String']['input']>;
+  uploader_organization_id?: InputMaybe<Scalars['OrganizationId']['input']>;
   use_cases?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -2221,11 +2221,11 @@ export type User = Node & {
   last_name?: Maybe<Scalars['String']['output']>;
   organization_capabilities?: Maybe<Array<OrganizationCapabilities>>;
   organizations?: Maybe<Array<Organization>>;
-  pending_organization_id?: Maybe<Scalars['ID']['output']>;
+  pending_organization_id?: Maybe<Scalars['OrganizationId']['output']>;
   picture?: Maybe<Scalars['String']['output']>;
   roles_portal?: Maybe<Array<RolePortal>>;
   selected_org_capabilities?: Maybe<Array<OrganizationCapability>>;
-  selected_organization_id?: Maybe<Scalars['String']['output']>;
+  selected_organization_id?: Maybe<Scalars['OrganizationId']['output']>;
 };
 
 export type UserConnection = {
@@ -2334,7 +2334,7 @@ export type UserSubscription = {
 
 export type UsersWithCapabilitiesInOrganizationInput = {
   capabilities: Array<OrganizationCapability>;
-  organizationId: Scalars['ID']['input'];
+  organizationId: Scalars['OrganizationId']['input'];
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -3753,11 +3753,11 @@ export type UserResolvers<ContextType = PortalContext, ParentType extends Resolv
   last_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   organization_capabilities?: Resolver<Maybe<Array<ResolversTypes['OrganizationCapabilities']>>, ParentType, ContextType>;
   organizations?: Resolver<Maybe<Array<ResolversTypes['Organization']>>, ParentType, ContextType>;
-  pending_organization_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  pending_organization_id?: Resolver<Maybe<ResolversTypes['OrganizationId']>, ParentType, ContextType>;
   picture?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   roles_portal?: Resolver<Maybe<Array<ResolversTypes['RolePortal']>>, ParentType, ContextType>;
   selected_org_capabilities?: Resolver<Maybe<Array<ResolversTypes['OrganizationCapability']>>, ParentType, ContextType>;
-  selected_organization_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  selected_organization_id?: Resolver<Maybe<ResolversTypes['OrganizationId']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -146,7 +146,7 @@ export type Connector = Document & Integration & Node & {
   product_version?: Maybe<Scalars['String']['output']>;
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -216,7 +216,7 @@ export type CsvFeed = Document & Integration & Node & {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -242,7 +242,7 @@ export type CustomDashboard = Document & Node & {
   name: Scalars['String']['output'];
   product_version?: Maybe<Scalars['String']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -271,7 +271,7 @@ export type DefaultDocument = Document & Node & {
   minio_name: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -484,7 +484,7 @@ export type Document = {
   minio_name: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -660,7 +660,7 @@ export type Integration = {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -689,7 +689,7 @@ export type IntegrationHack = Document & Integration & Node & {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -849,7 +849,7 @@ export type MutationAddServicePictureArgs = {
 
 
 export type MutationAddSubscriptionArgs = {
-  service_instance_id?: InputMaybe<Scalars['String']['input']>;
+  service_instance_id?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
@@ -857,7 +857,7 @@ export type MutationAddSubscriptionInServiceArgs = {
   capability_ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   end_date?: InputMaybe<Scalars['Date']['input']>;
   organization_id?: InputMaybe<Scalars['ID']['input']>;
-  service_instance_id?: InputMaybe<Scalars['String']['input']>;
+  service_instance_id?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
   start_date?: InputMaybe<Scalars['Date']['input']>;
 };
 
@@ -947,7 +947,7 @@ export type MutationCreateDocumentArgs = {
   input: CreateDocumentInput;
   logo?: InputMaybe<Scalars['Upload']['input']>;
   metadata: Array<DocumentMetadata>;
-  serviceInstanceId?: InputMaybe<Scalars['String']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
   sourceDocument?: InputMaybe<Scalars['Upload']['input']>;
 };
 
@@ -966,7 +966,7 @@ export type MutationDeleteCompetitorArgs = {
 export type MutationDeleteDocumentArgs = {
   documentId?: InputMaybe<Scalars['ID']['input']>;
   forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
-  service_instance_id?: InputMaybe<Scalars['String']['input']>;
+  service_instance_id?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
@@ -1008,7 +1008,7 @@ export type MutationEditOrganizationArgs = {
 
 export type MutationEditServiceCapabilityArgs = {
   input?: InputMaybe<EditServiceCapabilityInput>;
-  serviceInstanceId?: InputMaybe<Scalars['String']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
@@ -1106,7 +1106,7 @@ export type MutationUpdateDocumentArgs = {
   input: UpdateDocumentInput;
   logo?: InputMaybe<Scalars['Upload']['input']>;
   metadata: Array<DocumentMetadata>;
-  serviceInstanceId?: InputMaybe<Scalars['String']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
   sourceDocument?: InputMaybe<Scalars['Upload']['input']>;
 };
 
@@ -1142,7 +1142,7 @@ export type OneClickDeployInput = {
   platform_service_instance_id: Scalars['ID']['input'];
   resource_id: Scalars['ID']['input'];
   resource_title: Scalars['String']['input'];
-  service_instance_id: Scalars['ID']['input'];
+  service_instance_id: Scalars['ServiceInstanceId']['input'];
 };
 
 export type OpenAevScenario = Document & Node & {
@@ -1158,7 +1158,7 @@ export type OpenAevScenario = Document & Node & {
   name: Scalars['String']['output'];
   product_version?: Maybe<Scalars['String']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -1420,13 +1420,13 @@ export type QueryDeploymentRequestsListArgs = {
 
 export type QueryDocumentArgs = {
   documentId?: InputMaybe<Scalars['ID']['input']>;
-  serviceInstanceId?: InputMaybe<Scalars['ID']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
 export type QueryDocumentExistsArgs = {
   documentName?: InputMaybe<Scalars['String']['input']>;
-  service_instance_id?: InputMaybe<Scalars['String']['input']>;
+  service_instance_id?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
@@ -1438,7 +1438,7 @@ export type QueryDocumentsArgs = {
   orderMode: OrderingMode;
   parentsOnly?: InputMaybe<Scalars['Boolean']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
-  serviceInstanceId?: InputMaybe<Scalars['String']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 
@@ -1496,7 +1496,7 @@ export type QueryPlatformAssociatedOrganizationArgs = {
 
 
 export type QueryPublicDocumentBySlugArgs = {
-  serviceInstanceId: Scalars['ID']['input'];
+  serviceInstanceId: Scalars['ServiceInstanceId']['input'];
   slug: Scalars['String']['input'];
 };
 
@@ -1508,7 +1508,7 @@ export type QueryPublicDocumentsArgs = {
   orderBy: DocumentOrdering;
   orderMode: OrderingMode;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
-  serviceInstanceId: Scalars['ID']['input'];
+  serviceInstanceId: Scalars['ServiceInstanceId']['input'];
   slug: Scalars['String']['input'];
 };
 
@@ -1542,7 +1542,7 @@ export type QuerySeoServiceInstanceArgs = {
 
 
 export type QueryServiceGroupsArgs = {
-  serviceInstanceId: Scalars['ID']['input'];
+  serviceInstanceId: Scalars['ServiceInstanceId']['input'];
 };
 
 
@@ -1680,7 +1680,7 @@ export type RegisteredPlatform = Node & {
 };
 
 export type RegisteredPlatformInput = {
-  service_instance_id: Scalars['ID']['input'];
+  service_instance_id: Scalars['ServiceInstanceId']['input'];
 };
 
 export type RegisteredPlatformsInput = {
@@ -1728,7 +1728,7 @@ export type RssFeed = Document & Integration & Node & {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -1939,7 +1939,7 @@ export type Stream = Document & Integration & Node & {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -2049,7 +2049,7 @@ export type TaxiiFeed = Document & Integration & Node & {
   name: Scalars['String']['output'];
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -2087,7 +2087,7 @@ export type ThirdPartyIntegration = Document & Integration & Node & {
   product_version?: Maybe<Scalars['String']['output']>;
   remover_id?: Maybe<Scalars['ID']['output']>;
   service_instance?: Maybe<ServiceInstance>;
-  service_instance_id: Scalars['String']['output'];
+  service_instance_id: Scalars['ServiceInstanceId']['output'];
   share_number?: Maybe<Scalars['Int']['output']>;
   short_description?: Maybe<Scalars['String']['output']>;
   slug: Scalars['String']['output'];
@@ -2275,7 +2275,7 @@ export type UserServiceAddInput = {
 
 export type UserServiceAddYourselfInput = {
   email: Array<Scalars['String']['input']>;
-  serviceInstanceId?: InputMaybe<Scalars['ID']['input']>;
+  serviceInstanceId?: InputMaybe<Scalars['ServiceInstanceId']['input']>;
 };
 
 export type UserServiceCapability = Node & {
@@ -2819,7 +2819,7 @@ export type ConnectorResolvers<ContextType = PortalContext, ParentType extends R
   product_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -2852,7 +2852,7 @@ export type CsvFeedResolvers<ContextType = PortalContext, ParentType extends Res
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -2878,7 +2878,7 @@ export type CustomDashboardResolvers<ContextType = PortalContext, ParentType ext
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   product_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -2907,7 +2907,7 @@ export type DefaultDocumentResolvers<ContextType = PortalContext, ParentType ext
   minio_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -2986,7 +2986,7 @@ export type DocumentResolvers<ContextType = PortalContext, ParentType extends Re
   minio_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -3065,7 +3065,7 @@ export type IntegrationResolvers<ContextType = PortalContext, ParentType extends
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3093,7 +3093,7 @@ export type IntegrationHackResolvers<ContextType = PortalContext, ParentType ext
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3212,7 +3212,7 @@ export type OpenAevScenarioResolvers<ContextType = PortalContext, ParentType ext
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   product_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3421,7 +3421,7 @@ export type RssFeedResolvers<ContextType = PortalContext, ParentType extends Res
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3570,7 +3570,7 @@ export type StreamResolvers<ContextType = PortalContext, ParentType extends Reso
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3658,7 +3658,7 @@ export type TaxiiFeedResolvers<ContextType = PortalContext, ParentType extends R
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3696,7 +3696,7 @@ export type ThirdPartyIntegrationResolvers<ContextType = PortalContext, ParentTy
   product_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   remover_id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   service_instance?: Resolver<Maybe<ResolversTypes['ServiceInstance']>, ParentType, ContextType>;
-  service_instance_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  service_instance_id?: Resolver<ResolversTypes['ServiceInstanceId'], ParentType, ContextType>;
   share_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   short_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1,3 +1,4 @@
+import type { CompetitorId } from '../model/kanel/public/Competitor.js';
 import type { OrganizationId } from '../model/kanel/public/Organization.js';
 import type { ServiceInstanceId } from '../model/kanel/public/ServiceInstance.js';
 import type { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
@@ -18,6 +19,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  CompetitorId: { input: CompetitorId; output: CompetitorId; }
   Date: { input: any; output: any; }
   JSON: { input: any; output: any; }
   OrganizationId: { input: OrganizationId; output: OrganizationId; }
@@ -959,7 +961,7 @@ export type MutationCreateEpicArgs = {
 
 
 export type MutationDeleteCompetitorArgs = {
-  id: Scalars['ID']['input'];
+  id: Scalars['CompetitorId']['input'];
 };
 
 
@@ -2127,7 +2129,7 @@ export type UnregisterPlatformInput = {
 
 export type UpdateCompetitorInput = {
   domain?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['ID']['input'];
+  id: Scalars['CompetitorId']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
   tier?: InputMaybe<CompetitorTier>;
 };
@@ -2425,6 +2427,7 @@ export type ResolversTypes = ResolversObject<{
   Competitor: ResolverTypeWrapper<Competitor>;
   CompetitorConnection: ResolverTypeWrapper<CompetitorConnection>;
   CompetitorEdge: ResolverTypeWrapper<CompetitorEdge>;
+  CompetitorId: ResolverTypeWrapper<Scalars['CompetitorId']['output']>;
   CompetitorOrdering: CompetitorOrdering;
   CompetitorTier: CompetitorTier;
   Connector: ResolverTypeWrapper<Connector>;
@@ -2614,6 +2617,7 @@ export type ResolversParentTypes = ResolversObject<{
   Competitor: Competitor;
   CompetitorConnection: CompetitorConnection;
   CompetitorEdge: CompetitorEdge;
+  CompetitorId: Scalars['CompetitorId']['output'];
   Connector: Connector;
   CreateCompetitorInput: CreateCompetitorInput;
   CreateDeploymentRequestInput: CreateDeploymentRequestInput;
@@ -2797,6 +2801,10 @@ export type CompetitorEdgeResolvers<ContextType = PortalContext, ParentType exte
   node?: Resolver<ResolversTypes['Competitor'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface CompetitorIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['CompetitorId'], any> {
+  name: 'CompetitorId';
+}
 
 export type ConnectorResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['Connector'] = ResolversParentTypes['Connector']> = ResolversObject<{
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -3833,6 +3841,7 @@ export type Resolvers<ContextType = PortalContext> = ResolversObject<{
   Competitor?: CompetitorResolvers<ContextType>;
   CompetitorConnection?: CompetitorConnectionResolvers<ContextType>;
   CompetitorEdge?: CompetitorEdgeResolvers<ContextType>;
+  CompetitorId?: GraphQLScalarType;
   Connector?: ConnectorResolvers<ContextType>;
   CsvFeed?: CsvFeedResolvers<ContextType>;
   CustomDashboard?: CustomDashboardResolvers<ContextType>;

--- a/apps/portal-api/src/modules/common/user-organization.domain.ts
+++ b/apps/portal-api/src/modules/common/user-organization.domain.ts
@@ -14,7 +14,7 @@ import UserOrganization, {
 } from '../../model/kanel/public/UserOrganization';
 import { securityGuard } from '../../security/guard';
 import { sendMail } from '../../server/mail-service';
-import { extractId, isEmpty } from '../../utils/utils';
+import { isEmpty } from '../../utils/utils';
 import {
   createUserOrganizationCapability,
   updateUserOrganizationCapability,
@@ -44,7 +44,7 @@ export const updateMultipleUserOrgWithCapabilities = async (
     return;
   }
   for (const orgCapa of orgCapabilities) {
-    const organization_id = extractId<OrganizationId>(orgCapa.organization_id);
+    const organization_id = orgCapa.organization_id;
     if (organization_id !== userId.toString()) {
       const [newUserOrganization] = await insertNewUserOrganization({
         user_id: userId,

--- a/apps/portal-api/src/modules/deployment/competitor/competitor.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/competitor/competitor.app.test.ts
@@ -1,4 +1,3 @@
-import { toGlobalId } from 'graphql-relay';
 import { afterEach, describe, expect, it } from 'vitest';
 import { db } from '../../../../knexfile';
 import { TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
@@ -69,7 +68,7 @@ describe('CompetitorApp', () => {
       const { id } = await createCompetitor();
 
       const updatedCompetitor = await CompetitorApp.updateCompetitorById({
-        id: toGlobalId('Competitor', id!),
+        id,
         tier: CompetitorTier.Tier2,
         name: 'COMPETITOR',
         domain: 'Other.com',
@@ -92,7 +91,7 @@ describe('CompetitorApp', () => {
 
       await expect(
         CompetitorApp.updateCompetitorById({
-          id: toGlobalId('Competitor', second.id!),
+          id: second.id,
           domain: 'COMPETITOR.COM',
         })
       ).rejects.toThrow(ErrorCode.CompetitorDomainAlreadyExists);

--- a/apps/portal-api/src/modules/deployment/competitor/competitor.app.ts
+++ b/apps/portal-api/src/modules/deployment/competitor/competitor.app.ts
@@ -8,7 +8,7 @@ import { CompetitorId } from '../../../model/kanel/public/Competitor';
 import Organization from '../../../model/kanel/public/Organization';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { AlreadyExistsError } from '../../../utils/error/error.util';
-import { extractId, omit } from '../../../utils/utils';
+import { omit } from '../../../utils/utils';
 import { CompetitorDomain } from './competitor.domain';
 
 const throwIfUniqueViolation = (error: Error) => {
@@ -34,7 +34,7 @@ export const CompetitorApp = {
   async updateCompetitorById(data: UpdateCompetitorInput): Promise<Competitor> {
     try {
       return await CompetitorDomain.updateCompetitorBy(
-        { id: extractId<CompetitorId>(data.id) },
+        { id: data.id },
         { ...omit(data, ['id']) }
       );
     } catch (error) {

--- a/apps/portal-api/src/modules/deployment/competitor/competitor.graphql
+++ b/apps/portal-api/src/modules/deployment/competitor/competitor.graphql
@@ -1,3 +1,5 @@
+scalar CompetitorId
+
 enum CompetitorOrdering {
   name
   tier
@@ -35,7 +37,7 @@ input CreateCompetitorInput {
 }
 
 input UpdateCompetitorInput {
-  id: ID!
+  id: CompetitorId!
   name: String
   tier: CompetitorTier
   domain: String
@@ -55,5 +57,6 @@ extend type Mutation {
     @auth(portalCapa: MODIFY_COMPETITORS)
   updateCompetitor(input: UpdateCompetitorInput!): Competitor!
     @auth(portalCapa: MODIFY_COMPETITORS)
-  deleteCompetitor(id: ID!): Competitor! @auth(portalCapa: MODIFY_COMPETITORS)
+  deleteCompetitor(id: CompetitorId!): Competitor!
+    @auth(portalCapa: MODIFY_COMPETITORS)
 }

--- a/apps/portal-api/src/modules/deployment/competitor/competitor.resolver.ts
+++ b/apps/portal-api/src/modules/deployment/competitor/competitor.resolver.ts
@@ -6,10 +6,12 @@ import {
 
 import { CompetitorId } from '../../../model/kanel/public/Competitor';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
+import { createRelayIdScalar } from '../../../utils/scalar.util';
 import { CompetitorApp } from './competitor.app';
 import { CompetitorDomain } from './competitor.domain';
 
 const resolvers: Resolvers = {
+  CompetitorId: createRelayIdScalar<CompetitorId>('Competitor'),
   Query: {
     competitors: async (_, args: QueryCompetitorsArgs) => {
       try {
@@ -38,7 +40,7 @@ const resolvers: Resolvers = {
 
     deleteCompetitor: async (_, { id }) => {
       try {
-        return await CompetitorApp.deleteCompetitorById(id as CompetitorId);
+        return await CompetitorApp.deleteCompetitorById(id);
       } catch (error) {
         throw mapToGraphQLError(error);
       }

--- a/apps/portal-api/src/modules/deployment/deployment.app.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.app.ts
@@ -244,7 +244,7 @@ export const DeploymentApp = {
   updateDeploymentRequest: async (
     input: UpdateDeploymentRequestInput
   ): Promise<PlatformDeploymentRequest> => {
-    const deploymentRequestId = input.id as DeploymentRequestId;
+    const deploymentRequestId = input.id;
     const deploymentRequest =
       await loadDeploymentRequestForUpdate(deploymentRequestId);
     await checkStatusAndDataValidity(deploymentRequest, input);

--- a/apps/portal-api/src/modules/deployment/deployment.graphql
+++ b/apps/portal-api/src/modules/deployment/deployment.graphql
@@ -1,3 +1,5 @@
+scalar DeploymentRequestId
+
 enum DeploymentRequestPlatformRegion {
   eu_west
   us_east
@@ -167,7 +169,7 @@ input CreateDeploymentRequestInput {
 }
 
 input UpdateDeploymentRequestInput {
-  id: ID!
+  id: DeploymentRequestId!
   start_date: Date
   end_date: Date
   platform_id: String
@@ -249,7 +251,7 @@ enum ReorderDeploymentRequestInQueueDirection {
 }
 
 input ReorderDeploymentRequestInQueueInput {
-  id: ID!
+  id: DeploymentRequestId!
   direction: ReorderDeploymentRequestInQueueDirection!
 }
 
@@ -301,12 +303,13 @@ extend type Mutation {
     input: ReorderDeploymentRequestInQueueInput!
   ): Success! @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
   cancelDeploymentRequest(
-    deploymentRequestId: ID!
+    deploymentRequestId: DeploymentRequestId!
     cancellationReason: String
   ): DeploymentRequest
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION])
-  adminCancelDeploymentRequest(deploymentRequestId: ID): DeploymentRequest
-    @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
+  adminCancelDeploymentRequest(
+    deploymentRequestId: DeploymentRequestId
+  ): DeploymentRequest @auth(portalCapa: [BYPASS, MODIFY_TRIALS])
   updateDeploymentQuotaCapacity(
     input: UpdateDeploymentQuotaCapacityInput!
   ): Success! @auth(portalCapa: [BYPASS, MODIFY_TRIALS_QUOTA])

--- a/apps/portal-api/src/modules/deployment/deployment.resolver.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.resolver.ts
@@ -8,11 +8,13 @@ import {
 import { DeploymentRequestId } from '../../model/kanel/public/DeploymentRequest';
 import { UnknownErrorCode } from '../../utils/error/error.code';
 import { mapToGraphQLError } from '../../utils/error/error.mapping';
-import { extractId } from '../../utils/utils';
+import { createRelayIdScalar } from '../../utils/scalar.util';
 import { DeploymentApp } from './deployment.app';
 import { DeploymentRequestDomain } from './deployment.domain';
 
 const resolvers: Resolvers = {
+  DeploymentRequestId:
+    createRelayIdScalar<DeploymentRequestId>('DeploymentRequest'),
   Query: {
     deploymentRequests: async (_, args: QueryDeploymentRequestsArgs) => {
       try {
@@ -93,7 +95,7 @@ const resolvers: Resolvers = {
     ) => {
       try {
         return await DeploymentApp.cancelDeploymentRequest(
-          extractId<DeploymentRequestId>(deploymentRequestId),
+          deploymentRequestId,
           false,
           cancellationReason
         );
@@ -107,7 +109,7 @@ const resolvers: Resolvers = {
     adminCancelDeploymentRequest: async (_, { deploymentRequestId }) => {
       try {
         return await DeploymentApp.cancelDeploymentRequest(
-          extractId<DeploymentRequestId>(deploymentRequestId),
+          deploymentRequestId,
           true
         );
       } catch (error) {
@@ -122,7 +124,7 @@ const resolvers: Resolvers = {
       try {
         return await DeploymentApp.reorderDeploymentRequestInQueue({
           ...input,
-          id: extractId<DeploymentRequestId>(input.id),
+          id: input.id,
         });
       } catch (error) {
         throw mapToGraphQLError(error);

--- a/apps/portal-api/src/modules/deployment/group/service-group.graphql
+++ b/apps/portal-api/src/modules/deployment/group/service-group.graphql
@@ -14,7 +14,7 @@ input UpdateServiceGroupsInput {
 }
 
 type Query {
-  serviceGroups(serviceInstanceId: ID!): [ServiceGroup!]!
+  serviceGroups(serviceInstanceId: ServiceInstanceId!): [ServiceGroup!]!
     @auth(
       portalCapa: [BYPASS]
       orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_PLATFORM_REGISTRATION]

--- a/apps/portal-api/src/modules/deployment/group/service-group.graphql
+++ b/apps/portal-api/src/modules/deployment/group/service-group.graphql
@@ -1,3 +1,5 @@
+scalar ServiceGroupId
+
 type ServiceGroup implements Node {
   id: ID!
   name: String!
@@ -5,7 +7,7 @@ type ServiceGroup implements Node {
 }
 
 input UpdateServiceGroupsInputGroup {
-  id: ID!
+  id: ServiceGroupId!
   userIds: [ID!]!
 }
 

--- a/apps/portal-api/src/modules/deployment/group/service-group.resolver.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.resolver.ts
@@ -2,10 +2,12 @@ import { Resolvers } from '../../../__generated__/resolvers-types';
 import { ServiceGroupId } from '../../../model/kanel/public/ServiceGroup';
 import { UserId } from '../../../model/kanel/public/User';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
+import { createRelayIdScalar } from '../../../utils/scalar.util';
 import { extractId } from '../../../utils/utils';
 import { ServiceGroupApp } from './service-group.app';
 
 const resolvers: Resolvers = {
+  ServiceGroupId: createRelayIdScalar<ServiceGroupId>('ServiceGroup'),
   ServiceGroup: {
     users: ({ id }) => ServiceGroupApp.loadGroupUsers(id as ServiceGroupId),
   },
@@ -25,7 +27,7 @@ const resolvers: Resolvers = {
       try {
         const parsedInput = input.groups.map((group) => {
           return {
-            id: extractId<ServiceGroupId>(group.id),
+            id: group.id,
             userIds: group.userIds.map((userId) => extractId<UserId>(userId)),
           };
         });

--- a/apps/portal-api/src/modules/deployment/group/service-group.resolver.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.resolver.ts
@@ -1,6 +1,5 @@
 import { Resolvers } from '../../../__generated__/resolvers-types';
 import { ServiceGroupId } from '../../../model/kanel/public/ServiceGroup';
-import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { UserId } from '../../../model/kanel/public/User';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
 import { extractId } from '../../../utils/utils';
@@ -13,9 +12,8 @@ const resolvers: Resolvers = {
   Query: {
     serviceGroups: async (_, { serviceInstanceId }) => {
       try {
-        const id = extractId<ServiceInstanceId>(serviceInstanceId);
         return await ServiceGroupApp.loadGroups({
-          serviceInstanceId: id,
+          serviceInstanceId,
         });
       } catch (error) {
         throw mapToGraphQLError(error);

--- a/apps/portal-api/src/modules/document/document.app.ts
+++ b/apps/portal-api/src/modules/document/document.app.ts
@@ -14,7 +14,6 @@ import Document, {
   default as DocumentModel,
 } from '../../model/kanel/public/Document';
 import { ObjectUseCaseObjectId } from '../../model/kanel/public/ObjectUseCase';
-import { OrganizationId } from '../../model/kanel/public/Organization';
 import ServiceDefinition from '../../model/kanel/public/ServiceDefinition';
 import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { UseCaseId } from '../../model/kanel/public/UseCase';
@@ -246,9 +245,7 @@ export const DocumentApp = {
 
     return withTransaction(async () => {
       const { user } = requestContext.require();
-      const uploader_organization_id = input.uploader_organization_id
-        ? extractId<OrganizationId>(input.uploader_organization_id)
-        : null;
+      const uploader_organization_id = input.uploader_organization_id ?? null;
 
       const extractedUploaderId = extractId<UserId>(input.uploader_id ?? '');
       const uploader_id =

--- a/apps/portal-api/src/modules/document/document.app.ts
+++ b/apps/portal-api/src/modules/document/document.app.ts
@@ -438,7 +438,7 @@ export const DocumentApp = {
   loadDocuments: async (input: QueryDocumentsArgs) => {
     const serviceDefinition =
       await ServiceDefinitionDomain.loadServiceDefinitionByServiceInstance(
-        extractId<ServiceInstanceId>(input.serviceInstanceId)
+        input.serviceInstanceId
       );
     if (!serviceDefinition) {
       throw new Error(ErrorCode.ServiceDefinitionNotFound);
@@ -496,7 +496,7 @@ export const DocumentApp = {
   loadPublicDocuments: async (input: QueryPublicDocumentsArgs) => {
     const serviceDefinition =
       await ServiceDefinitionDomain.loadServiceDefinitionByServiceInstance(
-        extractId<ServiceInstanceId>(input.serviceInstanceId)
+        input.serviceInstanceId
       );
     if (!serviceDefinition) {
       throw new Error(ErrorCode.ServiceDefinitionNotFound);

--- a/apps/portal-api/src/modules/document/document.graphql
+++ b/apps/portal-api/src/modules/document/document.graphql
@@ -70,7 +70,7 @@ type DefaultDocument implements Node & Document {
   share_number: Int
   slug: String
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -94,7 +94,7 @@ interface Document implements Node {
   share_number: Int
   slug: String
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -141,7 +141,7 @@ type Mutation {
   createDocument(
     input: CreateDocumentInput!
     metadata: [DocumentMetadata!]!
-    serviceInstanceId: String
+    serviceInstanceId: ServiceInstanceId
     sourceDocument: Upload
     logo: Upload
     images: [Upload!]
@@ -150,7 +150,7 @@ type Mutation {
     documentId: ID!
     input: UpdateDocumentInput!
     metadata: [DocumentMetadata!]!
-    serviceInstanceId: String
+    serviceInstanceId: ServiceInstanceId
     sourceDocument: Upload
     logo: Upload
     images: [Upload!]
@@ -158,16 +158,17 @@ type Mutation {
   ): Document! @auth @service_capa(requires: [UPLOAD])
   deleteDocument(
     documentId: ID
-    service_instance_id: String
+    service_instance_id: ServiceInstanceId
     forceDelete: Boolean
   ): Document! @auth @service_capa(requires: [DELETE])
   incrementShareNumberDocument(documentId: ID): Document!
 }
 
 type Query {
-  documentExists(documentName: String, service_instance_id: String): Boolean
-    @auth
-    @service_capa(requires: [UPLOAD])
+  documentExists(
+    documentName: String
+    service_instance_id: ServiceInstanceId
+  ): Boolean @auth @service_capa(requires: [UPLOAD])
   publicDocuments(
     slug: String!
     first: Int!
@@ -176,10 +177,13 @@ type Query {
     orderMode: OrderingMode!
     searchTerm: String
     logicalFilters: LogicalFilterInput
-    serviceInstanceId: ID!
+    serviceInstanceId: ServiceInstanceId!
   ): DocumentConnection!
   publicDocumentsByServiceSlug(serviceInstanceSlug: String!): [Document!]!
-  publicDocumentBySlug(serviceInstanceId: ID!, slug: String!): Document
+  publicDocumentBySlug(
+    serviceInstanceId: ServiceInstanceId!
+    slug: String!
+  ): Document
   documents(
     first: Int!
     after: ID
@@ -187,8 +191,8 @@ type Query {
     orderMode: OrderingMode!
     searchTerm: String
     logicalFilters: LogicalFilterInput
-    serviceInstanceId: String
+    serviceInstanceId: ServiceInstanceId
     parentsOnly: Boolean
   ): DocumentConnection! @auth
-  document(documentId: ID, serviceInstanceId: ID): Document @auth
+  document(documentId: ID, serviceInstanceId: ServiceInstanceId): Document @auth
 }

--- a/apps/portal-api/src/modules/document/document.graphql
+++ b/apps/portal-api/src/modules/document/document.graphql
@@ -122,7 +122,7 @@ input UpdateDocumentInput {
   description: String
   active: Boolean
   use_cases: [String!]
-  uploader_organization_id: String
+  uploader_organization_id: OrganizationId
   uploader_id: String
 }
 

--- a/apps/portal-api/src/modules/document/document.resolver.ts
+++ b/apps/portal-api/src/modules/document/document.resolver.ts
@@ -1,4 +1,3 @@
-import { fromGlobalId } from 'graphql-relay/node/node.js';
 import {
   IntegrationType,
   Resolvers,
@@ -6,7 +5,6 @@ import {
   SubscriptionModel,
 } from '../../__generated__/resolvers-types';
 import Document, { DocumentId } from '../../model/kanel/public/Document';
-import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { logApp } from '../../utils/app-logger.util';
 import { ErrorCode, UnknownErrorCode } from '../../utils/error/error.code';
 import { mapToGraphQLError } from '../../utils/error/error.mapping';
@@ -42,9 +40,7 @@ const resolvers: Resolvers = {
       try {
         return await DocumentApp.createDocument({
           ...input,
-          serviceInstanceId: extractId<ServiceInstanceId>(
-            input.serviceInstanceId
-          ),
+          serviceInstanceId: input.serviceInstanceId,
         });
       } catch (error) {
         if (error.message?.includes('document_type_slug_unique')) {
@@ -60,9 +56,7 @@ const resolvers: Resolvers = {
         return await DocumentApp.updateDocument({
           ...input,
           parentDocumentId: extractId<DocumentId>(input.documentId),
-          serviceInstanceId: extractId<ServiceInstanceId>(
-            input.serviceInstanceId
-          ),
+          serviceInstanceId: input.serviceInstanceId,
           existingImageIds: (input.existingImageIds ?? []).map((imageId) =>
             extractId<DocumentId>(imageId)
           ),
@@ -83,7 +77,7 @@ const resolvers: Resolvers = {
       try {
         return await DocumentApp.deleteDocument(
           extractId<DocumentId>(documentId),
-          extractId<ServiceInstanceId>(service_instance_id),
+          service_instance_id,
           forceDelete
         );
       } catch (error) {
@@ -172,11 +166,11 @@ const resolvers: Resolvers = {
     uploader_organization: ({ id }, _) =>
       DocumentDomain.loadUploaderOrganization(id),
     service_instance: ({ service_instance_id }, _) => {
-      return getServiceInstance(service_instance_id as ServiceInstanceId);
+      return getServiceInstance(service_instance_id);
     },
     subscription: async ({ service_instance_id }, _, context) => {
       const subscription = await loadSubscriptionBy({
-        service_instance_id: service_instance_id as ServiceInstanceId,
+        service_instance_id,
         organization_id: context.user.selected_organization_id,
       });
 
@@ -188,7 +182,7 @@ const resolvers: Resolvers = {
       try {
         return checkDocumentExists(
           input.documentName ?? '',
-          fromGlobalId(input.service_instance_id).id as ServiceInstanceId
+          input.service_instance_id
         );
       } catch (error) {
         throw mapToGraphQLError(error);
@@ -212,10 +206,7 @@ const resolvers: Resolvers = {
     },
     publicDocumentBySlug: async (_, { serviceInstanceId, slug }) => {
       try {
-        return DocumentApp.loadPublicDocumentBySlug(
-          extractId<ServiceInstanceId>(serviceInstanceId),
-          slug
-        );
+        return DocumentApp.loadPublicDocumentBySlug(serviceInstanceId, slug);
       } catch (error) {
         throw mapToGraphQLError(error);
       }

--- a/apps/portal-api/src/modules/document/document.test.ts
+++ b/apps/portal-api/src/modules/document/document.test.ts
@@ -204,10 +204,7 @@ describe('Documents loading', () => {
         searchTerm: '',
         orderBy: 'file_name',
         orderMode: 'asc',
-        serviceInstanceId: toGlobalId(
-          'ServiceInstance',
-          SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID
-        ),
+        serviceInstanceId: SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID,
       },
       contextSimpleUserSecondOrga as PortalContext
     );
@@ -224,10 +221,7 @@ describe('Documents loading', () => {
         searchTerm: '',
         orderBy: 'file_name',
         orderMode: 'desc',
-        serviceInstanceId: toGlobalId(
-          'ServiceInstance',
-          SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID
-        ),
+        serviceInstanceId: SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID,
       },
       contextSimpleUserSecondOrga
     );
@@ -245,10 +239,7 @@ describe('Documents loading', () => {
         searchTerm: 'xfi',
         orderBy: 'file_name',
         orderMode: 'asc',
-        serviceInstanceId: toGlobalId(
-          'ServiceInstance',
-          SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID
-        ),
+        serviceInstanceId: SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID,
       },
       contextSimpleUserSecondOrga
     );

--- a/apps/portal-api/src/modules/document/domain/document.domain.test.ts
+++ b/apps/portal-api/src/modules/document/domain/document.domain.test.ts
@@ -97,10 +97,7 @@ describe('Document domain', () => {
             orderBy: DocumentOrdering.CreatedAt,
             orderMode: OrderingMode.Desc,
             first: 10,
-            serviceInstanceId: toGlobalId(
-              'ServiceInstance',
-              INTEGRATION_SERVICE_INSTANCE_ID
-            ),
+            serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
           },
           INTEGRATION_METADATA_KEYS
         );
@@ -138,10 +135,7 @@ describe('Document domain', () => {
             orderBy: DocumentOrdering.CreatedAt,
             orderMode: OrderingMode.Desc,
             first: 10,
-            serviceInstanceId: toGlobalId(
-              'ServiceInstance',
-              INTEGRATION_SERVICE_INSTANCE_ID
-            ),
+            serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
             logicalFilters: {
               operator: LogicalOperator.And,
               children: [
@@ -171,10 +165,7 @@ describe('Document domain', () => {
             orderBy: DocumentOrdering.CreatedAt,
             orderMode: OrderingMode.Desc,
             first: 10,
-            serviceInstanceId: toGlobalId(
-              'ServiceInstance',
-              INTEGRATION_SERVICE_INSTANCE_ID
-            ),
+            serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
             logicalFilters: {
               operator: LogicalOperator.And,
               children: [
@@ -204,10 +195,7 @@ describe('Document domain', () => {
             orderBy: DocumentOrdering.CreatedAt,
             orderMode: OrderingMode.Desc,
             first: 10,
-            serviceInstanceId: toGlobalId(
-              'ServiceInstance',
-              INTEGRATION_SERVICE_INSTANCE_ID
-            ),
+            serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
             logicalFilters: {
               operator: LogicalOperator.And,
               children: [
@@ -242,10 +230,7 @@ describe('Document domain', () => {
               orderBy: DocumentOrdering.CreatedAt,
               orderMode: OrderingMode.Desc,
               first: 10,
-              serviceInstanceId: toGlobalId(
-                'ServiceInstance',
-                INTEGRATION_SERVICE_INSTANCE_ID
-              ),
+              serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
               logicalFilters: {
                 operator: LogicalOperator.And,
                 children: [
@@ -289,10 +274,7 @@ describe('Document domain', () => {
               orderBy: DocumentOrdering.CreatedAt,
               orderMode: OrderingMode.Desc,
               first: 10,
-              serviceInstanceId: toGlobalId(
-                'ServiceInstance',
-                INTEGRATION_SERVICE_INSTANCE_ID
-              ),
+              serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
               logicalFilters: {
                 operator: LogicalOperator.Or,
                 children: [
@@ -362,10 +344,7 @@ describe('Document domain', () => {
               orderBy: DocumentOrdering.CreatedAt,
               orderMode: OrderingMode.Desc,
               first: 10,
-              serviceInstanceId: toGlobalId(
-                'ServiceInstance',
-                INTEGRATION_SERVICE_INSTANCE_ID
-              ),
+              serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
               logicalFilters: {
                 operator: LogicalOperator.And,
                 children: [
@@ -403,10 +382,7 @@ describe('Document domain', () => {
               orderBy: DocumentOrdering.CreatedAt,
               orderMode: OrderingMode.Desc,
               first: 10,
-              serviceInstanceId: toGlobalId(
-                'ServiceInstance',
-                INTEGRATION_SERVICE_INSTANCE_ID
-              ),
+              serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
               logicalFilters: {
                 operator: LogicalOperator.And,
                 children: [

--- a/apps/portal-api/src/modules/document/domain/document.domain.ts
+++ b/apps/portal-api/src/modules/document/domain/document.domain.ts
@@ -146,9 +146,7 @@ export const DocumentDomain = {
         searchTerm: input.searchTerm,
       },
       {
-        'Document.service_instance_id': extractId<ServiceInstanceId>(
-          input.serviceInstanceId
-        ),
+        'Document.service_instance_id': input.serviceInstanceId,
         'Document.type': type,
       },
       include_metadata

--- a/apps/portal-api/src/modules/document/openaev/scenarios/scenarios.graphql
+++ b/apps/portal-api/src/modules/document/openaev/scenarios/scenarios.graphql
@@ -16,7 +16,7 @@ type OpenAEVScenario implements Document & Node {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]

--- a/apps/portal-api/src/modules/document/openaev/scenarios/scenarios.resolver.ts
+++ b/apps/portal-api/src/modules/document/openaev/scenarios/scenarios.resolver.ts
@@ -1,5 +1,4 @@
 import { Resolvers } from '../../../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../../../model/kanel/public/ServiceInstance';
 import { getServiceInstance } from '../../../services/service-instance.domain';
 import { subscriptionApp } from '../../../subcription/subscription.app';
 import { useCaseDomain } from '../../../use-case/use-case.domain';
@@ -15,7 +14,7 @@ const resolvers: Resolvers = {
     uploader_organization: ({ id }, _) =>
       DocumentDomain.loadUploaderOrganization(id),
     service_instance: ({ service_instance_id }, _) =>
-      getServiceInstance(service_instance_id as ServiceInstanceId),
+      getServiceInstance(service_instance_id),
     subscription: ({ service_instance_id }, _, context) =>
       subscriptionApp.loadSubscriptionModel(context.user, service_instance_id),
   },

--- a/apps/portal-api/src/modules/document/opencti/custom-dashboards/custom-dashboards.graphql
+++ b/apps/portal-api/src/modules/document/opencti/custom-dashboards/custom-dashboards.graphql
@@ -16,7 +16,7 @@ type CustomDashboard implements Document & Node {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]

--- a/apps/portal-api/src/modules/document/opencti/custom-dashboards/custom-dashboards.resolver.ts
+++ b/apps/portal-api/src/modules/document/opencti/custom-dashboards/custom-dashboards.resolver.ts
@@ -1,5 +1,4 @@
 import { Resolvers } from '../../../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../../../model/kanel/public/ServiceInstance';
 import { getServiceInstance } from '../../../services/service-instance.domain';
 import { subscriptionApp } from '../../../subcription/subscription.app';
 import { useCaseDomain } from '../../../use-case/use-case.domain';
@@ -15,7 +14,7 @@ const resolvers: Resolvers = {
     uploader_organization: ({ id }, _) =>
       DocumentDomain.loadUploaderOrganization(id),
     service_instance: ({ service_instance_id }, _) =>
-      getServiceInstance(service_instance_id as ServiceInstanceId),
+      getServiceInstance(service_instance_id),
     subscription: async ({ service_instance_id }, _, context) =>
       subscriptionApp.loadSubscriptionModel(context.user, service_instance_id),
   },

--- a/apps/portal-api/src/modules/document/opencti/integrations/integrations.graphql
+++ b/apps/portal-api/src/modules/document/opencti/integrations/integrations.graphql
@@ -52,7 +52,7 @@ interface Integration implements Node & Document {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -86,7 +86,7 @@ type IntegrationHack implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -119,7 +119,7 @@ type CsvFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -153,7 +153,7 @@ type Connector implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -195,7 +195,7 @@ type TaxiiFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -229,7 +229,7 @@ type RssFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -264,7 +264,7 @@ type Stream implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]
@@ -299,7 +299,7 @@ type ThirdPartyIntegration implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String! @auth
+  service_instance_id: ServiceInstanceId! @auth
   service_instance: ServiceInstance @auth
   subscription: SubscriptionModel @auth
   children_documents: [ShareableResource!]

--- a/apps/portal-api/src/modules/document/opencti/integrations/integrations.resolver.ts
+++ b/apps/portal-api/src/modules/document/opencti/integrations/integrations.resolver.ts
@@ -2,7 +2,6 @@ import {
   IntegrationType,
   Resolvers,
 } from '../../../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../../../model/kanel/public/ServiceInstance';
 import { logApp } from '../../../../utils/app-logger.util';
 import { getServiceInstance } from '../../../services/service-instance.domain';
 import { subscriptionApp } from '../../../subcription/subscription.app';
@@ -39,7 +38,7 @@ const resolvers: Resolvers = {
     uploader_organization: ({ id }, _) =>
       DocumentDomain.loadUploaderOrganization(id),
     service_instance: ({ service_instance_id }, _) =>
-      getServiceInstance(service_instance_id as ServiceInstanceId),
+      getServiceInstance(service_instance_id),
     subscription: ({ service_instance_id }, _, context) =>
       subscriptionApp.loadSubscriptionModel(context.user, service_instance_id),
   },

--- a/apps/portal-api/src/modules/organization-management/users/user-admin/users.admin.app.ts
+++ b/apps/portal-api/src/modules/organization-management/users/user-admin/users.admin.app.ts
@@ -17,7 +17,6 @@ import { updateUserSession } from '../../../../session-store-manager';
 import { auth0Client } from '../../../../thirdparty/auth0/client';
 import { logApp } from '../../../../utils/app-logger.util';
 import { ErrorCode } from '../../../../utils/error/error.code';
-import { extractId } from '../../../../utils/utils';
 import {
   loadUserOrganization,
   updateMultipleUserOrgWithCapabilities,
@@ -48,9 +47,7 @@ export const usersAdminApp = {
     // In most of the case there will be only one organization in the list, but in case where the scenario is an admin pltfm it can be multiple or none
     const chosenOrganizationId: OrganizationId | undefined = input
       .organization_capabilities?.[0]
-      ? extractId<OrganizationId>(
-          input.organization_capabilities?.[0].organization_id
-        )
+      ? input.organization_capabilities?.[0].organization_id
       : undefined;
 
     // The admin orga should only allow to add users in the same organization and with the same domain.
@@ -102,9 +99,7 @@ export const usersAdminApp = {
     const { organization_capabilities, ...userInput } = input;
     const mappedCapabilities = (organization_capabilities ?? []).map(
       (orgCapability) => ({
-        organizationId: extractId<OrganizationId>(
-          orgCapability.organization_id
-        ),
+        organizationId: orgCapability.organization_id,
         capabilities: orgCapability.capabilities,
       })
     );

--- a/apps/portal-api/src/modules/organization-management/users/users.graphql
+++ b/apps/portal-api/src/modules/organization-management/users/users.graphql
@@ -26,14 +26,14 @@ type User implements Node {
   picture: String
   country: String
   disabled: Boolean
-  selected_organization_id: String
+  selected_organization_id: OrganizationId
   organizations: [Organization!]
   organization_capabilities: [OrganizationCapabilities!]
   capabilities: [Capability!]
   roles_portal: [RolePortal!]
   selected_org_capabilities: [OrganizationCapability!]
   last_login: Date
-  pending_organization_id: ID
+  pending_organization_id: OrganizationId
 }
 
 type UserEdge {
@@ -48,7 +48,7 @@ type UserConnection {
 }
 
 input UsersWithCapabilitiesInOrganizationInput {
-  organizationId: ID!
+  organizationId: OrganizationId!
   capabilities: [OrganizationCapability!]!
 }
 
@@ -95,7 +95,7 @@ input EditMeUserInput {
 }
 
 input OrganizationCapabilitiesInput {
-  organization_id: ID!
+  organization_id: OrganizationId!
   capabilities: [String!]
 }
 
@@ -130,17 +130,21 @@ type Mutation {
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
   editUserCapabilities(id: ID!, input: EditUserCapabilitiesInput!): User!
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
-  changeSelectedOrganization(organization_id: ID!): User @auth
+  changeSelectedOrganization(organization_id: OrganizationId!): User @auth
   bulkRemovePendingUserFromOrganization(
     input: BulkPendingUserFromOrganizationInput
   ): Success @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
   bulkAcceptPendingUserInOrganization(
     input: BulkPendingUserFromOrganizationInput
   ): Success @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
-  removePendingUserFromOrganization(user_id: ID!, organization_id: ID!): User
-    @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
-  removeUserFromOrganization(user_id: ID!, organization_id: ID!): User
-    @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
+  removePendingUserFromOrganization(
+    user_id: ID!
+    organization_id: OrganizationId!
+  ): User @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
+  removeUserFromOrganization(
+    user_id: ID!
+    organization_id: OrganizationId!
+  ): User @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_ACCESS])
 
   # Profile
   editMeUser(input: EditMeUserInput!): User! @auth

--- a/apps/portal-api/src/modules/organization-management/users/users.helper.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.helper.ts
@@ -1,4 +1,3 @@
-import { toGlobalId } from 'graphql-relay/node/node.js';
 import { GraphQLError } from 'graphql/error/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../../../../knexfile';
@@ -280,10 +279,7 @@ export const mapUserToGraphqlUser = (
 ): GraphqlUser => {
   return {
     ...user,
-    selected_organization_id: toGlobalId(
-      'Organization',
-      user.selected_organization_id
-    ),
+    selected_organization_id: user.selected_organization_id,
     capabilities:
       'capabilities' in user ? (user.capabilities as Capability[]) : null,
   };

--- a/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
@@ -370,10 +370,7 @@ describe('User mutation resolver', () => {
             password: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.PASSWORD,
             organization_capabilities: [
               {
-                organization_id: toGlobalId(
-                  'Organization',
-                  TEST_ORGANIZATIONS.FILIGRAN.ID
-                ),
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
                 capabilities: [],
               },
             ],
@@ -446,10 +443,7 @@ describe('User mutation resolver', () => {
               password: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.PASSWORD,
               organization_capabilities: [
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.FILIGRAN.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
                   capabilities: [],
                 },
               ],
@@ -528,10 +522,7 @@ describe('User mutation resolver', () => {
               password: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.PASSWORD,
               organization_capabilities: [
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
                   capabilities: [],
                 },
               ],
@@ -588,30 +579,21 @@ describe('User mutation resolver', () => {
             input: {
               organization_capabilities: [
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
                   capabilities: [
                     OrganizationCapability.ManageAccess,
                     OrganizationCapability.ManageSubscription,
                   ],
                 },
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.FILIGRAN.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
                   capabilities: [
                     OrganizationCapability.ManageAccess,
                     OrganizationCapability.ManageSubscription,
                   ],
                 },
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
                   capabilities: [],
                 },
               ],
@@ -632,20 +614,14 @@ describe('User mutation resolver', () => {
             input: {
               organization_capabilities: [
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
                   capabilities: [
                     OrganizationCapability.ManageAccess,
                     OrganizationCapability.ManageSubscription,
                   ],
                 },
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.FILIGRAN.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
                   capabilities: [
                     OrganizationCapability.ManageAccess,
                     OrganizationCapability.ManageSubscription,
@@ -684,10 +660,7 @@ describe('User mutation resolver', () => {
               organization_capabilities:
                 secondOrgaUser.organization_capabilities.map(
                   (organizationCapabilities) => ({
-                    organization_id: toGlobalId(
-                      'Organization',
-                      organizationCapabilities.organization.id
-                    ),
+                    organization_id: organizationCapabilities.organization.id,
                     capabilities: organizationCapabilities.capabilities,
                   })
                 ),
@@ -706,10 +679,7 @@ describe('User mutation resolver', () => {
             input: {
               organization_capabilities: [
                 {
-                  organization_id: toGlobalId(
-                    'Organization',
-                    TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
-                  ),
+                  organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
                   capabilities: [],
                 },
               ],
@@ -742,10 +712,7 @@ describe('User mutation resolver', () => {
             organization_capabilities:
               secondOrgaUser.organization_capabilities.map(
                 (organizationCapabilities) => ({
-                  organization_id: toGlobalId(
-                    'Organization',
-                    organizationCapabilities.organization.id
-                  ),
+                  organization_id: organizationCapabilities.organization.id,
                   capabilities: organizationCapabilities.capabilities,
                 })
               ),
@@ -1012,11 +979,7 @@ describe('User mutation resolver', () => {
       });
 
       const userId = toGlobalId('User', pendingUser.id);
-      const organizationId = toGlobalId(
-        'Organization',
-        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
-      );
-
+      const organizationId = TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID;
       // When
       await usersResolver.Mutation.removePendingUserFromOrganization(
         undefined,
@@ -1058,15 +1021,12 @@ describe('User mutation resolver', () => {
         roles: [],
       });
       const userId = toGlobalId('User', pendingUser.id);
-      const organizationId = toGlobalId(
-        'Organization',
-        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
-      );
+      const organizationId = TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID;
       const subscriptionSpy = new SubscriptionSpy();
       await subscriptionSpy.spy(
         usersResolver.Subscription?.UserPending,
         {
-          organizationId: organizationId,
+          organizationId: toGlobalId('Organization', organizationId),
         },
         contextAdminSecondOrga,
         ['delete']

--- a/apps/portal-api/src/modules/organization-management/users/users.resolver.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.resolver.ts
@@ -1,11 +1,9 @@
-import { fromGlobalId } from 'graphql-relay/node/node.js';
 import {
   Resolvers,
   User,
   UserPendingSubscription,
   UserSubscription,
 } from '../../../__generated__/resolvers-types';
-import { OrganizationId } from '../../../model/kanel/public/Organization';
 import { UserId } from '../../../model/kanel/public/User';
 import { dispatch, listen } from '../../../pub';
 import { hubspotReachOutSalesHook } from '../../../thirdparty/hubspot/hubspot';
@@ -50,7 +48,7 @@ const resolvers: Resolvers = {
 
     usersWithCapabilitiesInOrganization: async (_, { input }) => {
       return loadUsersByCapabilitiesInOrganization(
-        fromGlobalId(input.organizationId).id,
+        input.organizationId,
         input.capabilities
       );
     },
@@ -176,9 +174,10 @@ const resolvers: Resolvers = {
     },
     changeSelectedOrganization: async (_, { organization_id }) => {
       try {
-        const user = await UsersOrganizationApp.changeSelectedOrganization(
-          extractId<OrganizationId>(organization_id)
-        );
+        const user =
+          await UsersOrganizationApp.changeSelectedOrganization(
+            organization_id
+          );
 
         return mapUserToGraphqlUser(user);
       } catch (error) {
@@ -189,7 +188,7 @@ const resolvers: Resolvers = {
       try {
         const user = await UsersOrganizationApp.removeUserFromOrganization({
           userId: extractId<UserId>(user_id),
-          organizationId: extractId<OrganizationId>(organization_id),
+          organizationId: organization_id,
         });
         return mapUserToGraphqlUser(user);
       } catch (error) {
@@ -254,11 +253,10 @@ const resolvers: Resolvers = {
       { user_id, organization_id }
     ) => {
       try {
-        const organizationId = extractId<OrganizationId>(organization_id);
         const user =
           await UsersOrganizationApp.removePendingUserFromOrganization({
             userId: extractId<UserId>(user_id),
-            organizationId,
+            organizationId: organization_id,
           });
 
         const graphQLUser = mapUserToGraphqlUser(user);
@@ -267,7 +265,7 @@ const resolvers: Resolvers = {
           'delete',
           {
             ...graphQLUser,
-            pending_organization_id: organizationId,
+            pending_organization_id: organization_id,
           } as User,
           'User'
         );

--- a/apps/portal-api/src/modules/registration/registration.graphql
+++ b/apps/portal-api/src/modules/registration/registration.graphql
@@ -104,7 +104,7 @@ input RegisteredPlatformsInput {
 }
 
 input RegisteredPlatformInput {
-  service_instance_id: ID!
+  service_instance_id: ServiceInstanceId!
 }
 
 input AutoRegisterPlatformInput {

--- a/apps/portal-api/src/modules/registration/registration.resolver.ts
+++ b/apps/portal-api/src/modules/registration/registration.resolver.ts
@@ -12,7 +12,6 @@ import {
 } from '../../utils/error/error.code';
 import { mapToGraphQLError } from '../../utils/error/error.mapping';
 import { BadRequestError } from '../../utils/error/error.util';
-import { extractId } from '../../utils/utils';
 import { DeploymentRequestDomain } from '../deployment/deployment.domain';
 import { loadSubscriptionByServiceInstanceAndOrganization } from '../services/service-instance.domain';
 import { registrationApp } from './registration.app';
@@ -65,9 +64,7 @@ const resolvers: Resolvers = {
       }
     },
     registeredPlatform: async (_, { input }) =>
-      registrationApp.loadRegisteredPlatform(
-        extractId<ServiceInstanceId>(input.service_instance_id)
-      ),
+      registrationApp.loadRegisteredPlatform(input.service_instance_id),
     registeredPlatforms: async (_, { input }) =>
       registrationApp.loadRegisteredPlatforms(input),
     /**

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
@@ -1,4 +1,3 @@
-import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -22,7 +21,6 @@ describe('Query.registeredPlatform', () => {
   it('should decode the service_instance_id from global ID and pass the raw UUID to registrationApp', async () => {
     // Given
     const rawId = uuidv4() as ServiceInstanceId;
-    const globalId = toGlobalId('ServiceInstance', rawId);
     const expectedPlatform = { id: rawId, title: 'My Platform' };
     vi.spyOn(registrationApp, 'loadRegisteredPlatform').mockResolvedValue(
       expectedPlatform as unknown as RegisteredPlatform
@@ -31,7 +29,7 @@ describe('Query.registeredPlatform', () => {
     // When
     const result = await registrationResolver.Query!.registeredPlatform!(
       {},
-      { input: { service_instance_id: globalId } },
+      { input: { service_instance_id: rawId } },
       contextSimpleUserFiligran2,
       INFO
     );

--- a/apps/portal-api/src/modules/security-management/capability/auth.helper.ts
+++ b/apps/portal-api/src/modules/security-management/capability/auth.helper.ts
@@ -1,4 +1,3 @@
-import { fromGlobalId } from 'graphql-relay/node/node.js';
 import { db, dbRaw } from '../../../../knexfile';
 import { loadSubscriptionBy } from '../../subcription/subscription.helper';
 import { CAPABILITY_BYPASS } from '../../../portal.const';
@@ -94,10 +93,7 @@ export const getCapabilityUser = (
   args: ServiceCapabilityArgs
 ) =>
   args.service_instance_id
-    ? loadCapabilitiesByServiceId(
-        user,
-        fromGlobalId(args.service_instance_id).id
-      )
+    ? loadCapabilitiesByServiceId(user, args.service_instance_id)
     : loadSubscriptionBy({
         id: extractId(args.subscription_id),
       } as SubscriptionMutator).then(([subscription]) =>

--- a/apps/portal-api/src/modules/security-management/service-capability/service-capability.graphql
+++ b/apps/portal-api/src/modules/security-management/service-capability/service-capability.graphql
@@ -11,6 +11,6 @@ input EditServiceCapabilityInput {
 type Mutation {
   editServiceCapability(
     input: EditServiceCapabilityInput
-    serviceInstanceId: String
+    serviceInstanceId: ServiceInstanceId
   ): SubscriptionModel @auth
 }

--- a/apps/portal-api/src/modules/security-management/service-capability/service-capability.resolver.ts
+++ b/apps/portal-api/src/modules/security-management/service-capability/service-capability.resolver.ts
@@ -1,5 +1,4 @@
 import { Resolvers } from '../../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { UserServiceId } from '../../../model/kanel/public/UserService';
 import { UnknownErrorCode } from '../../../utils/error/error.code';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
@@ -15,7 +14,7 @@ const resolvers: Resolvers = {
         return serviceCapabilityApp.editServiceCapability(
           user_service_id,
           input.capabilities,
-          extractId<ServiceInstanceId>(serviceInstanceId)
+          serviceInstanceId
         );
       } catch (error) {
         throw mapToGraphQLError(error, UnknownErrorCode.EditCapabilitiesError);

--- a/apps/portal-api/src/modules/subcription/subscription.app.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.app.ts
@@ -41,10 +41,10 @@ import {
 export const subscriptionApp = {
   loadSubscriptionModel: async (
     user: UserLoadUserBy,
-    service_instance_id: string
+    service_instance_id: ServiceInstanceId
   ): Promise<SubscriptionModel> => {
     const subscription = await loadSubscriptionBy({
-      service_instance_id: service_instance_id as ServiceInstanceId,
+      service_instance_id: service_instance_id,
       organization_id: user.selected_organization_id,
     });
 

--- a/apps/portal-api/src/modules/subcription/subscription.app.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.app.ts
@@ -20,6 +20,7 @@ import { ServiceIdentifierToMailTemplate } from '../../server/mail-template/mail
 import { logApp } from '../../utils/app-logger.util';
 import { ErrorCode } from '../../utils/error/error.code';
 import { loadOrganizationBy } from '../organization-management/organizations/organizations.domain';
+import { addCapabilitiesToSubscription } from '../security-management/service-capability/subscription-capability.domain';
 import {
   loadServiceDefinitionByServiceInstance,
   loadServiceInstanceById,
@@ -30,7 +31,6 @@ import {
   buildSubscribeEvent,
   shouldSendEventForService,
 } from '../telemetry/telemetry.helper';
-import { addCapabilitiesToSubscription } from '../security-management/service-capability/subscription-capability.domain';
 import { UserServiceDomain } from '../user_service/user_service.domain';
 import {
   createSubscription,
@@ -44,7 +44,7 @@ export const subscriptionApp = {
     service_instance_id: ServiceInstanceId
   ): Promise<SubscriptionModel> => {
     const subscription = await loadSubscriptionBy({
-      service_instance_id: service_instance_id,
+      service_instance_id,
       organization_id: user.selected_organization_id,
     });
 

--- a/apps/portal-api/src/modules/subcription/subscription.graphql
+++ b/apps/portal-api/src/modules/subcription/subscription.graphql
@@ -28,10 +28,10 @@ type SubscriptionEdge {
 }
 
 type Mutation {
-  addSubscription(service_instance_id: String): ServiceInstance
+  addSubscription(service_instance_id: ServiceInstanceId): ServiceInstance
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_SUBSCRIPTION])
   addSubscriptionInService(
-    service_instance_id: String
+    service_instance_id: ServiceInstanceId
     organization_id: ID
     capability_ids: [ID]
     start_date: Date

--- a/apps/portal-api/src/modules/subcription/subscription.graphql
+++ b/apps/portal-api/src/modules/subcription/subscription.graphql
@@ -32,7 +32,7 @@ type Mutation {
     @auth(orgaCapa: [ADMINISTRATE_ORGANIZATION, MANAGE_SUBSCRIPTION])
   addSubscriptionInService(
     service_instance_id: ServiceInstanceId
-    organization_id: ID
+    organization_id: OrganizationId
     capability_ids: [ID]
     start_date: Date
     end_date: Date

--- a/apps/portal-api/src/modules/subcription/subscription.resolver.test.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.resolver.test.ts
@@ -1,4 +1,3 @@
-import { toGlobalId } from 'graphql-relay/node/node.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TestHelper } from '../../../tests/test.helper';
 import {
@@ -22,10 +21,7 @@ describe('Subscription mutation resolver', () => {
       const response = await subscriptionResolver.Mutation.addSubscription(
         undefined,
         {
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
         },
         contextSimpleUserSecondOrga
       );
@@ -47,10 +43,7 @@ describe('Subscription mutation resolver', () => {
       await subscriptionResolver.Mutation.addSubscription(
         undefined,
         {
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.INTEGRATIONS.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
         },
         contextSimpleUserSecondOrga
       );
@@ -72,10 +65,7 @@ describe('Subscription mutation resolver', () => {
       await subscriptionResolver.Mutation.addSubscription(
         undefined,
         {
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.VAULT.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.VAULT.ID,
         },
         contextSimpleUserSecondOrga
       );

--- a/apps/portal-api/src/modules/subcription/subscription.resolver.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.resolver.ts
@@ -2,7 +2,6 @@ import { Resolvers } from '../../__generated__/resolvers-types';
 
 import { OrganizationId } from '../../model/kanel/public/Organization';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
-import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import {
   SubscriptionId,
   SubscriptionMutator,
@@ -34,11 +33,9 @@ const resolvers: Resolvers = {
   },
   Mutation: {
     addSubscription: async (_, { service_instance_id }) => {
-      const serviceInstanceId =
-        extractId<ServiceInstanceId>(service_instance_id);
       try {
         return await subscriptionApp.subscribeSelectedOrganizationToService({
-          serviceInstanceId,
+          serviceInstanceId: service_instance_id,
         });
       } catch (error) {
         throw mapToGraphQLError(error);
@@ -59,8 +56,7 @@ const resolvers: Resolvers = {
         const organizationId =
           extractId<OrganizationId>(organization_id) ??
           context.user.selected_organization_id;
-        const serviceInstanceId =
-          extractId<ServiceInstanceId>(service_instance_id);
+        const serviceInstanceId = service_instance_id;
         const capabilityIds = capability_ids.map((capability_id) =>
           extractId<ServiceCapabilityId>(capability_id)
         );
@@ -73,9 +69,7 @@ const resolvers: Resolvers = {
           capabilityIds,
         });
 
-        return loadServiceWithSubscriptions(
-          extractId<ServiceInstanceId>(service_instance_id)
-        );
+        return loadServiceWithSubscriptions(serviceInstanceId);
       } catch (error) {
         throw mapToGraphQLError(
           error,

--- a/apps/portal-api/src/modules/subcription/subscription.resolver.ts
+++ b/apps/portal-api/src/modules/subcription/subscription.resolver.ts
@@ -1,6 +1,5 @@
 import { Resolvers } from '../../__generated__/resolvers-types';
 
-import { OrganizationId } from '../../model/kanel/public/Organization';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
 import {
   SubscriptionId,
@@ -54,8 +53,7 @@ const resolvers: Resolvers = {
     ) => {
       try {
         const organizationId =
-          extractId<OrganizationId>(organization_id) ??
-          context.user.selected_organization_id;
+          organization_id ?? context.user.selected_organization_id;
         const serviceInstanceId = service_instance_id;
         const capabilityIds = capability_ids.map((capability_id) =>
           extractId<ServiceCapabilityId>(capability_id)

--- a/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
+++ b/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
@@ -152,10 +152,7 @@ describe('TelemetryApp', () => {
         userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
         input: {
           platform_identifier: PlatformIdentifier.Opencti,
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.INTEGRATIONS.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
           resource_id: toGlobalId('DocumentId', documentId),
           resource_title: 'CsvFeed Title',
           platform_service_instance_id: toGlobalId(
@@ -239,10 +236,7 @@ describe('TelemetryApp', () => {
         userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
         input: {
           platform_identifier: PlatformIdentifier.Opencti,
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.INTEGRATIONS.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
           resource_id: toGlobalId('DocumentId', documentId),
           resource_title: 'CsvFeed Title',
           platform_service_instance_id: toGlobalId(
@@ -324,10 +318,7 @@ describe('TelemetryApp', () => {
         userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.BYPASS.ID,
         input: {
           platform_identifier: PlatformIdentifier.Opencti,
-          service_instance_id: toGlobalId(
-            'ServiceInstance',
-            SERVICES.INSTANCES.INTEGRATIONS.ID
-          ),
+          service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
           resource_id: toGlobalId('DocumentId', documentId),
           resource_title: 'Connector Title',
           platform_service_instance_id: toGlobalId(

--- a/apps/portal-api/src/modules/telemetry/telemetry.app.ts
+++ b/apps/portal-api/src/modules/telemetry/telemetry.app.ts
@@ -2,7 +2,6 @@ import config from 'config';
 import { OneClickDeployInput } from '../../__generated__/resolvers-types';
 import { requestContext } from '../../context/request.context';
 import { DocumentId } from '../../model/kanel/public/Document';
-import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { UserId } from '../../model/kanel/public/User';
 import { esDbClient } from '../../thirdparty/elasticsearch/client';
 import { PgBossProducer } from '../../thirdparty/pgboss/producer';
@@ -91,7 +90,7 @@ export const telemetryApp = {
       id: selected_organization_id,
     });
     const serviceDefinition = await loadServiceDefinitionByServiceInstance(
-      extractId<ServiceInstanceId>(input.service_instance_id)
+      input.service_instance_id
     );
 
     const platformServiceInstanceId = extractId<'RegisteredPlatform'>(

--- a/apps/portal-api/src/modules/telemetry/telemetry.graphql
+++ b/apps/portal-api/src/modules/telemetry/telemetry.graphql
@@ -5,7 +5,7 @@ type TelemetryResponse {
 
 input OneClickDeployInput {
   platform_identifier: PlatformIdentifier!
-  service_instance_id: ID!
+  service_instance_id: ServiceInstanceId!
   resource_id: ID!
   resource_title: String!
   platform_service_instance_id: ID!

--- a/apps/portal-api/src/modules/user_service/user_service.graphql
+++ b/apps/portal-api/src/modules/user_service/user_service.graphql
@@ -18,7 +18,7 @@ input UserServiceAddInput {
 
 input UserServiceAddYourselfInput {
   email: [String!]!
-  serviceInstanceId: ID
+  serviceInstanceId: ServiceInstanceId
 }
 
 input UserServiceDeleteInput {

--- a/apps/portal-api/src/modules/user_service/user_service.resolver.ts
+++ b/apps/portal-api/src/modules/user_service/user_service.resolver.ts
@@ -1,5 +1,4 @@
 import { Resolvers } from '../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { SubscriptionId } from '../../model/kanel/public/Subscription';
 import { UserId } from '../../model/kanel/public/User';
 import { UserServiceId } from '../../model/kanel/public/UserService';
@@ -48,7 +47,7 @@ const resolvers: Resolvers = {
         const user = context.user;
         return await UserServiceApp.addYourselfInUserService(
           user.selected_organization_id,
-          extractId<ServiceInstanceId>(input.serviceInstanceId),
+          input.serviceInstanceId,
           input.email,
           []
         );

--- a/apps/portal-api/src/server/mail-template/free_trial_registered.html
+++ b/apps/portal-api/src/server/mail-template/free_trial_registered.html
@@ -190,10 +190,12 @@
                       Before you start the trial, we would like to remind you of some of the trial platform limitations.<br />
                       <br />
                       <strong>The trial environment has two storage limits:</strong>
+                    </p>
                       <ul style="margin: 8px 0; padding-left: 20px;">
                         <li style="margin-bottom: 4px;">Intelligence data storage: up to 40 GB (this covers all the threat data, objects, and relationships you create or ingest)</li>
                         <li style="margin-bottom: 4px;">File storage: up to 3 GB (this covers any files or documents you upload)</li>
                       </ul>
+                    <p style="margin: 0; margin-bottom: 16px; line-height: 24px">
                       Ingesting large, premium feeds with rich data sets during this trial could impact your storage quickly. <strong>We recommend you bring in only 2-3 days worth of data as part of a premium feed.</strong>
                     </p>
                     {{/if}}

--- a/apps/portal-api/src/utils/scalar.util.test.ts
+++ b/apps/portal-api/src/utils/scalar.util.test.ts
@@ -59,6 +59,9 @@ describe('createRelayIdScalar', () => {
         `${typeName}Id must be a string`
       );
     });
+    it('should return the raw ID as-is if already decoded', () => {
+      expect(scalar.parseValue(rawId)).toBe(rawId);
+    });
   });
 
   describe('parseLiteral', () => {
@@ -82,5 +85,10 @@ describe('createRelayIdScalar', () => {
         );
       }
     );
+    it('should return the raw ID as-is if already decoded', () => {
+      expect(scalar.parseLiteral({ kind: Kind.STRING, value: rawId })).toBe(
+        rawId
+      );
+    });
   });
 });

--- a/apps/portal-api/src/utils/scalar.util.ts
+++ b/apps/portal-api/src/utils/scalar.util.ts
@@ -1,6 +1,14 @@
 import { GraphQLScalarType, Kind } from 'graphql';
-import { toGlobalId } from 'graphql-relay/node/node.js';
-import { extractId } from './utils';
+import { fromGlobalId, toGlobalId } from 'graphql-relay/node/node.js';
+
+const parseRelayId = <T extends string>(typeName: string, value: string): T => {
+  const { type, id } = fromGlobalId(value);
+  if (type === typeName && id) {
+    return id as T;
+  }
+  // Already a raw ID (not a Relay-encoded global ID)
+  return value as T;
+};
 
 export const createRelayIdScalar = <T extends string>(
   typeName: string
@@ -13,13 +21,13 @@ export const createRelayIdScalar = <T extends string>(
     },
     parseValue(value: unknown): T {
       if (typeof value === 'string') {
-        return extractId<T>(value);
+        return parseRelayId<T>(typeName, value);
       }
       throw new Error(`${typeName}Id must be a string`);
     },
     parseLiteral(ast): T {
       if (ast.kind === Kind.STRING) {
-        return extractId<T>(ast.value);
+        return parseRelayId<T>(typeName, ast.value);
       }
       throw new Error(`${typeName}Id must be a string`);
     },

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -157,11 +157,11 @@ type Mutation {
   adminEditUser(id: ID!, input: AdminEditUserInput!): User!
   addUser(input: AddUserInput!): User
   editUserCapabilities(id: ID!, input: EditUserCapabilitiesInput!): User!
-  changeSelectedOrganization(organization_id: ID!): User
+  changeSelectedOrganization(organization_id: OrganizationId!): User
   bulkRemovePendingUserFromOrganization(input: BulkPendingUserFromOrganizationInput): Success
   bulkAcceptPendingUserInOrganization(input: BulkPendingUserFromOrganizationInput): Success
-  removePendingUserFromOrganization(user_id: ID!, organization_id: ID!): User
-  removeUserFromOrganization(user_id: ID!, organization_id: ID!): User
+  removePendingUserFromOrganization(user_id: ID!, organization_id: OrganizationId!): User
+  removeUserFromOrganization(user_id: ID!, organization_id: OrganizationId!): User
   editMeUser(input: EditMeUserInput!): User!
   uploadUserPicture(document: Upload!): User!
   resetPassword: Success!
@@ -179,7 +179,7 @@ type Mutation {
   addServicePicture(serviceInstanceId: ServiceInstanceId!, document: Upload, isLogo: Boolean): ServiceInstance
   updatePlatformServiceMetadata(input: UpdatePlatformServiceMetadataInput!, document: Upload): RegisteredPlatform
   addSubscription(service_instance_id: ServiceInstanceId): ServiceInstance
-  addSubscriptionInService(service_instance_id: ServiceInstanceId, organization_id: ID, capability_ids: [ID], start_date: Date, end_date: Date): ServiceInstance
+  addSubscriptionInService(service_instance_id: ServiceInstanceId, organization_id: OrganizationId, capability_ids: [ID], start_date: Date, end_date: Date): ServiceInstance
   deleteSubscription(subscription_id: ID!): ServiceInstance
   sendTelemetryEvent: SendTelemetryMutation
   addUseCase(input: AddUseCaseInput!): UseCase!
@@ -599,7 +599,7 @@ input UpdateDocumentInput {
   description: String
   active: Boolean
   use_cases: [String!]
-  uploader_organization_id: String
+  uploader_organization_id: OrganizationId
   uploader_id: String
 }
 
@@ -1006,14 +1006,14 @@ type User implements Node {
   picture: String
   country: String
   disabled: Boolean
-  selected_organization_id: String
+  selected_organization_id: OrganizationId
   organizations: [Organization!]
   organization_capabilities: [OrganizationCapabilities!]
   capabilities: [Capability!]
   roles_portal: [RolePortal!]
   selected_org_capabilities: [OrganizationCapability!]
   last_login: Date
-  pending_organization_id: ID
+  pending_organization_id: OrganizationId
 }
 
 type UserEdge {
@@ -1028,7 +1028,7 @@ type UserConnection {
 }
 
 input UsersWithCapabilitiesInOrganizationInput {
-  organizationId: ID!
+  organizationId: OrganizationId!
   capabilities: [OrganizationCapability!]!
 }
 
@@ -1051,7 +1051,7 @@ input EditMeUserInput {
 }
 
 input OrganizationCapabilitiesInput {
-  organization_id: ID!
+  organization_id: OrganizationId!
   capabilities: [String!]
 }
 

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -94,13 +94,13 @@ type Query {
   deploymentRequestsAvailable(platformIdentifier: PlatformIdentifier): [DeploymentAvailability!]!
   deploymentRequestsList(first: Int!, after: ID, filters: [DeploymentRequestFilter!], orderBy: DeploymentRequestOrdering!, orderMode: OrderingMode!, searchTerm: String): DeploymentRequestConnection!
   trialDeployments(input: TrialDeploymentsInput): TrialsDeployments!
-  serviceGroups(serviceInstanceId: ID!): [ServiceGroup!]!
-  documentExists(documentName: String, service_instance_id: String): Boolean
-  publicDocuments(slug: String!, first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: ID!): DocumentConnection!
+  serviceGroups(serviceInstanceId: ServiceInstanceId!): [ServiceGroup!]!
+  documentExists(documentName: String, service_instance_id: ServiceInstanceId): Boolean
+  publicDocuments(slug: String!, first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: ServiceInstanceId!): DocumentConnection!
   publicDocumentsByServiceSlug(serviceInstanceSlug: String!): [Document!]!
-  publicDocumentBySlug(serviceInstanceId: ID!, slug: String!): Document
-  documents(first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: String, parentsOnly: Boolean): DocumentConnection!
-  document(documentId: ID, serviceInstanceId: ID): Document
+  publicDocumentBySlug(serviceInstanceId: ServiceInstanceId!, slug: String!): Document
+  documents(first: Int!, after: ID, orderBy: DocumentOrdering!, orderMode: OrderingMode!, searchTerm: String, logicalFilters: LogicalFilterInput, serviceInstanceId: ServiceInstanceId, parentsOnly: Boolean): DocumentConnection!
+  document(documentId: ID, serviceInstanceId: ServiceInstanceId): Document
   updateOpenCTIManifest(tag: String): Success!
   organization(id: ID!): Organization
   organizations(first: Int = 50, after: ID, orderBy: OrganizationOrdering!, orderMode: OrderingMode!, searchTerm: String): OrganizationConnection!
@@ -145,9 +145,9 @@ type Mutation {
   adminCancelDeploymentRequest(deploymentRequestId: ID): DeploymentRequest
   updateDeploymentQuotaCapacity(input: UpdateDeploymentQuotaCapacityInput!): Success!
   updateServiceGroups(input: UpdateServiceGroupsInput!): Success
-  createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
-  updateDocument(documentId: ID!, input: UpdateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: String, sourceDocument: Upload, logo: Upload, images: [Upload!], existingImageIds: [ID!]): Document!
-  deleteDocument(documentId: ID, service_instance_id: String, forceDelete: Boolean): Document!
+  createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: ServiceInstanceId, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
+  updateDocument(documentId: ID!, input: UpdateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: ServiceInstanceId, sourceDocument: Upload, logo: Upload, images: [Upload!], existingImageIds: [ID!]): Document!
+  deleteDocument(documentId: ID, service_instance_id: ServiceInstanceId, forceDelete: Boolean): Document!
   incrementShareNumberDocument(documentId: ID): Document!
   frontendErrorLog(message: String!, codeStack: String, componentStack: String): Boolean
   addOrganization(input: OrganizationInput!): Organization
@@ -175,16 +175,16 @@ type Mutation {
   refreshUserPlatformToken: RefreshUserPlatformTokenResponse!
   refreshPlatformRegistrationConnectivityStatus(input: RefreshPlatformRegistrationConnectivityStatusInput!): RefreshPlatformRegistrationConnectivityStatusResponse!
   autoRegisterPlatform(platform: PlatformInput @deprecated(reason: "Use input instead"), input: AutoRegisterPlatformInput): Success!
+  editServiceCapability(input: EditServiceCapabilityInput, serviceInstanceId: ServiceInstanceId): SubscriptionModel
   addServicePicture(serviceInstanceId: ServiceInstanceId!, document: Upload, isLogo: Boolean): ServiceInstance
   updatePlatformServiceMetadata(input: UpdatePlatformServiceMetadataInput!, document: Upload): RegisteredPlatform
-  addSubscription(service_instance_id: String): ServiceInstance
-  addSubscriptionInService(service_instance_id: String, organization_id: ID, capability_ids: [ID], start_date: Date, end_date: Date): ServiceInstance
+  addSubscription(service_instance_id: ServiceInstanceId): ServiceInstance
+  addSubscriptionInService(service_instance_id: ServiceInstanceId, organization_id: ID, capability_ids: [ID], start_date: Date, end_date: Date): ServiceInstance
   deleteSubscription(subscription_id: ID!): ServiceInstance
   sendTelemetryEvent: SendTelemetryMutation
   addUseCase(input: AddUseCaseInput!): UseCase!
   editUseCase(id: ID!, input: EditUseCaseInput!): UseCase!
   deleteUseCase(id: ID!): UseCase!
-  editServiceCapability(input: EditServiceCapabilityInput, serviceInstanceId: String): SubscriptionModel
   addUserService(input: UserServiceAddInput!): [UserService]
   addYourselfInUserService(input: UserServiceAddYourselfInput!): [UserService]
   deleteUserService(input: UserServiceDeleteInput!): UserService
@@ -547,7 +547,7 @@ type DefaultDocument implements Node & Document {
   share_number: Int
   slug: String
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -571,7 +571,7 @@ interface Document implements Node {
   share_number: Int
   slug: String
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -632,7 +632,7 @@ type OpenAEVScenario implements Document & Node {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -657,7 +657,7 @@ type CustomDashboard implements Document & Node {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -715,7 +715,7 @@ interface Integration implements Node & Document {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -743,7 +743,7 @@ type IntegrationHack implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -771,7 +771,7 @@ type CsvFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -800,7 +800,7 @@ type Connector implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -837,7 +837,7 @@ type TaxiiFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -867,7 +867,7 @@ type RssFeed implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -897,7 +897,7 @@ type Stream implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -927,7 +927,7 @@ type ThirdPartyIntegration implements Node & Document & Integration {
   share_number: Int
   slug: String!
   use_cases: [UseCase!]
-  service_instance_id: String!
+  service_instance_id: ServiceInstanceId!
   service_instance: ServiceInstance
   subscription: SubscriptionModel
   children_documents: [ShareableResource!]
@@ -1215,7 +1215,7 @@ input RegisteredPlatformsInput {
 }
 
 input RegisteredPlatformInput {
-  service_instance_id: ID!
+  service_instance_id: ServiceInstanceId!
 }
 
 input AutoRegisterPlatformInput {
@@ -1231,6 +1231,35 @@ enum ServiceConfigurationStatus {
 type RolePortal implements Node {
   id: ID!
   name: String!
+}
+
+type GenericServiceCapability implements Node {
+  id: ID!
+  name: String
+}
+
+input EditServiceCapabilityInput {
+  user_service_id: String
+  capabilities: [String]!
+}
+
+type UserServiceCapability implements Node {
+  id: ID!
+  user_service_id: ID!
+  generic_service_capability: GenericServiceCapability
+  subscription_capability: SubscriptionCapability
+}
+
+type SubscriptionCapability implements Node {
+  id: ID!
+  service_capability: ServiceCapability
+}
+
+type ServiceCapability implements Node {
+  id: ID!
+  name: String
+  description: String
+  service_definition_id: ID
 }
 
 enum ServiceDefinitionIdentifier {
@@ -1432,7 +1461,7 @@ type TelemetryResponse {
 
 input OneClickDeployInput {
   platform_identifier: PlatformIdentifier!
-  service_instance_id: ID!
+  service_instance_id: ServiceInstanceId!
   resource_id: ID!
   resource_title: String!
   platform_service_instance_id: ID!
@@ -1474,35 +1503,6 @@ input EditUseCaseInput {
   color: String
 }
 
-type GenericServiceCapability implements Node {
-  id: ID!
-  name: String
-}
-
-input EditServiceCapabilityInput {
-  user_service_id: String
-  capabilities: [String]!
-}
-
-type UserServiceCapability implements Node {
-  id: ID!
-  user_service_id: ID!
-  generic_service_capability: GenericServiceCapability
-  subscription_capability: SubscriptionCapability
-}
-
-type SubscriptionCapability implements Node {
-  id: ID!
-  service_capability: ServiceCapability
-}
-
-type ServiceCapability implements Node {
-  id: ID!
-  name: String
-  description: String
-  service_definition_id: ID
-}
-
 enum UserServiceOrdering {
   first_name
   last_name
@@ -1523,7 +1523,7 @@ input UserServiceAddInput {
 
 input UserServiceAddYourselfInput {
   email: [String!]!
-  serviceInstanceId: ID
+  serviceInstanceId: ServiceInstanceId
 }
 
 input UserServiceDeleteInput {

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -146,8 +146,8 @@ type Mutation {
   createDeploymentRequest(input: CreateDeploymentRequestInput): DeploymentRequest!
   updateDeploymentRequest(input: UpdateDeploymentRequestInput!): PlatformDeploymentRequest!
   reorderDeploymentRequestInQueue(input: ReorderDeploymentRequestInQueueInput!): Success!
-  cancelDeploymentRequest(deploymentRequestId: ID!, cancellationReason: String): DeploymentRequest
-  adminCancelDeploymentRequest(deploymentRequestId: ID): DeploymentRequest
+  cancelDeploymentRequest(deploymentRequestId: DeploymentRequestId!, cancellationReason: String): DeploymentRequest
+  adminCancelDeploymentRequest(deploymentRequestId: DeploymentRequestId): DeploymentRequest
   updateDeploymentQuotaCapacity(input: UpdateDeploymentQuotaCapacityInput!): Success!
   updateServiceGroups(input: UpdateServiceGroupsInput!): Success
   createDocument(input: CreateDocumentInput!, metadata: [DocumentMetadata!]!, serviceInstanceId: ServiceInstanceId, sourceDocument: Upload, logo: Upload, images: [Upload!]): Document!
@@ -197,6 +197,11 @@ type Mutation {
   updateEpic(id: ID!, input: UpdateEpicInput!, document: [Upload!]): Epic!
   deleteEpic(id: ID!): Epic!
 }
+
+"""
+A Relay global ID for DeploymentRequest, extracted to a branded DeploymentRequestId string
+"""
+scalar DeploymentRequestId
 
 enum DeploymentRequestPlatformRegion {
   eu_west
@@ -367,7 +372,7 @@ input CreateDeploymentRequestInput {
 }
 
 input UpdateDeploymentRequestInput {
-  id: ID!
+  id: DeploymentRequestId!
   start_date: Date
   end_date: Date
   platform_id: String
@@ -450,7 +455,7 @@ enum ReorderDeploymentRequestInQueueDirection {
 }
 
 input ReorderDeploymentRequestInQueueInput {
-  id: ID!
+  id: DeploymentRequestId!
   direction: ReorderDeploymentRequestInQueueDirection!
 }
 

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -470,6 +470,11 @@ input TrialDeploymentsInput {
   platformIdentifiers: [PlatformIdentifier!]
 }
 
+"""
+A Relay global ID for ServiceGroup, extracted to a branded ServiceGroupId string
+"""
+scalar ServiceGroupId
+
 type ServiceGroup implements Node {
   id: ID!
   name: String!
@@ -477,7 +482,7 @@ type ServiceGroup implements Node {
 }
 
 input UpdateServiceGroupsInputGroup {
-  id: ID!
+  id: ServiceGroupId!
   userIds: [ID!]!
 }
 

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -45,6 +45,11 @@ type Success {
   success: Boolean!
 }
 
+"""
+A Relay global ID for Competitor, extracted to a branded CompetitorId string
+"""
+scalar CompetitorId
+
 enum CompetitorOrdering {
   name
   tier
@@ -82,7 +87,7 @@ input CreateCompetitorInput {
 }
 
 input UpdateCompetitorInput {
-  id: ID!
+  id: CompetitorId!
   name: String
   tier: CompetitorTier
   domain: String
@@ -137,7 +142,7 @@ type Query {
 type Mutation {
   createCompetitor(input: CreateCompetitorInput!): Competitor!
   updateCompetitor(input: UpdateCompetitorInput!): Competitor!
-  deleteCompetitor(id: ID!): Competitor!
+  deleteCompetitor(id: CompetitorId!): Competitor!
   createDeploymentRequest(input: CreateDeploymentRequestInput): DeploymentRequest!
   updateDeploymentRequest(input: UpdateDeploymentRequestInput!): PlatformDeploymentRequest!
   reorderDeploymentRequestInQueue(input: ReorderDeploymentRequestInQueueInput!): Success!

--- a/apps/portal-front/src/components/admin/user/pending-user-list.tsx
+++ b/apps/portal-front/src/components/admin/user/pending-user-list.tsx
@@ -62,7 +62,7 @@ import { useDebounceCallback } from 'usehooks-ts';
 const removePendingUser = graphql`
   mutation pendingUserListRemoveUserMutation(
     $user_id: ID!
-    $organization_id: ID!
+    $organization_id: OrganizationId!
   ) {
     removePendingUserFromOrganization(
       user_id: $user_id

--- a/apps/portal-front/src/components/admin/user/remove-user-from-orga.tsx
+++ b/apps/portal-front/src/components/admin/user/remove-user-from-orga.tsx
@@ -17,7 +17,7 @@ const removeUser = graphql`
   mutation removeUserFromOrgaMutation(
     $connections: [ID!]!
     $user_id: ID!
-    $organization_id: ID!
+    $organization_id: OrganizationId!
   ) {
     removeUserFromOrganization(
       user_id: $user_id

--- a/apps/portal-front/src/components/competitor/competitor.graphql.ts
+++ b/apps/portal-front/src/components/competitor/competitor.graphql.ts
@@ -61,7 +61,7 @@ export const CompetitorEditMutation = graphql`
 `;
 
 export const CompetitorDeleteMutation = graphql`
-  mutation competitorDeleteMutation($id: ID!, $connections: [ID!]!) {
+  mutation competitorDeleteMutation($id: CompetitorId!, $connections: [ID!]!) {
     deleteCompetitor(id: $id) {
       id @deleteEdge(connections: $connections)
     }

--- a/apps/portal-front/src/components/menu/organization-switcher.tsx
+++ b/apps/portal-front/src/components/menu/organization-switcher.tsx
@@ -15,7 +15,7 @@ interface TeamSwitcherProps {
 }
 
 const changeSelectedOrganizationMutation = graphql`
-  mutation organizationSwitcherMutation($organization_id: ID!) {
+  mutation organizationSwitcherMutation($organization_id: OrganizationId!) {
     changeSelectedOrganization(organization_id: $organization_id) {
       id
       selected_organization_id

--- a/apps/portal-front/src/components/service/[slug]/capabilities/service-capability.graphql.ts
+++ b/apps/portal-front/src/components/service/[slug]/capabilities/service-capability.graphql.ts
@@ -3,7 +3,7 @@ import { graphql } from 'react-relay';
 export const ServiceCapabilityCreateMutation = graphql`
   mutation serviceCapabilityMutation(
     $input: EditServiceCapabilityInput
-    $serviceInstanceId: String
+    $serviceInstanceId: ServiceInstanceId
   ) {
     editServiceCapability(
       input: $input

--- a/apps/portal-front/src/components/service/document/document.graphql.ts
+++ b/apps/portal-front/src/components/service/document/document.graphql.ts
@@ -4,7 +4,7 @@ export const DocumentCreateMutation = graphql`
   mutation documentCreateMutation(
     $input: CreateDocumentInput!
     $metadata: [DocumentMetadata!]!
-    $serviceInstanceId: String!
+    $serviceInstanceId: ServiceInstanceId!
     $connections: [ID!]!
     $sourceDocument: Upload
     $logo: Upload
@@ -32,7 +32,7 @@ export const DocumentUpdateMutation = graphql`
     $metadata: [DocumentMetadata!]!
     $sourceDocument: Upload
     $existingImageIds: [ID!]
-    $serviceInstanceId: String!
+    $serviceInstanceId: ServiceInstanceId!
     $logo: Upload
     $images: [Upload!]
   ) {
@@ -56,7 +56,7 @@ export const DocumentDeleteMutation = graphql`
   mutation documentDeleteMutation(
     $documentId: ID
     $connections: [ID!]!
-    $serviceInstanceId: String
+    $serviceInstanceId: ServiceInstanceId
     $forceDelete: Boolean
   ) {
     deleteDocument(
@@ -70,7 +70,10 @@ export const DocumentDeleteMutation = graphql`
 `;
 
 export const DocumentExistsQuery = graphql`
-  query documentExistsQuery($documentName: String, $serviceInstanceId: String) {
+  query documentExistsQuery(
+    $documentName: String
+    $serviceInstanceId: ServiceInstanceId
+  ) {
     documentExists(
       documentName: $documentName
       service_instance_id: $serviceInstanceId
@@ -229,7 +232,7 @@ export const DocumentsListQuery = graphql`
     $orderMode: OrderingMode!
     $logicalFilters: LogicalFilterInput
     $searchTerm: String
-    $serviceInstanceId: String
+    $serviceInstanceId: ServiceInstanceId
     $parentsOnly: Boolean
   ) {
     ...documentsList
@@ -237,7 +240,10 @@ export const DocumentsListQuery = graphql`
 `;
 
 export const DocumentsItemQuery = graphql`
-  query documentQuery($documentId: ID!, $serviceInstanceId: ID!) {
+  query documentQuery(
+    $documentId: ID!
+    $serviceInstanceId: ServiceInstanceId!
+  ) {
     document(documentId: $documentId, serviceInstanceId: $serviceInstanceId) {
       ...documentItem_fragment
     }

--- a/apps/portal-front/src/components/service/document/public-document.graphql.ts
+++ b/apps/portal-front/src/components/service/document/public-document.graphql.ts
@@ -128,7 +128,7 @@ export const PublicDocumentListQuery = graphql`
     $orderMode: OrderingMode!
     $logicalFilters: LogicalFilterInput
     $searchTerm: String
-    $serviceInstanceId: ID!
+    $serviceInstanceId: ServiceInstanceId!
   ) {
     ...publicDocumentList
   }
@@ -143,7 +143,10 @@ export const PublicDocumentsByServiceSlugQuery = graphql`
 `;
 
 export const PublicDocumentBySlugQuery = graphql`
-  query publicDocumentBySlugQuery($serviceInstanceId: ID!, $slug: String!) {
+  query publicDocumentBySlugQuery(
+    $serviceInstanceId: ServiceInstanceId!
+    $slug: String!
+  ) {
     publicDocumentBySlug(serviceInstanceId: $serviceInstanceId, slug: $slug) {
       ...publicDocumentItemFragment
     }

--- a/apps/portal-front/src/components/service/service-group.graphql.ts
+++ b/apps/portal-front/src/components/service/service-group.graphql.ts
@@ -12,7 +12,9 @@ export const serviceGroupFragment = graphql`
 `;
 
 export const ServiceGroupsByServiceInstanceId = graphql`
-  query serviceGroupsByServiceInstanceIdQuery($serviceInstanceId: ID!) {
+  query serviceGroupsByServiceInstanceIdQuery(
+    $serviceInstanceId: ServiceInstanceId!
+  ) {
     serviceGroups(serviceInstanceId: $serviceInstanceId) {
       ...serviceGroup_fragment
     }

--- a/apps/portal-front/src/components/service/trial-instances/trial-instances.graphql.ts
+++ b/apps/portal-front/src/components/service/trial-instances/trial-instances.graphql.ts
@@ -27,7 +27,7 @@ export const DeploymentRequestsAvailableQuery = graphql`
 
 export const CancelDeploymentRequestMutation = graphql`
   mutation trialInstancesCancelDeploymentRequestMutation(
-    $deploymentRequestId: ID!
+    $deploymentRequestId: DeploymentRequestId!
     $cancellationReason: String
   ) {
     cancelDeploymentRequest(

--- a/apps/portal-front/src/components/subcription/subscription.graphql.ts
+++ b/apps/portal-front/src/components/subcription/subscription.graphql.ts
@@ -49,7 +49,7 @@ export const SubscriptionDeleteMutation = graphql`
 
 export const AddSubscriptionInServiceMutation = graphql`
   mutation subscriptionInServiceCreateMutation(
-    $service_instance_id: String!
+    $service_instance_id: ServiceInstanceId!
     $organization_id: ID
     $capability_ids: [ID]
     $start_date: Date!
@@ -69,7 +69,7 @@ export const AddSubscriptionInServiceMutation = graphql`
 
 export const AddSubscriptionMutation = graphql`
   mutation subscriptionCreateMutation(
-    $service_instance_id: String!
+    $service_instance_id: ServiceInstanceId!
     $connections: [ID!]!
   ) {
     addSubscription(service_instance_id: $service_instance_id)

--- a/apps/portal-front/src/components/subcription/subscription.graphql.ts
+++ b/apps/portal-front/src/components/subcription/subscription.graphql.ts
@@ -50,7 +50,7 @@ export const SubscriptionDeleteMutation = graphql`
 export const AddSubscriptionInServiceMutation = graphql`
   mutation subscriptionInServiceCreateMutation(
     $service_instance_id: ServiceInstanceId!
-    $organization_id: ID
+    $organization_id: OrganizationId
     $capability_ids: [ID]
     $start_date: Date!
     $end_date: Date

--- a/apps/portal-front/src/components/trials/trials.graphql.ts
+++ b/apps/portal-front/src/components/trials/trials.graphql.ts
@@ -68,7 +68,7 @@ export const TrialsReorderRequestInQueueMutation = graphql`
 
 export const TrialsAdminCancelDeploymentRequestMutation = graphql`
   mutation trialsAdminCancelDeploymentRequestMutation(
-    $deploymentRequestId: ID!
+    $deploymentRequestId: DeploymentRequestId!
     $removeConnections: [ID!]!
   ) {
     adminCancelDeploymentRequest(deploymentRequestId: $deploymentRequestId) {


### PR DESCRIPTION
# Context
Remove extractId calls for:
- ServiceInstance
- DeploymentRequest
- ServiceGroup
- Organization
- Competitor

Improve RelayId scalar so it supports already decoded fields (technically, fields named id).

## How to test
test there is no regression on these modules

## Related issues

- Related to #2082

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.