### PR TITLE
[frontend/backend] feat(settings): add FeatureFlag GraphQL enum and use generated enum in frontend (#1678)

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -621,6 +621,10 @@ export enum EpicType {
   Other = 'other'
 }
 
+export enum FeatureFlag {
+  Dummy = 'DUMMY'
+}
+
 export enum FiligranProduct {
   Openaev = 'openaev',
   Opencti = 'opencti',
@@ -1915,7 +1919,7 @@ export type Settings = {
   __typename?: 'Settings';
   base_url_front: Scalars['String']['output'];
   environment: Scalars['String']['output'];
-  platform_feature_flags: Array<Scalars['String']['output']>;
+  platform_feature_flags: Array<FeatureFlag>;
   platform_providers: Array<PlatformProvider>;
 };
 
@@ -2484,6 +2488,7 @@ export type ResolversTypes = ResolversObject<{
   EpicEdge: ResolverTypeWrapper<Omit<EpicEdge, 'node'> & { node: ResolversTypes['Epic'] }>;
   EpicOrdering: EpicOrdering;
   EpicType: EpicType;
+  FeatureFlag: FeatureFlag;
   FiligranProduct: FiligranProduct;
   Filter: Filter;
   FilterKey: FilterKey;
@@ -3571,7 +3576,7 @@ export type ServiceLinkResolvers<ContextType = PortalContext, ParentType extends
 export type SettingsResolvers<ContextType = PortalContext, ParentType extends ResolversParentTypes['Settings'] = ResolversParentTypes['Settings']> = ResolversObject<{
   base_url_front?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   environment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  platform_feature_flags?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  platform_feature_flags?: Resolver<Array<ResolversTypes['FeatureFlag']>, ParentType, ContextType>;
   platform_providers?: Resolver<Array<ResolversTypes['PlatformProvider']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/apps/portal-api/src/modules/settings/settings.graphql
+++ b/apps/portal-api/src/modules/settings/settings.graphql
@@ -1,3 +1,7 @@
+enum FeatureFlag {
+  DUMMY
+}
+
 type PlatformProvider {
   name: String!
   type: String!
@@ -5,7 +9,7 @@ type PlatformProvider {
 }
 
 type Settings {
-  platform_feature_flags: [String!]!
+  platform_feature_flags: [FeatureFlag!]!
   platform_providers: [PlatformProvider!]!
   base_url_front: String!
   environment: String!

--- a/apps/portal-api/src/modules/settings/settings.resolver.ts
+++ b/apps/portal-api/src/modules/settings/settings.resolver.ts
@@ -1,26 +1,7 @@
 import config from 'config';
-import { FeatureFlag, Resolvers } from '../../__generated__/resolvers-types';
+import { Resolvers } from '../../__generated__/resolvers-types';
 import portalConfig from '../../config';
-import {logApp} from '../../utils/app-logger.util';
-
-const resolveFeatureFlags = (): FeatureFlag[] => {
-  const enabledFeatures = portalConfig.enabled_features;
-  const allFlags = Object.values(FeatureFlag);
-
-  if(enabledFeatures.includes('*')){
-    return allFlags;
-  }
-
-  return enabledFeatures.filter((feature): feature is FeatureFlag => {
-    const isValid = (allFlags as string[]).includes(feature);
-    if(!isValid) {
-      logApp.warn(
-        `[FEATURE-FLAG] Unknown feature flag in config: "${feature}"`
-      );
-    }
-    return isValid;
-  });
-};
+import { resolveFeatureFlags } from '../../utils/feature-flag.util';
 
 const resolvers: Resolvers = {
   Query: {
@@ -29,7 +10,7 @@ const resolvers: Resolvers = {
         platform_providers: config.get('login_settings'),
         base_url_front: config.get('base_url_front'),
         environment: config.get('environment'),
-        platform_feature_flags: resolveFeatureFlags(),
+        platform_feature_flags: resolveFeatureFlags(portalConfig.enabled_features),
       };
     },
   },

--- a/apps/portal-api/src/modules/settings/settings.resolver.ts
+++ b/apps/portal-api/src/modules/settings/settings.resolver.ts
@@ -1,6 +1,26 @@
 import config from 'config';
-import { Resolvers } from '../../__generated__/resolvers-types';
+import { FeatureFlag, Resolvers } from '../../__generated__/resolvers-types';
 import portalConfig from '../../config';
+import {logApp} from '../../utils/app-logger.util';
+
+const resolveFeatureFlags = (): FeatureFlag[] => {
+  const enabledFeatures = portalConfig.enabled_features;
+  const allFlags = Object.values(FeatureFlag);
+
+  if(enabledFeatures.includes('*')){
+    return allFlags;
+  }
+
+  return enabledFeatures.filter((feature): feature is FeatureFlag => {
+    const isValid = (allFlags as string[]).includes(feature);
+    if(!isValid) {
+      logApp.warn(
+        `[FEATURE-FLAG] Unknown feature flag in config: "${feature}"`
+      );
+    }
+    return isValid;
+  });
+};
 
 const resolvers: Resolvers = {
   Query: {
@@ -9,7 +29,7 @@ const resolvers: Resolvers = {
         platform_providers: config.get('login_settings'),
         base_url_front: config.get('base_url_front'),
         environment: config.get('environment'),
-        platform_feature_flags: portalConfig.enabled_features,
+        platform_feature_flags: resolveFeatureFlags(),
       };
     },
   },

--- a/apps/portal-api/src/utils/feature-flag.util.test.ts
+++ b/apps/portal-api/src/utils/feature-flag.util.test.ts
@@ -1,0 +1,89 @@
+import config from 'config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FeatureFlag } from '../__generated__/resolvers-types';
+import { isFeatureEnabled, resolveFeatureFlags } from './feature-flag.util';
+
+vi.mock('config', async (importOriginal) => {
+  const mod = await importOriginal<{ default: typeof config }>();
+  return {
+    default: {
+      get: vi.fn(mod.default.get.bind(mod.default)),
+      has: mod.default.has.bind(mod.default),
+    },
+  };
+});
+
+describe('resolveFeatureFlags', () => {
+  const allFlags = Object.values(FeatureFlag);
+
+  describe('wildcard handling', () => {
+    it('should return all flags when "*" is present', () => {
+      const result = resolveFeatureFlags(['*']);
+      expect(result).toEqual(allFlags);
+    });
+
+    it('should return all flags when "*" is mixed with other values', () => {
+      const result = resolveFeatureFlags(['*', 'DUMMY', 'INVALID']);
+      expect(result).toEqual(allFlags);
+    });
+  });
+
+  describe('flag validation', () => {
+    it.each`
+      enabledFeatures | expected               | description
+      ${['DUMMY']}    | ${[FeatureFlag.Dummy]} | ${'single valid flag'}
+      ${[]}           | ${[]}                  | ${'empty array'}
+      ${['INVALID']}  | ${[]}                  | ${'single invalid flag'}
+      ${['DUMM']}     | ${[]}                  | ${'typo in flag name'}
+      ${['dummy']}    | ${[]}                  | ${'lowercase flag name'}
+    `(
+      'should return $expected for $description',
+      ({ enabledFeatures, expected }) => {
+        expect(resolveFeatureFlags(enabledFeatures)).toEqual(expected);
+      }
+    );
+  });
+
+  describe('mixed valid and invalid flags', () => {
+    it('should keep valid flags and filter out invalid ones', () => {
+      const result = resolveFeatureFlags(['DUMMY', 'NONEXISTENT', 'TYPO']);
+      expect(result).toEqual([FeatureFlag.Dummy]);
+    });
+  });
+});
+
+describe('isFeatureEnabled', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when feature is enabled', () => {
+    it.each`
+      enabledFeatures       | description
+      ${['DUMMY']}          | ${'flag is explicitly listed'}
+      ${['DUMMY', 'OTHER']} | ${'flag is among multiple flags'}
+      ${['*']}              | ${'wildcard is present'}
+      ${['*', 'DUMMY']}     | ${'wildcard is mixed with flag'}
+    `('should return true when $description', ({ enabledFeatures }) => {
+      vi.mocked(config.get).mockReturnValue(enabledFeatures);
+      expect(isFeatureEnabled(FeatureFlag.Dummy)).toBe(true);
+    });
+  });
+
+  describe('when feature is not enabled', () => {
+    it.each`
+      enabledFeatures | description
+      ${[]}           | ${'list is empty'}
+      ${['OTHER']}    | ${'flag is not in list'}
+      ${undefined}    | ${'config returns undefined'}
+    `(
+      'should throw ForbiddenAccess when $description',
+      ({ enabledFeatures }) => {
+        vi.mocked(config.get).mockReturnValue(enabledFeatures);
+        expect(() => isFeatureEnabled(FeatureFlag.Dummy)).toThrow(
+          "Feature 'DUMMY' is not enabled."
+        );
+      }
+    );
+  });
+});

--- a/apps/portal-api/src/utils/feature-flag.util.ts
+++ b/apps/portal-api/src/utils/feature-flag.util.ts
@@ -1,6 +1,27 @@
 import config from 'config';
-import { FeatureFlag } from '../__generated__/resolvers-types'
+import { FeatureFlag } from '../__generated__/resolvers-types';
+import { logApp } from './app-logger.util';
 import { ForbiddenAccess } from './error/error.util';
+
+export const resolveFeatureFlags = (
+  enabledFeatures: string[]
+): FeatureFlag[] => {
+  const allFlags = Object.values(FeatureFlag);
+
+  if (enabledFeatures.includes('*')) {
+    return allFlags;
+  }
+
+  return enabledFeatures.filter((feature): feature is FeatureFlag => {
+    const isValid = (allFlags as string[]).includes(feature);
+    if (!isValid) {
+      logApp.warn(
+        `[FEATURE-FLAG] Unknown feature flag in config: "${feature}"`
+      );
+    }
+    return isValid;
+  });
+};
 
 export const isFeatureEnabled = (requiredFlag: FeatureFlag) => {
   const isEnabled = (config.get<string[]>('enabled_features') ?? []).some(

--- a/apps/portal-api/src/utils/feature-flag.util.ts
+++ b/apps/portal-api/src/utils/feature-flag.util.ts
@@ -1,7 +1,8 @@
 import config from 'config';
+import { FeatureFlag } from '../__generated__/resolvers-types'
 import { ForbiddenAccess } from './error/error.util';
 
-export const isFeatureEnabled = (requiredFlag: string) => {
+export const isFeatureEnabled = (requiredFlag: FeatureFlag) => {
   const isEnabled = (config.get<string[]>('enabled_features') ?? []).some(
     (flag) => ['*', requiredFlag].includes(flag)
   );

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -1099,6 +1099,10 @@ type ServiceInstanceSubscription {
   delete: ServiceInstance
 }
 
+enum FeatureFlag {
+  DUMMY
+}
+
 type PlatformProvider {
   name: String!
   type: String!
@@ -1106,7 +1110,7 @@ type PlatformProvider {
 }
 
 type Settings {
-  platform_feature_flags: [String!]!
+  platform_feature_flags: [FeatureFlag!]!
   platform_providers: [PlatformProvider!]!
   base_url_front: String!
   environment: String!

--- a/apps/portal-front/src/hooks/useIsFeatureEnabled.test.tsx
+++ b/apps/portal-front/src/hooks/useIsFeatureEnabled.test.tsx
@@ -4,7 +4,7 @@ import {
   SettingsProps,
 } from '@/components/settings/env-portal-context';
 import { useIsFeatureEnabled } from '@/hooks/useIsFeatureEnabled';
-import { FeatureFlag } from '@/utils/constant';
+import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
 import { settingsContext_fragment$data } from '@generated/settingsContext_fragment.graphql';
 import { renderHook } from '@testing-library/react';
 import { expect } from 'vitest';
@@ -21,8 +21,7 @@ describe('useIsFeatureEnabled', () => {
 
   it.each`
     expected | featureFlags
-    ${true}  | ${['*']}
-    ${true}  | ${[FeatureFlag.DUMMY]}
+    ${true}  | ${[FeatureFlagEnum.DUMMY]}
     ${false} | ${[]}
   `(
     'Should return $expected when enabled feature flags are $featureFlags',
@@ -32,7 +31,7 @@ describe('useIsFeatureEnabled', () => {
       } as Partial<settingsContext_fragment$data> as settingsContext_fragment$data;
 
       const { result } = renderHook(
-        () => useIsFeatureEnabled(FeatureFlag.DUMMY),
+        () => useIsFeatureEnabled(FeatureFlagEnum.DUMMY),
         { wrapper: createWrapper({ settings }) }
       );
 

--- a/apps/portal-front/src/hooks/useIsFeatureEnabled.ts
+++ b/apps/portal-front/src/hooks/useIsFeatureEnabled.ts
@@ -1,10 +1,10 @@
 import { SettingsContext } from '@/components/settings/env-portal-context';
-import { FeatureFlag } from '@/utils/constant';
+import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
 import { useContext } from 'react';
 
-export const useIsFeatureEnabled = (requiredFlag: FeatureFlag) => {
+export const useIsFeatureEnabled = (requiredFlag: FeatureFlagEnum) => {
   const { settings } = useContext(SettingsContext);
   return (settings?.platform_feature_flags ?? []).some((flag) =>
-    ['*', requiredFlag].includes(flag)
+    [requiredFlag as string].includes(flag)
   );
 };

--- a/apps/portal-front/src/utils/constant.ts
+++ b/apps/portal-front/src/utils/constant.ts
@@ -2,8 +2,3 @@ export const DEBOUNCE_TIME = 300;
 export const ANIMATION_TIME = 300;
 export const PLATFORM_ORGANIZATION_UUID =
   'ba091095-418f-4b4f-b150-6c9295e232c4';
-
-export enum FeatureFlag {
-  // dummy feature flag used for testing purposes
-  DUMMY = 'DUMMY',
-}

--- a/apps/portal-front/src/utils/settings.service.ts
+++ b/apps/portal-front/src/utils/settings.service.ts
@@ -1,18 +1,18 @@
 import serverPortalApiFetch from '@/relay/serverPortalApiFetch';
-import { FeatureFlag } from '@/utils/constant';
+import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
 import SettingsQuery, {
   settingsQuery,
   settingsQuery$data,
 } from '@generated/settingsQuery.graphql';
 
-let cachedFeatureFlags: FeatureFlag[];
+let cachedFeatureFlags: string[];
 
 export interface SettingsResponse {
   data: settingsQuery$data;
 }
 
 export async function isFeatureEnabled(
-  flagName: FeatureFlag
+  flagName: FeatureFlagEnum
 ): Promise<boolean> {
   if (cachedFeatureFlags === undefined) {
     try {
@@ -22,12 +22,12 @@ export async function isFeatureEnabled(
       >(SettingsQuery, {}, { cache: 'force-cache' })) as SettingsResponse;
       cachedFeatureFlags = [
         ...(response.data?.settings?.platform_feature_flags || []),
-      ] as FeatureFlag[];
+      ];
     } catch (error) {
       console.error('Failed to fetch feature flags:', error);
       cachedFeatureFlags = [];
     }
   }
 
-  return !!cachedFeatureFlags?.some((flag) => [flagName, '*'].includes(flag));
+  return !!cachedFeatureFlags?.some((flag) => [flagName as string].includes(flag));
 }


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Add a `FeatureFlag` GraphQL enum as the single source of truth for feature flags, replacing the manual TypeScript enum in the frontend and untyped strings in the backend.

**What changed:**

**Backend:**
- Added `enum FeatureFlag` in `settings.graphql` and changed `platform_feature_flags` type from `[String!]!` to `[FeatureFlag!]!`
- Extracted `resolveFeatureFlags()` into `feature-flag.util.ts` — validates config values against the enum, expands the `*` wildcard to all enum values, and logs unknown flags as warnings
- Typed the `isFeatureEnabled()` parameter from `string` to `FeatureFlag`
- Added unit tests for both `resolveFeatureFlags` and `isFeatureEnabled`

**Frontend:**
- Removed the manual `FeatureFlag` enum from `constant.ts`
- Migrated `useIsFeatureEnabled`, `settings.service.ts`, and tests to use the auto-generated `FeatureFlagEnum` from `@generated/models/FeatureFlag.enum`
- Removed wildcard `*` handling from frontend code since the backend now resolves it

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. Backend validation:
    - `cd apps/portal-api`
    - `yarn generate:ts` — verify `FeatureFlag` enum is in `src/__generated__/resolvers-types.ts`
    - `yarn check-ts` — should pass
    - `yarn test` — all tests pass, including new tests in `feature-flag.util.test.ts`
2. Frontend validation:
    - `cd apps/portal-front`
    - `yarn relay` — verify `__generated__/models/FeatureFlag.enum.ts` is created
    - `yarn check-ts` — should pass (no new errors introduced)
    - `yarn test` — all tests pass
3. Test wildcard resolution: set `"enabled_features": ["*"]` in `config/local.json`, start the backend, and verify the API returns all enum values instead of `"*"`
4. Test invalid flag logging: set `"enabled_features": ["TYPO"]` in `config/local.json`, start the backend, and verify a warning appears in the logs


## Related issues

- Related to #1678

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.

- The `*` wildcard in `enabled_features` config is now resolved server-side: the resolver expands it to all enum values. Frontend no longer handles `*`.
- Adding a new feature flag only requires adding a value to `enum FeatureFlag` in `settings.graphql` — both backend and frontend enums are auto-generated from there.
- `skip-feature-env` label is recommended since this is an internal refactoring with no UI changes.