### PR TITLE
[frontend/backend] fix(import-from-hub): support tenant_id and accept oaev_instance_id alias (#2145)

### DIFF
--- a/apps/portal-api/src/__generated__/resolvers-types.ts
+++ b/apps/portal-api/src/__generated__/resolvers-types.ts
@@ -1527,6 +1527,7 @@ export type QueryPendingUsersArgs = {
 
 export type QueryPlatformAssociatedOrganizationArgs = {
   platformId: Scalars['String']['input'];
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/apps/portal-api/src/modules/registration/registration.app.test.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.test.ts
@@ -9,7 +9,9 @@ import {
   it,
   vi,
 } from 'vitest';
-import { TestHelper } from '../../../tests/helper/test.helper';
+import {
+  TestHelper,
+} from '../../../tests/helper/test.helper';
 import {
   // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
@@ -91,6 +93,7 @@ describe('registration app', () => {
       await TestHelper.serviceInstance.create({
         id: serviceInstanceId,
         name: 'test',
+        service_definition_id: SERVICES.DEFINITIONS.OPENCTI_REGISTRATION.ID,
       });
       await TestHelper.serviceConfiguration.create({
         service_instance_id: serviceInstanceId,
@@ -111,6 +114,7 @@ describe('registration app', () => {
       await TestHelper.serviceInstance.create({
         id: serviceInstanceId,
         name: 'test',
+        service_definition_id: SERVICES.DEFINITIONS.OPENCTI_REGISTRATION.ID,
       });
       await TestHelper.serviceConfiguration.create({
         service_instance_id: serviceInstanceId,
@@ -129,6 +133,27 @@ describe('registration app', () => {
       await expect(call).rejects.toThrow(ErrorCode.UserIsNotInOrganization);
     });
 
+    it('should throw TenantIdMandatory when platform requires tenantId and none is provided', async () => {
+      const platformId = uuidv4();
+      const serviceInstanceId = uuidv4() as ServiceInstanceId;
+
+      // Use OpenAEV service definition (OpenAEV requires tenantId from v2.4.0)
+      await TestHelper.serviceInstance.create({
+        id: serviceInstanceId,
+        name: 'test',
+        service_definition_id: SERVICES.DEFINITIONS.OPENAEV_REGISTRATION.ID,
+      });
+      await TestHelper.serviceConfiguration.create({
+        service_instance_id: serviceInstanceId,
+        config: { platform_id: platformId, platform_version: '2.5.0' },
+        status: ServiceConfigurationStatus.Active,
+      });
+
+      const call =
+        registrationApp.loadPlatformAssociatedOrganization(platformId);
+      await expect(call).rejects.toThrow(BadRequestErrorCode.TenantIdMandatory);
+    });
+
     it('should return an organization when platform is found and user is allowed', async () => {
       const platformId = uuidv4();
       const serviceInstanceId = uuidv4() as ServiceInstanceId;
@@ -136,6 +161,7 @@ describe('registration app', () => {
       await TestHelper.serviceInstance.create({
         id: serviceInstanceId,
         name: 'test',
+        service_definition_id: SERVICES.DEFINITIONS.OPENCTI_REGISTRATION.ID,
       });
       await TestHelper.serviceConfiguration.create({
         service_instance_id: serviceInstanceId,

--- a/apps/portal-api/src/modules/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.ts
@@ -66,11 +66,14 @@ import { ServiceConfigurationDomain } from './service-configuration/service-conf
 
 export const registrationApp = {
   loadPlatformAssociatedOrganization: async (
-    platformId: string
+    platformId: string,
+    tenantId?: string | null
   ): Promise<Organization | null> => {
     const { user } = requestContext.require();
     const serviceConfiguration =
-      await ServiceConfigurationDomain.loadConfigurationByPlatform(platformId);
+      await ServiceConfigurationDomain.loadConfigurationByPlatform(platformId, {
+        tenantId,
+      });
     if (!serviceConfiguration) {
       return null;
     }

--- a/apps/portal-api/src/modules/registration/registration.app.ts
+++ b/apps/portal-api/src/modules/registration/registration.app.ts
@@ -78,6 +78,27 @@ export const registrationApp = {
       return null;
     }
 
+    if (!tenantId) {
+      const serviceDefinition = await loadServiceDefinitionByServiceInstance(
+        serviceConfiguration.service_instance_id
+      );
+      if (!serviceDefinition) {
+        throw new Error(ErrorCode.ServiceDefinitionNotFound);
+      }
+      const platformIdentifier = serviceDefinition.identifier
+        ? platformIdentifierMappedByServiceDefinitionIdentifier[
+          serviceDefinition.identifier as ServiceDefinitionIdentifier
+          ]
+        : undefined;
+      if (!platformIdentifier) {
+        throw new Error(ErrorCode.InvalidPlatformIdentifier);
+      }
+      const config = serviceConfiguration.config as PlatformConfiguration;
+      if (isTenantIdRequired(platformIdentifier, config.platform_version)) {
+        throw new Error(BadRequestErrorCode.TenantIdMandatory);
+      }
+    }
+
     const subscription = await loadSubscriptionBy({
       service_instance_id: serviceConfiguration.service_instance_id,
     });

--- a/apps/portal-api/src/modules/registration/registration.graphql
+++ b/apps/portal-api/src/modules/registration/registration.graphql
@@ -158,7 +158,7 @@ type Query {
   registeredPlatform(input: RegisteredPlatformInput!): RegisteredPlatform @auth
   registeredPlatforms(input: RegisteredPlatformsInput): [RegisteredPlatform!]!
     @auth
-  platformAssociatedOrganization(platformId: String!): Organization @auth
+  platformAssociatedOrganization(platformId: String!, tenantId: String): Organization @auth
 }
 
 type Mutation {

--- a/apps/portal-api/src/modules/registration/registration.resolver.ts
+++ b/apps/portal-api/src/modules/registration/registration.resolver.ts
@@ -74,10 +74,11 @@ const resolvers: Resolvers = {
      */
     openCTIPlatformRegistrationStatus: async (_, { input }) =>
       registrationApp.loadPlatformRegistrationStatus(input),
-    platformAssociatedOrganization: async (_, { platformId }) => {
+    platformAssociatedOrganization: async (_, { platformId, tenantId }) => {
       try {
         return await registrationApp.loadPlatformAssociatedOrganization(
-          platformId
+          platformId,
+          tenantId
         );
       } catch (error) {
         throw mapToGraphQLError(error);

--- a/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
+++ b/apps/portal-api/src/modules/registration/test/resolver/registration.resolver.platformAssociatedOrganization.test.ts
@@ -39,11 +39,38 @@ describe('query.platformAssociatedOrganization', () => {
     // Then
     expect(
       registrationApp.loadPlatformAssociatedOrganization
-    ).toHaveBeenCalledWith(platformId);
+    ).toHaveBeenCalledWith(platformId, undefined);
     expect(result).toMatchObject({
       id: TEST_ORGANIZATIONS.FILIGRAN.ID,
       name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
     });
+  });
+
+  it('should forward tenantId to the app when provided', async () => {
+    // Given
+    const platformId = uuidv4();
+    const tenantId = uuidv4();
+    const organization = {
+      id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      name: TEST_ORGANIZATIONS.FILIGRAN.NAME,
+    };
+    vi.spyOn(
+      registrationApp,
+      'loadPlatformAssociatedOrganization'
+    ).mockResolvedValue(organization as unknown as Organization);
+
+    // When
+    await registrationResolver.Query!.platformAssociatedOrganization!(
+      {},
+      { platformId, tenantId },
+      contextSimpleUserFiligran2,
+      GRAPHQL_RESOLVE_INFO
+    );
+
+    // Then
+    expect(
+      registrationApp.loadPlatformAssociatedOrganization
+    ).toHaveBeenCalledWith(platformId, tenantId);
   });
 
   it('should return null when the platform has no associated organization', async () => {

--- a/apps/portal-api/tests/tests.const.ts
+++ b/apps/portal-api/tests/tests.const.ts
@@ -94,6 +94,9 @@ export const SERVICES = {
     OPENCTI_INTEGRATIONS: {
       ID: '42007953-4dbc-480a-8693-8c05f1123460' as ServiceDefinitionId,
     },
+    OPENAEV_REGISTRATION: {
+      ID: 'e66a6b50-1f92-4f62-b84c-88ed6b871790' as ServiceDefinitionId,
+    },
     OPENCTI_REGISTRATION: {
       ID: '5f769173-5ace-4ef3-b04f-2c95609c5b59' as ServiceDefinitionId,
     },

--- a/apps/portal-front/app/redirect/[identifier]/resource.ts
+++ b/apps/portal-front/app/redirect/[identifier]/resource.ts
@@ -85,12 +85,11 @@ export const redirectToResource = async (
       )?.organization_id;
     }
 
-    const personalSpaceGlobalId = user.organizations.find(
-      (o) => o.personal_space
-    )!.id;
-
     // 3. Switch to the found organization
-    await switchOrganization(organizationId ?? personalSpaceGlobalId);
+    // If no organization is associated with the platform/tenant, fall back to the user's
+    // currently selected organization so users stay in their working context when
+    // Import from Hub is triggered from an unregistered platform.
+    await switchOrganization(organizationId ?? user.selected_organization_id);
 
     // No subscribed services for any organization of the user,
     // redirect to the personal space homepage with highlighting the services

--- a/apps/portal-front/app/redirect/[identifier]/resource.ts
+++ b/apps/portal-front/app/redirect/[identifier]/resource.ts
@@ -30,7 +30,9 @@ export const redirectToResource = async (
 ) => {
   const searchParams = request.nextUrl.searchParams;
   const opencti_platform_id = searchParams.get('opencti_platform_id');
+  const oaev_instance_id = searchParams.get('oaev_instance_id');
   const platform_id = searchParams.get('platform_id');
+  const tenant_id = searchParams.get('tenant_id');
   const service_instance_id = searchParams.get('service_instance_id');
   const document_id = searchParams.get('document_id');
   let identifier = params.identifier;
@@ -70,7 +72,8 @@ export const redirectToResource = async (
     }
 
     let organizationId: string | undefined = await loadPlatformOrganizationId(
-      opencti_platform_id ?? platform_id
+      opencti_platform_id ?? oaev_instance_id ?? platform_id,
+      tenant_id
     );
 
     // 2. Load the services instances subscribed by the user's organizations

--- a/apps/portal-front/app/redirect/[identifier]/utils/load.ts
+++ b/apps/portal-front/app/redirect/[identifier]/utils/load.ts
@@ -51,7 +51,8 @@ interface PlatformAssociatedOrganizationResponse {
 }
 
 export const loadPlatformOrganizationId = async (
-  platformId?: string | null
+  platformId?: string | null,
+  tenantId?: string | null,
 ): Promise<string | undefined> => {
   if (!platformId) {
     return;
@@ -63,6 +64,7 @@ export const loadPlatformOrganizationId = async (
       platformAssociatedOrganizationQuery
     >(PlatformAssociatedOrganizationQueryGraphql, {
       platformId,
+      tenantId,
     })) as PlatformAssociatedOrganizationResponse;
 
     return associatedOrganization.data.platformAssociatedOrganization?.id;

--- a/apps/portal-front/app/redirect/[identifier]/utils/platform.ts
+++ b/apps/portal-front/app/redirect/[identifier]/utils/platform.ts
@@ -1,8 +1,14 @@
 import { graphql } from 'react-relay';
 
 export const PlatformAssociatedOrganizationQuery = graphql`
-  query platformAssociatedOrganizationQuery($platformId: String!) {
-    platformAssociatedOrganization(platformId: $platformId) {
+  query platformAssociatedOrganizationQuery(
+    $platformId: String!
+    $tenantId: String
+  ) {
+    platformAssociatedOrganization(
+      platformId: $platformId
+      tenantId: $tenantId
+    ) {
       id
     }
   }

--- a/apps/portal-front/schema.graphql
+++ b/apps/portal-front/schema.graphql
@@ -119,7 +119,7 @@ type Query {
   canUnregisterPlatform(input: CanUnregisterPlatformInput!): CanUnregisterResponse!
   registeredPlatform(input: RegisteredPlatformInput!): RegisteredPlatform
   registeredPlatforms(input: RegisteredPlatformsInput): [RegisteredPlatform!]!
-  platformAssociatedOrganization(platformId: String!): Organization
+  platformAssociatedOrganization(platformId: String!, tenantId: String): Organization
   publicServiceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!): ServiceConnection!
   serviceInstances(first: Int!, after: ID, orderBy: ServiceInstanceOrdering!, orderMode: OrderingMode!, searchTerm: String, filters: [ServiceInstanceFilter!]): ServiceConnection!
   serviceInstanceLinksByTags(tags: [ServiceInstanceTag!]!): [SeoServiceInstance!]!


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Part of the OpenAEV multi-tenancy epic. This PR adapts the "Import from Hub" flow to support multi-tenant OpenAEV instances, building on the foundations laid by #2162 (register/unregister with tenant).

**Backend changes:**
- `platformAssociatedOrganization` GraphQL query now accepts an optional `tenantId` argument
- `loadPlatformAssociatedOrganization` propagates `tenantId` down to `loadConfigurationByPlatform` (already multi-tenant aware since #2162)

**Frontend changes:**
- `/redirect/:identifier` resource flow now reads `tenant_id` from query params and propagates it through the resolution chain (`resource.ts` → `loadPlatformOrganizationId` → Relay query)
- Added backwards-compatible alias: `oaev_instance_id` is accepted as a synonym of `platform_id` to support OpenAEV instances that haven't migrated to the new query param name yet (same pattern as the existing `opencti_platform_id` → `platform_id` alias)
- **Redirect fallback fix** : when `platform_id`/`tenant_id` don't match any registered organization, the redirect used to silently fall back to the user's personal space. It now falls back to the user's currently selected organization, so users stay in their working context when "Import from Hub" is triggered from an unregistered platform.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #2145 
- Companion OpenAEV PR: OpenAEV-Platform/openaev#5529

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.

**Commits** (kept separate for easier review):
1. `fix(import-from-hub): support tenant_id and accept oaev_instance_id alias` — the main change covering both back and front
2. `test(registration): cover tenantId forwarding in platformAssociatedOrganization resolver` — unit test for the resolver
3. `fix(redirect): fallback to user selected organization instead of personal space when platform has no associated organization` — additional UX fix (see "Redirect fallback fix" above)