### PR TITLE
[frontend] refactor(session): forward all cookies as a list instead of looking up by name (#2073)

### DIFF
--- a/apps/portal-api/config/default.json
+++ b/apps/portal-api/config/default.json
@@ -104,10 +104,6 @@
   "hubspot_webhook_url": "changeMe",
   "system_token_hash": "eb511fd584085eeab986f2c588f8a8e9b765b469361bde9caa75040162171055b2b330969b56d0b11e50801eabf61fa8d4f66db8df39333dea4663dd027faca4",
   "system_token_salt": "7e0da0e4c903f610403cca8dc21de19d",
-  "session": {
-    "name": "cloud-portal",
-    "secret": "changeMe"
-  },
   "session_store": {
     "type": "postgresql",
     "cleanup_interval_minutes": 60

--- a/apps/portal-front/src/relay/environment/fetchFn.ts
+++ b/apps/portal-front/src/relay/environment/fetchFn.ts
@@ -6,7 +6,7 @@ import {
   RequestParameters,
   Variables,
 } from 'relay-runtime';
-import { scrubSensitiveVariables } from './fetchFn.utils';
+import { buildCookieHeader, scrubSensitiveVariables } from './fetchFn.utils';
 
 function prepareUri(uri: string | undefined) {
   if (uri) {
@@ -57,10 +57,10 @@ export async function networkFetch({
     Accept: 'application/json',
     'Content-Type': 'application/json',
   };
-  if (cookieList?.length) {
-    headers.cookie = cookieList
-      .map((ck) => `${ck.name}=${ck.value}`)
-      .join('; ');
+
+  const cookieHeader = buildCookieHeader(cookieList);
+  if (cookieHeader) {
+    headers.cookie = cookieHeader;
   }
 
   const activeCacheConfig = isDevelopment()

--- a/apps/portal-front/src/relay/environment/fetchFn.ts
+++ b/apps/portal-front/src/relay/environment/fetchFn.ts
@@ -1,6 +1,5 @@
 import { isDevelopment } from '@/lib/utils';
 import { createClient } from 'graphql-sse';
-import { RequestCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import {
   GraphQLResponse,
   Observable,
@@ -39,14 +38,14 @@ export async function networkFetch({
   apiUri = '/graphql-api',
   request,
   variables,
-  portalCookie,
-  cache = portalCookie ? 'no-store' : undefined,
+  cookieList,
+  cache = cookieList?.length ? 'no-store' : undefined,
   options = {},
 }: {
   apiUri?: string;
   request: RequestParameters;
   variables: Variables;
-  portalCookie?: RequestCookie;
+  cookieList?: { name: string; value: string }[];
   cache?: RequestCache;
   options?: RequestInit;
 }): Promise<GraphQLResponse> {
@@ -58,8 +57,10 @@ export async function networkFetch({
     Accept: 'application/json',
     'Content-Type': 'application/json',
   };
-  if (portalCookie) {
-    headers.cookie = portalCookie.name + '=' + portalCookie.value;
+  if (cookieList?.length) {
+    headers.cookie = cookieList
+      .map((ck) => `${ck.name}=${ck.value}`)
+      .join('; ');
   }
 
   const activeCacheConfig = isDevelopment()

--- a/apps/portal-front/src/relay/environment/fetchFn.utils.test.ts
+++ b/apps/portal-front/src/relay/environment/fetchFn.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scrubSensitiveVariables } from './fetchFn.utils';
+import { buildCookieHeader, scrubSensitiveVariables } from './fetchFn.utils';
 
 describe('scrubSensitiveVariables', () => {
   describe('sensitive top-level fields', () => {
@@ -99,6 +99,18 @@ describe('scrubSensitiveVariables', () => {
 
     it('returns undefined as-is', () => {
       expect(scrubSensitiveVariables(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('buildCookieHeader', () => {
+    it.each`
+      description           | input                                                                    | expected
+      ${'single cookie'}    | ${[{ name: 'session', value: 'abc' }]}                                   | ${'session=abc'}
+      ${'multiple cookies'} | ${[{ name: 'session', value: 'abc' }, { name: 'theme', value: 'dark' }]} | ${'session=abc; theme=dark'}
+      ${'empty array'}      | ${[]}                                                                    | ${undefined}
+      ${'undefined'}        | ${undefined}                                                             | ${undefined}
+    `('should return $expected for $description', ({ input, expected }) => {
+      expect(buildCookieHeader(input)).toBe(expected);
     });
   });
 });

--- a/apps/portal-front/src/relay/environment/fetchFn.utils.ts
+++ b/apps/portal-front/src/relay/environment/fetchFn.utils.ts
@@ -23,3 +23,10 @@ export function scrubSensitiveVariables(variables: Variables): Variables {
     })
   );
 }
+
+export function buildCookieHeader(
+  cookieList?: { name: string; value: string }[]
+): string | undefined {
+  if (!cookieList?.length) return undefined;
+  return cookieList.map((ck) => `${ck.name}=${ck.value}`).join('; ');
+}

--- a/apps/portal-front/src/relay/environment/fetchFormData.test.ts
+++ b/apps/portal-front/src/relay/environment/fetchFormData.test.ts
@@ -1,4 +1,3 @@
-import { RequestCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { RequestParameters, UploadableMap } from 'relay-runtime';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -57,7 +56,7 @@ describe('fetchFormData', () => {
       );
     });
 
-    it('should set cookie header if portalCookie is provided', async () => {
+    it('should set cookie header if cookieList is provided', async () => {
       const mockJson = { data: { foo: 'bar' } };
       let headers: Record<string, unknown> = {};
       globalThis.fetch = vi.fn().mockImplementation((_, opts) => {
@@ -66,9 +65,12 @@ describe('fetchFormData', () => {
           json: () => Promise.resolve(mockJson),
         });
       });
-      const portalCookie = { name: 'session', value: 'abc' } as RequestCookie;
-      await fetchFormData('/api', request, {}, {}, portalCookie);
-      expect(headers.cookie).toBe('session=abc');
+      const cookieList = [
+        { name: 'session', value: 'abc' },
+        { name: 'other', value: 'xyz' },
+      ];
+      await fetchFormData('/api', request, {}, {}, cookieList);
+      expect(headers.cookie).toBe('session=abc; other=xyz');
     });
 
     describe('file mapping', () => {

--- a/apps/portal-front/src/relay/environment/fetchFormData.ts
+++ b/apps/portal-front/src/relay/environment/fetchFormData.ts
@@ -1,4 +1,3 @@
-import { RequestCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { RequestParameters, UploadableMap, Variables } from 'relay-runtime';
 import { UnauthenticatedError } from './fetchFn';
 
@@ -32,7 +31,7 @@ export const fetchFormData = async (
   request: RequestParameters,
   variables: Variables,
   uploadables: UploadableMap,
-  portalCookie?: RequestCookie
+  cookieList?: { name: string; value: string }[]
 ) => {
   const headers: { [k: string]: string } = {
     Accept: 'application/json',
@@ -78,14 +77,16 @@ export const fetchFormData = async (
     formData.append(String(index), file)
   );
 
-  if (portalCookie) {
-    headers.cookie = portalCookie.name + '=' + portalCookie.value;
+  if (cookieList?.length) {
+    headers.cookie = cookieList
+      .map((ck) => `${ck.name}=${ck.value}`)
+      .join('; ');
   }
   const resp = await fetch(apiUri, {
     method: 'POST',
     credentials: 'same-origin',
     headers,
-    cache: portalCookie ? 'no-store' : undefined,
+    cache: cookieList?.length ? 'no-store' : undefined,
     body: formData,
   });
   const json = await resp.json();

--- a/apps/portal-front/src/relay/environment/fetchFormData.ts
+++ b/apps/portal-front/src/relay/environment/fetchFormData.ts
@@ -1,5 +1,6 @@
 import { RequestParameters, UploadableMap, Variables } from 'relay-runtime';
 import { UnauthenticatedError } from './fetchFn';
+import { buildCookieHeader } from './fetchFn.utils';
 
 const FILE_PREFIX_SEPARATOR = 'prefix-';
 
@@ -77,16 +78,16 @@ export const fetchFormData = async (
     formData.append(String(index), file)
   );
 
-  if (cookieList?.length) {
-    headers.cookie = cookieList
-      .map((ck) => `${ck.name}=${ck.value}`)
-      .join('; ');
+  const cookieHeader = buildCookieHeader(cookieList);
+  if (cookieHeader) {
+    headers.cookie = cookieHeader;
   }
+
   const resp = await fetch(apiUri, {
     method: 'POST',
     credentials: 'same-origin',
     headers,
-    cache: cookieList?.length ? 'no-store' : undefined,
+    cache: cookieHeader ? 'no-store' : undefined,
     body: formData,
   });
   const json = await resp.json();

--- a/apps/portal-front/src/relay/serverPortalApiFetch.ts
+++ b/apps/portal-front/src/relay/serverPortalApiFetch.ts
@@ -22,15 +22,14 @@ export default async function serverPortalApiFetch<
 ): Promise<GraphQLResponse> {
   const c = await cookies();
   const h = await headers();
-  const cookieName = process.env.PORTAL_COOKIE_NAME ?? 'cloud-portal';
-  const portalCookie = c.get(cookieName);
+  const cookieList = c.getAll();
   const pathname = h.get('x-pathname');
   const apiUri = getGraphqlApi(true, 'api');
   return networkFetch({
     apiUri,
     request: request.params,
     variables,
-    portalCookie,
+    cookieList,
     options,
   }).catch((e: unknown) => {
     if (e instanceof UnauthenticatedError) {

--- a/apps/portal-front/src/relay/serverPortalApiFetch.ts
+++ b/apps/portal-front/src/relay/serverPortalApiFetch.ts
@@ -23,7 +23,8 @@ export default async function serverPortalApiFetch<
   const c = await cookies();
   const h = await headers();
   const cookieName = process.env.PORTAL_COOKIE_NAME ?? 'cloud-portal';
-  const portalCookie = c.get(cookieName);  const pathname = h.get('x-pathname');
+  const portalCookie = c.get(cookieName);
+  const pathname = h.get('x-pathname');
   const apiUri = getGraphqlApi(true, 'api');
   return networkFetch({
     apiUri,


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

The portal session cookie name is configurable on the backend (via session.name config or PORTAL_COOKIE_NAME env var), but the frontend server-side fetch layer had the value cloud-portal hardcoded in serverPortalApiFetch.ts.
When a custom cookie name was configured on the backend, the frontend could not resolve the session cookie, breaking authenticated GraphQL calls and redirecting users back to the login form.

Instead of duplicating the backend cookie name configuration on the frontend (via an environment variable), the SSR fetch layer now forwards all cookies from the incoming request to the backend as a structured list. The backend express-session middleware already knows which cookie is its own — it looks up the name it was configured with and ignores the rest.
The cookie list is passed as a { name: string; value: string }[] array through the fetch chain, and the Cookie header is built at the last moment in fetchFn.ts / fetchFormData.ts — keeping the data structured as long as possible.
This eliminates the need for any shared configuration between frontend and backend for session cookie handling.

### Changes

**`apps/portal-front/src/relay/serverPortalApiFetch.ts`**
- Replace `c.get('cloud-portal')` with `c.getAll()` to collect all cookies as a list.
- Pass `cookieList` instead of `portalCookie` to `networkFetch`.

**`apps/portal-front/src/relay/environment/fetchFn.ts`**
- Replace `portalCookie: RequestCookie` parameter with `cookieList: { name: string; value: string }[]`.
- Build the `Cookie` header from the list at fetch time.
- Remove `RequestCookie` import.

**`apps/portal-front/src/relay/environment/fetchFormData.ts`**
- Same parameter and logic change as `fetchFn.ts`.
- Remove `RequestCookie` import.

**`apps/portal-front/src/relay/environment/fetchFormData.test.ts`**
- Update the cookie test to pass an array of cookie objects instead of a `RequestCookie`.
- Remove `RequestCookie` import.

**`apps/portal-front/src/relay/environment/fetchFn.utils.ts`**

- Add buildCookieHeader utility to serialize a cookie list into a Cookie header string.

**`apps/portal-front/src/relay/environment/fetchFn.utils.test.ts`**

- Add tests for buildCookieHeader (single cookie, multiple cookies, empty array, undefined).

**`apps/portal-api/config/default.json`**
- Remove `session` block accidentally added in #2081.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

### Default behavior
 
1. Start the backend: `yarn dev:api`
2. Start the frontend: `yarn dev:front`
3. Log in at `http://localhost:3002` — should work as before
 
### Custom cookie name (the fix)
 
1. Set a custom cookie name in `apps/portal-api/config/local.json`:
   ```json
   "session": {
     "name": "my-custom-cookie",
     "secret": "your-secret"
   }
   ```
2. Start the backend: `yarn dev:api`
3. Start the frontend: `yarn dev:front` (no env var needed!)
4. Log in at `http://localhost:3002`
5. Verify in DevTools → Application → Cookies that the cookie is named `my-custom-cookie`
6. Verify that authenticated pages load correctly (no redirect loop to login)

## Related issues

- Related to #2073

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.