### PR TITLE
[frontend] fix(form): Fix mouse wheel scroll in service form dropdowns (#2132)

### DIFF
--- a/apps/portal-front/package.json
+++ b/apps/portal-front/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@filigran/icon": "0.22.6",
-    "@filigran/ui": "1.0.6",
+    "@filigran/ui": "1.0.7",
     "@hookform/resolvers": "5.2.2",
     "@svgr/webpack": "8.1.0",
     "@tailwindcss/postcss": "4.2.2",

--- a/apps/portal-front/src/components/ui/select-users.tsx
+++ b/apps/portal-front/src/components/ui/select-users.tsx
@@ -306,7 +306,11 @@ const SelectUsersFormField = React.forwardRef<
               placeholder="Search user..."
               onKeyDown={handleInputKeyDown}
             />
-            <CommandList>
+            <CommandList
+              onWheel={(e) => {
+                e.currentTarget.scrollTop += e.deltaY;
+                e.stopPropagation();
+              }}>
               <CommandEmpty>{t('Utils.NotFound')}</CommandEmpty>
               <CommandGroup>
                 {users.map((option) => {

--- a/apps/portal-front/src/components/ui/select-users.tsx
+++ b/apps/portal-front/src/components/ui/select-users.tsx
@@ -261,17 +261,26 @@ const SelectUsersFormField = React.forwardRef<
                   )}
                 </div>
                 <div className="flex items-center shrink-0">
-                  <button
-                    type="button"
+                  <span
+                    role="button"
+                    tabIndex={0}
                     className="flex items-center justify-center"
                     onClick={(event) => {
+                      event.stopPropagation();
                       setSelectedValues([]);
                       onValueChange('');
-                      event.stopPropagation();
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setSelectedValues([]);
+                        onValueChange('');
+                      }
                     }}
                     aria-label="Clear all selections">
                     <CloseIcon className="mx-s h-3 cursor-pointer text-muted-foreground" />
-                  </button>
+                  </span>
                   <Separator
                     orientation="vertical"
                     className="h-6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3284,9 +3284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/ui@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@filigran/ui@npm:1.0.6"
+"@filigran/ui@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@filigran/ui@npm:1.0.7"
   dependencies:
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/modifiers": "npm:9.0.0"
@@ -3329,7 +3329,7 @@ __metadata:
     react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0
     react-hook-form: ^7.68.0
     zod: ^4.1.13
-  checksum: 10/75a0459f73f6aa089b3d1524d1110d377a636ee42a0066a57baea33033bab5fa07dad89637d94801c244675d1be4b5fcd67fc8ccf27006202686e4e3fdf10a97
+  checksum: 10/d814f4566c7c5e898f1090fe39824b93f7156a04901067e2332e66200c2cda46c08f600b3bafe50230a9a3f2c1502098188707f08e4d56b42d1d01b534601f7f
   languageName: node
   linkType: hard
 
@@ -9051,7 +9051,7 @@ __metadata:
   resolution: "@xtm-hub/portal-front@workspace:apps/portal-front"
   dependencies:
     "@filigran/icon": "npm:0.22.6"
-    "@filigran/ui": "npm:1.0.6"
+    "@filigran/ui": "npm:1.0.7"
     "@hookform/resolvers": "npm:5.2.2"
     "@svgr/webpack": "npm:8.1.0"
     "@tailwindcss/postcss": "npm:4.2.2"


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Mouse wheel and trackpad scroll is broken inside dropdown lists in service creation drawers (RSS Feed, Scenario, Dashboard, Integration). Users can only navigate using keyboard arrows or by typing to filter.

**Root cause**: The `wheel` event is intercepted in the `Sheet > Popover > cmdk` component chain, preventing native browser scroll from reaching the scrollable `CommandList`.

**This PR includes 3 changes:**

1. **Bump `@filigran/ui` to 1.0.7** — includes two upstream fixes:
    - `onWheel` handler on `CommandList` in `MultiSelectFormField` → fixes scroll on **Use cases** dropdown
    - Button nesting fix (`<button>` replaced by `<span role="button">`) → fixes hydration warning

2. **Fix `SelectUsersFormField` scroll** (`select-users.tsx`) — same `onWheel` handler applied to the local clone of `MultiSelectFormField` → fixes scroll on **Author** dropdown

3. **Fix button nesting in `SelectUsersFormField`** (`select-users.tsx`) — same `<button>` → `<span role="button">` fix applied to the "Clear all selections" button nested inside the `PopoverTrigger`


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. Go to any service library (OpenCTI Integrations, OpenAEV Scenarios, Custom Dashboards)
2. Click "Add new" to open a creation drawer
3. Open the **Use cases** dropdown → scroll with mouse wheel or trackpad → should scroll smoothly
4. Open the **Author** dropdown → scroll with mouse wheel or trackpad → should scroll smoothly
5. Select some values, then click the **X** (Clear) button → should clear the selection
6. Open browser DevTools Console → no `<button> cannot be a descendant of <button>` warning


## Related issues

- Related to #2132
- Related to #1748

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.

- Upstream PRs on filigran-ui: [#246 (onWheel fix)](https://github.com/FiligranHQ/filigran-ui/pull/246), [#247 (button nesting fix)](https://github.com/FiligranHQ/filigran-ui/pull/247)
- `SelectUsersFormField` is a local clone of `MultiSelectFormField` from `@filigran/ui`, adapted for Relay user search. Both fixes had to be applied in both places. This duplication is a candidate for future refactoring (generalizing the lib component for async data sources).