### PR TITLE
[backend] test: automatically restore all mocks after each test (#2171)

### DIFF
--- a/apps/portal-api/src/modules/deployment/deployment.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/deployment.app.test.ts
@@ -89,10 +89,15 @@ import {
 import { DeploymentQuotaDomain } from './quota/deployment.quota.domain';
 
 describe('deployment app', () => {
-  const telemetrySpy = vi
-    .spyOn(telemetryApp, 'sendTelemetryEvent')
-    .mockResolvedValue();
-  const mockSendMail = vi.spyOn(mailService, 'sendMail');
+  let telemetrySpy: MockInstance;
+  let mockSendMail: MockInstance;
+
+  beforeEach(() => {
+    telemetrySpy = vi
+      .spyOn(telemetryApp, 'sendTelemetryEvent')
+      .mockResolvedValue();
+    mockSendMail = vi.spyOn(mailService, 'sendMail');
+  });
 
   afterEach(async () => {
     await DeploymentRequestDomain.deleteDeploymentRequestBy({});

--- a/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
+++ b/apps/portal-api/src/modules/deployment/group/service-group.app.test.ts
@@ -91,8 +91,6 @@ describe('serviceGroupApp', () => {
 
   describe('updateGroups', () => {
     afterEach(async () => {
-      vi.restoreAllMocks();
-
       for (const groupId of [
         adminGroupId,
         analystGroupId,
@@ -393,7 +391,6 @@ describe('serviceGroupApp', () => {
     });
 
     afterEach(async () => {
-      vi.restoreAllMocks();
       if (trackedServiceInstanceIds.length > 0) {
         for (const serviceInstanceId of trackedServiceInstanceIds) {
           await TestHelper.deploymentRequest.delete({

--- a/apps/portal-api/src/modules/document/document.app.test.ts
+++ b/apps/portal-api/src/modules/document/document.app.test.ts
@@ -105,7 +105,6 @@ describe('documentApp', () => {
 
   afterEach(async () => {
     await deleteDocuments();
-    vi.restoreAllMocks();
   });
 
   afterAll(async () => {

--- a/apps/portal-api/src/modules/document/document.helper.test.ts
+++ b/apps/portal-api/src/modules/document/document.helper.test.ts
@@ -66,7 +66,6 @@ describe('documentHelper', () => {
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
     await TestHelper.document.delete({});
   });
 
@@ -415,7 +414,6 @@ describe('documentHelper', () => {
     } as DocumentModel;
 
     beforeEach(() => {
-      vi.restoreAllMocks();
       vi.spyOn(MinIOClient, 'deleteFile').mockResolvedValue(undefined);
     });
 

--- a/apps/portal-api/src/modules/document/document.security.test.ts
+++ b/apps/portal-api/src/modules/document/document.security.test.ts
@@ -47,7 +47,6 @@ const mockServiceDefinition = (identifier: ServiceDefinitionIdentifier) => ({
 describe('document security', () => {
   describe('isUserRestrictedToActiveDocument', () => {
     beforeEach(() => {
-      vi.restoreAllMocks();
       vi.spyOn(access, 'isUserGranted').mockReturnValue(false);
       vi.spyOn(capabilityHelper, 'loadCapabilities').mockResolvedValue([]);
       vi.spyOn(

--- a/apps/portal-api/src/modules/document/document.test.ts
+++ b/apps/portal-api/src/modules/document/document.test.ts
@@ -1,6 +1,15 @@
 import { toGlobalId } from 'graphql-relay/node/node.js';
 import { Readable } from 'stream';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import {
   contextSimpleUserSecondOrga,
   requestContextSimpleUserSecondOrga,
@@ -250,7 +259,7 @@ describe('documents loading', () => {
 
 describe('increment shared counter', () => {
   const documentId = '117804d0-2e0e-42f0-b87c-019de622f605';
-  beforeAll(async () => {
+  beforeEach(async () => {
     const testContext = {
       user: requestContextSimpleUserSecondOrga.user,
       portalContext: {
@@ -287,7 +296,7 @@ describe('increment shared counter', () => {
     );
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await deleteDocuments();
     vi.useRealTimers();
   });

--- a/apps/portal-api/src/modules/document/domain/document.children.domain.test.ts
+++ b/apps/portal-api/src/modules/document/domain/document.children.domain.test.ts
@@ -76,8 +76,6 @@ describe('documentChildrenDomain', () => {
   afterEach(async () => {
     await TestHelper.documentChildren.delete({});
     await TestHelper.document.delete({});
-
-    vi.restoreAllMocks();
   });
 
   describe('deleteExternalImages', () => {

--- a/apps/portal-api/src/modules/document/domain/document.metadata.domain.test.ts
+++ b/apps/portal-api/src/modules/document/domain/document.metadata.domain.test.ts
@@ -1,5 +1,5 @@
 import { FileUpload } from 'graphql-upload/processRequest.mjs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestHelper } from '../../../../tests/helper/test.helper';
 import { TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
 import {
@@ -41,10 +41,6 @@ describe('documentMetadataDomain', () => {
     await TestHelper.document.delete({
       type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('loadMetadataValueByKey', () => {

--- a/apps/portal-api/src/modules/organization-management/users/user-organization/users.organization.app.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/user-organization/users.organization.app.test.ts
@@ -27,7 +27,6 @@ describe('usersOrganizationApp', () => {
 
     afterEach(async () => {
       portalConfig.enabled_emails = originalEnabledEmails;
-      vi.restoreAllMocks();
     });
 
     const mockLoadOrganizationsWithPendingUsers = (users: User[]) => {

--- a/apps/portal-api/src/modules/organization-management/users/user-profile/users.profile.app.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/user-profile/users.profile.app.test.ts
@@ -69,9 +69,6 @@ describe('user profile app', () => {
   });
 
   describe('requestTransferPersonalSpace', () => {
-    afterEach(async () => {
-      vi.restoreAllMocks();
-    });
     it('should send error if email is not valid format', async () => {
       await expect(
         usersProfileApp.requestTransferPersonalSpace(
@@ -130,7 +127,6 @@ describe('user profile app', () => {
       });
     });
     afterEach(async () => {
-      vi.restoreAllMocks();
       await deleteSubscription({
         id: newSubscription.id as SubscriptionId,
       });
@@ -182,7 +178,6 @@ describe('user profile app', () => {
 
   describe('uploadUserPicture', () => {
     afterEach(async () => {
-      vi.restoreAllMocks();
       await updateUser(TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID, {
         picture: null,
         picture_minio: null,

--- a/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.resolver.test.ts
@@ -273,9 +273,6 @@ describe('user mutation resolver', () => {
   });
 
   describe('adminAddUser', () => {
-    afterEach(async () => {
-      vi.restoreAllMocks();
-    });
     it('should not create an existing user', async () => {
       // Given
       try {

--- a/apps/portal-api/src/modules/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.test.ts
@@ -508,10 +508,6 @@ describe('registration app', () => {
       });
     });
 
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it('should throw an error when configuration for platform does not exist', async () => {
       loadConfigurationByPlatformSpy.mockReturnValue(Promise.resolve(null));
 

--- a/apps/portal-api/src/modules/registration/registration.domain.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.domain.test.ts
@@ -187,10 +187,6 @@ describe('registration domain', () => {
       );
     });
 
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it('should prevent refresh when user is not allowed on target organization', async () => {
       assertUserIsAllowedOnOrganizationSpy.mockReturnValue(
         Promise.reject('ERROR')

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.canUnregisterPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.canUnregisterPlatform.test.ts
@@ -1,6 +1,6 @@
 import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -17,10 +17,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('query.canUnregisterPlatform', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it.each`
     description        | organizationId                                      | expectedOrgGlobalId
     ${'with orgId'}    | ${TEST_ORGANIZATIONS.FILIGRAN.ID as OrganizationId} | ${toGlobalId('Organization', TEST_ORGANIZATIONS.FILIGRAN.ID)}

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.isPlatformRegistered.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.isPlatformRegistered.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -15,10 +15,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('query.isPlatformRegistered', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should return the response from registrationApp on success', async () => {
     // Given
     const input: IsPlatformRegisteredInput = { platformId: uuidv4() };

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -15,10 +15,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('query.platformAssociatedOrganization', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should return the organization returned by the app on success', async () => {
     // Given
     const platformId = uuidv4();

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshPlatformRegistrationConnectivityStatus.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshPlatformRegistrationConnectivityStatus.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -13,10 +13,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.refreshPlatformRegistrationConnectivityStatus', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it.each`
     status                                             | description
     ${PlatformRegistrationConnectivityStatus.Active}   | ${'active'}

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshUserPlatformToken.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.refreshUserPlatformToken.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -10,10 +10,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.refreshUserPlatformToken', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should call registrationApp.refreshUserPlatformToken with the context user id and return the token', async () => {
     // Given
     const newToken = uuidv4();

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
@@ -1,6 +1,6 @@
 import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -16,10 +16,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.registerPlatform', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should decode organizationId from global ID before calling registrationApp and return the token', async () => {
     // Given
     const rawOrgId = TEST_ORGANIZATIONS.FILIGRAN.ID;

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatform.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -18,10 +18,6 @@ vi.mock('../../../deployment/deployment.domain', () => ({
 }));
 
 describe('registeredPlatform type resolvers', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe('registeredPlatform.subscription', () => {
     it('should call loadSubscriptionByServiceInstanceAndOrganization with the organization id and instance id from parent', async () => {
       // Given

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.registeredPlatforms.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -14,10 +14,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('query.registeredPlatform', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should decode the service_instance_id from global ID and pass the raw UUID to registrationApp', async () => {
     // Given
     const rawId = uuidv4() as ServiceInstanceId;
@@ -41,10 +37,6 @@ describe('query.registeredPlatform', () => {
 });
 
 describe('query.registeredPlatforms', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should pass the input directly to registrationApp and return its result', async () => {
     // Given
     const input: RegisteredPlatformsInput = {

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.unregisterPlatform.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.unregisterPlatform.test.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   contextSimpleUserFiligran2,
   INFO,
@@ -13,10 +13,6 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.unregisterPlatform', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should call registrationApp.unregisterPlatform and return { success: true }', async () => {
     // Given
     const input: UnregisterPlatformInput = {

--- a/apps/portal-api/src/modules/service/definition/service-definition.resolver.test.ts
+++ b/apps/portal-api/src/modules/service/definition/service-definition.resolver.test.ts
@@ -12,7 +12,6 @@ import serviceDefinitionResolver from './service-definition.resolver';
 describe('serviceDefinition resolver fields', () => {
   afterEach(async () => {
     vi.clearAllTimers();
-    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
   describe('service_capability field resolver', () => {

--- a/apps/portal-api/src/modules/service/instance/service-instance.app.test.ts
+++ b/apps/portal-api/src/modules/service/instance/service-instance.app.test.ts
@@ -107,10 +107,6 @@ describe('service Instance app', () => {
       );
     });
 
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it('should load service instance when user already has access', async () => {
       // Given
       loadSubscriptionBySpy.mockResolvedValueOnce(mockSubscription);
@@ -395,15 +391,10 @@ describe('service Instance app', () => {
     });
 
     afterEach(async () => {
-      vi.restoreAllMocks();
       await TestHelper.serviceConfiguration.delete({});
       await TestHelper.subscription.delete({});
-      await TestHelper.serviceInstance.delete({
-        id: serviceInstance.id,
-      });
-      await TestHelper.serviceDefinition.delete({
-        id: serviceDefinition.id,
-      });
+      await TestHelper.serviceInstance.delete({ id: serviceInstance.id });
+      await TestHelper.serviceDefinition.delete({ id: serviceDefinition.id });
     });
 
     it('should update name, sync config title, dispatch, and return RegisteredPlatform', async () => {
@@ -781,9 +772,7 @@ describe('service Instance app', () => {
       await TestHelper.serviceInstance.delete({
         id: secondServiceInstancePublicId,
       });
-      await TestHelper.serviceInstance.delete({
-        id: privateServiceInstanceId,
-      });
+      await TestHelper.serviceInstance.delete({ id: privateServiceInstanceId });
       await TestHelper.document.delete({ id: logoId });
     });
     it('should return public service instances with document IDs converted to global IDs', async () => {
@@ -896,10 +885,6 @@ describe('service Instance app', () => {
       dispatchSpy = vi.spyOn(pub, 'dispatch');
       updateServiceInstanceSpy.mockResolvedValue(mockUpdatedServiceInstance);
       dispatchSpy.mockResolvedValue(undefined);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     it('should upload a logo, update the service instance, and dispatch an edit event', async () => {

--- a/apps/portal-api/src/modules/service/instance/service-instance.domain.test.ts
+++ b/apps/portal-api/src/modules/service/instance/service-instance.domain.test.ts
@@ -56,12 +56,8 @@ describe('service instance domain', () => {
   describe('loadServiceInstancesByServiceDefinitionAndTags', () => {
     // Happy path
     afterAll(async () => {
-      await TestHelper.serviceInstance.delete({
-        name: 'ServiceInstance 1',
-      });
-      await TestHelper.serviceInstance.delete({
-        name: 'One serviceInstance',
-      });
+      await TestHelper.serviceInstance.delete({ name: 'ServiceInstance 1' });
+      await TestHelper.serviceInstance.delete({ name: 'One serviceInstance' });
     });
     it('should return service instances linked to service definition and with tags', async () => {
       // When
@@ -246,9 +242,7 @@ describe('service instance domain', () => {
 
     afterAll(async () => {
       await TestHelper.serviceInstance.delete({ name: 'Original Name' });
-      await TestHelper.serviceInstance.delete({
-        name: 'Only Name Updated',
-      });
+      await TestHelper.serviceInstance.delete({ name: 'Only Name Updated' });
     });
 
     it('should update only provided fields', async () => {
@@ -466,8 +460,6 @@ describe('service instance domain', () => {
     });
 
     afterEach(async () => {
-      vi.restoreAllMocks();
-
       await TestHelper.user_Service.delete({
         user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
       });
@@ -824,12 +816,8 @@ describe('service instance domain', () => {
     });
 
     afterAll(async () => {
-      await TestHelper.serviceInstance.delete({
-        id: publicServiceInstanceId,
-      });
-      await TestHelper.serviceInstance.delete({
-        id: privateServiceInstanceId,
-      });
+      await TestHelper.serviceInstance.delete({ id: publicServiceInstanceId });
+      await TestHelper.serviceInstance.delete({ id: privateServiceInstanceId });
     });
 
     it('should return only public service instances', async () => {

--- a/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
+++ b/apps/portal-api/src/modules/telemetry/telemetry.app.test.ts
@@ -506,6 +506,5 @@ describe('telemetryApp', () => {
 
   afterEach(async () => {
     vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 });

--- a/apps/portal-api/src/modules/user-service/user-service.domain.test.ts
+++ b/apps/portal-api/src/modules/user-service/user-service.domain.test.ts
@@ -160,10 +160,6 @@ describe('userServiceDomain', () => {
       vi.spyOn(mailService, 'sendMail').mockResolvedValue(undefined);
     });
 
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     const getSubscription = async () => {
       const allSubscriptions = await TestHelper.subscription.loadAll({
         id: sub.id,
@@ -453,7 +449,6 @@ describe('userServiceDomain', () => {
     });
 
     afterEach(async () => {
-      vi.restoreAllMocks();
       for (const subId of createdSubscriptionIds) {
         await cleanupUserServices(subId);
         await TestHelper.subscription.delete({ id: subId });

--- a/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.test.ts
+++ b/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.test.ts
@@ -47,7 +47,6 @@ describe('epicApp', () => {
     // Clean up the Document and Epic tables before each test
     await TestHelper.epic.delete({});
     await TestHelper.document.delete({ file_name: 'epic-image.png' });
-    vi.restoreAllMocks();
   });
 
   describe('createEpic', () => {

--- a/apps/portal-api/src/security/directive-graphql/directive-auth.helper.test.ts
+++ b/apps/portal-api/src/security/directive-graphql/directive-auth.helper.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   CAPABILITY_MODIFY_TRIALS,
   CAPABILITY_READ_TRIALS,
@@ -85,10 +85,6 @@ describe('auth directives', () => {
   });
 
   describe('hasServiceCapability', () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it.each`
       description                                             | expected | expectedError                                                                                                | isUserBypass | isUserOrganizationAdmin | areIdsMissing | hasRequiredCapabilities
       ${'allow bypass user'}                                  | ${true}  | ${null}                                                                                                      | ${true}      | ${false}                | ${false}      | ${false}

--- a/apps/portal-api/src/security/guard.test.ts
+++ b/apps/portal-api/src/security/guard.test.ts
@@ -1,5 +1,5 @@
 import { MockInstance } from '@vitest/spy';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
@@ -19,10 +19,6 @@ describe('security Guard', () => {
       authHelper,
       'isUserAllowedOnOrganization'
     );
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('assertUserIsAllowedOnOrganization', () => {

--- a/apps/portal-api/src/server/mail-service.helper.test.ts
+++ b/apps/portal-api/src/server/mail-service.helper.test.ts
@@ -192,10 +192,6 @@ describe('renderEmail', () => {
     });
   });
   describe('sendMail', () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it('should enqueue a job via PgBossProducer when queue processing is enabled', async () => {
       vi.mocked(config.get).mockReturnValue(true);
 

--- a/apps/portal-api/src/thirdparty/hubspot/hubspot.test.ts
+++ b/apps/portal-api/src/thirdparty/hubspot/hubspot.test.ts
@@ -48,7 +48,6 @@ describe('hubspot', () => {
 
   afterEach(async () => {
     await TestHelper.deploymentRequest.delete({});
-    vi.restoreAllMocks();
   });
 
   describe('reachOutSales (direct sending)', () => {

--- a/apps/portal-api/src/thirdparty/pgboss/producer.test.ts
+++ b/apps/portal-api/src/thirdparty/pgboss/producer.test.ts
@@ -2,7 +2,6 @@ import { PgBoss, type JobSpyInterface } from 'pg-boss';
 import {
   afterAll,
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -22,7 +21,7 @@ describe('pgBossProducer – transactional enqueue (integration)', () => {
   const TEST_SCHEMA = 'pgboss_producer_test';
   const TEST_QUEUE = 'producer_txn_test';
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const { host, port, user, password, database } = portalConfig.database;
 
     boss = new PgBoss({
@@ -51,7 +50,6 @@ describe('pgBossProducer – transactional enqueue (integration)', () => {
   });
 
   afterAll(async () => {
-    vi.restoreAllMocks();
     if (boss) {
       await boss.stop({ graceful: true, timeout: 2_000 });
     }

--- a/apps/portal-api/src/utils/extract-referer.util.test.ts
+++ b/apps/portal-api/src/utils/extract-referer.util.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logApp } from './app-logger.util';
 import {
   resolveSessionReferer,
@@ -8,10 +8,6 @@ import {
 describe('toSafeRedirectPath', () => {
   beforeEach(() => {
     vi.spyOn(logApp, 'warn').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('relative paths', () => {
@@ -106,10 +102,6 @@ describe('resolveSessionReferer', () => {
   beforeEach(() => {
     vi.spyOn(logApp, 'warn').mockImplementation(() => {});
     vi.spyOn(logApp, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it('returns undefined for empty string', () => {

--- a/apps/portal-api/src/utils/feature-flag.util.test.ts
+++ b/apps/portal-api/src/utils/feature-flag.util.test.ts
@@ -1,5 +1,5 @@
 import config from 'config';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FeatureFlag } from '../__generated__/resolvers-types';
 import { isFeatureEnabled, resolveFeatureFlags } from './feature-flag.util';
 
@@ -53,10 +53,6 @@ describe('resolveFeatureFlags', () => {
 });
 
 describe('isFeatureEnabled', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe('when feature is enabled', () => {
     it.each`
       enabledFeatures       | description

--- a/apps/portal-api/tests/setup-test.ts
+++ b/apps/portal-api/tests/setup-test.ts
@@ -87,13 +87,13 @@ function mockRequestContext() {
 
 beforeEach(() => {
   // Set fresh context for each test
+  mockRequestContext();
+
   const testKey = getCurrentTestKey();
   testRequestStorage.set(testKey, { ...requestContextSimpleUserFiligran2 });
 });
 
 beforeAll(async ({}, suite) => {
-  mockRequestContext();
-
   const currentFile = suite?.file?.name;
   if (isUtilOrHelper(currentFile)) {
     console.log('⚠️ Did not clean', currentFile);

--- a/apps/portal-api/tests/setup-test.ts
+++ b/apps/portal-api/tests/setup-test.ts
@@ -1,4 +1,4 @@
-import { beforeAll } from 'vitest';
+import { afterEach, beforeAll } from 'vitest';
 import { requestContext, RequestContext } from '../src/context/request.context';
 import { closeDbTestConnection, getDbTestConnection } from './config-test';
 import { requestContextSimpleUserFiligran2 } from './tests.const';
@@ -132,6 +132,10 @@ beforeAll(async ({}, suite) => {
     throw error;
   }
 }, 60000);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 process.on('SIGINT', async () => {
   await closeDbTestConnection();

--- a/apps/portal-api/vitest.config.ts
+++ b/apps/portal-api/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     fileParallelism: false,
     coverage: {
       provider: 'v8',
-      include: ['./**'],
+      include: ['./**/*.ts'],
       exclude: [
         'builder/**',
         'src/__generated__/**',


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Instead of having to add `vi.restoreAllMocks` in after each in test files, this PR adds it globally.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Nothing to manually test, only automated tests update

## Related issues

- Related to #2171 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.