### PR TITLE
[backend] fix(Roadmap): Fix service capabilities (#2219)

### DIFF
--- a/apps/portal-api/src/modules/user-service/user-service.domain.ts
+++ b/apps/portal-api/src/modules/user-service/user-service.domain.ts
@@ -358,7 +358,7 @@ export const UserServiceDomain = {
       .first();
   },
 
-  loadUserServiceCapability: async (
+  loadUserServiceGenericCapability: async (
     userId: UserId,
     subscriptionId: SubscriptionId,
     capability: GenericServiceCapabilityName

--- a/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.test.ts
+++ b/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.test.ts
@@ -18,6 +18,22 @@ import { DocumentApp } from '../document/document.app';
 import * as DocumentUploadsHelper from '../document/document.uploads.helper';
 import { DocumentDomain } from '../document/domain/document.domain';
 import * as ServiceInstanceDomain from '../service/instance/service-instance.domain';
+
+const guardMock = vi.hoisted(() => ({
+  assertUserHasCapaOnService: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../security/guard', async () => {
+  const actual = await vi.importActual<typeof import('../../security/guard')>(
+    '../../security/guard'
+  );
+
+  return {
+    ...actual,
+    assertUserHasCapaOnService: guardMock.assertUserHasCapaOnService,
+  };
+});
+
 import { EpicApp } from './epic.app';
 import { EpicDomain } from './epic.domain';
 
@@ -38,6 +54,8 @@ describe('epicApp', () => {
   };
 
   beforeEach(async () => {
+    guardMock.assertUserHasCapaOnService.mockResolvedValue(undefined);
+
     vi.spyOn(DocumentUploadsHelper, 'processUploads').mockResolvedValue([
       minioFileMock,
     ]);

--- a/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.ts
+++ b/apps/portal-api/src/modules/xtm-suite-roadmap/epic.app.ts
@@ -5,18 +5,23 @@ import {
   EpicType,
   QueryEpicsArgs,
   ServiceDefinitionIdentifier,
+  ServiceRestriction,
   UpdateEpicInput,
 } from '../../__generated__/resolvers-types';
 import portalConfig from '../../config';
 import { requestContext } from '../../context/request.context';
 import Epic, { EpicId } from '../../model/kanel/public/Epic';
 import User from '../../model/kanel/public/User';
+import { assertUserHasCapaOnService } from '../../security/guard';
 import { sendMail } from '../../server/mail-service';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 import { processUploads, Upload } from '../document/document.uploads.helper';
 import { DocumentDomain } from '../document/domain/document.domain';
-import { loadSubscribedServiceInstancesByIdentifier } from '../service/instance/service-instance.domain';
+import {
+  loadServiceInstanceBy,
+  loadSubscribedServiceInstancesByIdentifier,
+} from '../service/instance/service-instance.domain';
 import { EpicDomain } from './epic.domain';
 
 const addImage = async (user: User, uploads: Upload[]) => {
@@ -59,6 +64,15 @@ export const EpicApp = {
   ): Promise<Epic> => {
     const { user } = requestContext.require();
 
+    const serviceInstance = await loadServiceInstanceBy(
+      'slug',
+      'xtm-suite-roadmap'
+    );
+
+    await assertUserHasCapaOnService(user, serviceInstance.id, [
+      ServiceRestriction.Upsert,
+    ]);
+
     const { is_integration, ...restInput } = input;
     const createdDocument = await addImage(user, uploads);
 
@@ -74,6 +88,14 @@ export const EpicApp = {
   },
   updateEpic: async (id: EpicId, input: UpdateEpicInput, uploads: Upload[]) => {
     const { user } = requestContext.require();
+
+    const serviceInstance = await loadServiceInstanceBy(
+      'slug',
+      'xtm-suite-roadmap'
+    );
+    await assertUserHasCapaOnService(user, serviceInstance.id, [
+      ServiceRestriction.Upsert,
+    ]);
 
     const { is_integration, ...restInput } = input;
 
@@ -107,6 +129,17 @@ export const EpicApp = {
   },
 
   deleteEpic: async (id: EpicId) => {
+    const { user } = requestContext.require();
+
+    const serviceInstance = await loadServiceInstanceBy(
+      'slug',
+      'xtm-suite-roadmap'
+    );
+
+    await assertUserHasCapaOnService(user, serviceInstance.id, [
+      ServiceRestriction.Delete,
+    ]);
+
     const [epic] = await EpicDomain.loadEpicsBy({ id: id });
     await EpicDomain.deleteEpicBy({ id });
     if (epic.document_id) {

--- a/apps/portal-api/src/modules/xtm-suite-roadmap/epic.graphql
+++ b/apps/portal-api/src/modules/xtm-suite-roadmap/epic.graphql
@@ -79,11 +79,7 @@ type Query {
 }
 
 type Mutation {
-  createEpic(input: CreateEpicInput!, document: [Upload!]): Epic!
-    @auth
-    @service_capa(requires: [UPSERT])
-  updateEpic(id: ID!, input: UpdateEpicInput!, document: [Upload!]): Epic!
-    @auth
-    @service_capa(requires: [UPSERT])
-  deleteEpic(id: ID!): Epic! @auth @service_capa(requires: [DELETE])
+  createEpic(input: CreateEpicInput!, document: [Upload!]): Epic! @auth
+  updateEpic(id: ID!, input: UpdateEpicInput!, document: [Upload!]): Epic! @auth
+  deleteEpic(id: ID!): Epic! @auth
 }

--- a/apps/portal-api/src/security/guard.test.ts
+++ b/apps/portal-api/src/security/guard.test.ts
@@ -5,16 +5,21 @@ import {
   // eslint-disable-next-line no-restricted-imports
   contextBypassUser,
   requestContextAdminSecondOrga,
+  SERVICES,
   TEST_ORGANIZATIONS,
 } from '../../tests/tests.const';
 import {
   OrganizationCapability,
   PortalCapability,
+  ServiceRestriction,
 } from '../__generated__/resolvers-types';
 import { requestContext } from '../context/request.context';
 import * as authHelper from '../modules/security-management/capability/auth.helper';
+import * as subscriptionDomain from '../modules/subscription/subscription.domain';
+import { UserServiceDomain } from '../modules/user-service/user-service.domain';
 import { ErrorCode } from '../utils/error/error.code';
-import { securityGuard } from './guard';
+import * as access from './access';
+import { assertUserHasCapaOnService, securityGuard } from './guard';
 
 describe('security Guard', () => {
   let isUserAllowedOnOrganizationSpy: MockInstance;
@@ -133,6 +138,165 @@ describe('security Guard', () => {
           PortalCapability.ManageDeployment,
         ])
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('assertUserHasCapaOnService', () => {
+    let isUserGrantedSpy: MockInstance;
+    let loadSubscriptionBySpy: MockInstance;
+    let loadUserServiceWithCapabilitiesBySpy: MockInstance;
+
+    beforeEach(() => {
+      isUserGrantedSpy = vi.spyOn(access, 'isUserGranted');
+      loadSubscriptionBySpy = vi.spyOn(
+        subscriptionDomain,
+        'loadSubscriptionBy'
+      );
+      loadUserServiceWithCapabilitiesBySpy = vi.spyOn(
+        UserServiceDomain,
+        'loadUserServiceWithCapabilitiesBy'
+      );
+
+      isUserGrantedSpy.mockReturnValue(false);
+      loadSubscriptionBySpy.mockResolvedValue({ id: 'subscription-id' });
+      loadUserServiceWithCapabilitiesBySpy.mockResolvedValue([
+        {
+          user_service_capability: [],
+        },
+      ]);
+    });
+
+    it('should bypass checks when user is granted', async () => {
+      // Given
+      isUserGrantedSpy.mockReturnValue(true);
+
+      // When
+      await assertUserHasCapaOnService(
+        contextBypassUser.user,
+        SERVICES.INSTANCES.EPIC.ID,
+        [ServiceRestriction.Upsert]
+      );
+
+      // Then
+      expect(loadSubscriptionBySpy).not.toHaveBeenCalled();
+      expect(loadUserServiceWithCapabilitiesBySpy).not.toHaveBeenCalled();
+    });
+
+    it('should allow access when one required capability is present', async () => {
+      // Given
+      loadUserServiceWithCapabilitiesBySpy.mockResolvedValue([
+        {
+          user_service_capability: [
+            {
+              subscription_capability: {
+                service_capability: {
+                  name: ServiceRestriction.Upsert,
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      // When
+      const call = assertUserHasCapaOnService(
+        requestContextAdminSecondOrga.user,
+        SERVICES.INSTANCES.EPIC.ID,
+        [ServiceRestriction.Upsert]
+      );
+
+      // Then
+      await expect(call).resolves.toBeUndefined();
+      expect(loadSubscriptionBySpy).toHaveBeenCalledWith({
+        service_instance_id: SERVICES.INSTANCES.EPIC.ID,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      });
+      expect(loadUserServiceWithCapabilitiesBySpy).toHaveBeenCalledWith({
+        user_id: requestContextAdminSecondOrga.user.id,
+        subscription_id: 'subscription-id',
+      });
+    });
+
+    it('should throw MissingCapabilityOnService when no required capability is present', async () => {
+      // Given
+      loadUserServiceWithCapabilitiesBySpy.mockResolvedValue([
+        {
+          user_service_capability: [
+            {
+              subscription_capability: {
+                service_capability: {
+                  name: ServiceRestriction.Upload,
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      // When
+      const call = assertUserHasCapaOnService(
+        requestContextAdminSecondOrga.user,
+        SERVICES.INSTANCES.EPIC.ID,
+        [ServiceRestriction.Upsert]
+      );
+
+      // Then
+      await expect(call).rejects.toThrow(ErrorCode.MissingCapabilityOnService);
+    });
+
+    it.each`
+      capabilities
+      ${[null, {}, { subscription_capability: null }, { subscription_capability: { service_capability: null } }, { subscription_capability: { service_capability: { name: null } } }]}
+      ${[{ subscription_capability: { service_capability: { name: undefined } } }]}
+    `(
+      'should ignore nullish capability entries and throw when no valid capability matches ($capabilities)',
+      async ({ capabilities }) => {
+        // Given
+        loadUserServiceWithCapabilitiesBySpy.mockResolvedValue([
+          {
+            user_service_capability: capabilities,
+          },
+        ]);
+
+        // When
+        const call = assertUserHasCapaOnService(
+          requestContextAdminSecondOrga.user,
+          SERVICES.INSTANCES.EPIC.ID,
+          [ServiceRestriction.Upsert]
+        );
+
+        // Then
+        await expect(call).rejects.toThrow(
+          ErrorCode.MissingCapabilityOnService
+        );
+      }
+    );
+
+    it('should allow access when one of multiple required capabilities is present', async () => {
+      // Given
+      loadUserServiceWithCapabilitiesBySpy.mockResolvedValue([
+        {
+          user_service_capability: [
+            {
+              subscription_capability: {
+                service_capability: {
+                  name: ServiceRestriction.Delete,
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      // When
+      const call = assertUserHasCapaOnService(
+        requestContextAdminSecondOrga.user,
+        SERVICES.INSTANCES.EPIC.ID,
+        [ServiceRestriction.Upsert, ServiceRestriction.Delete]
+      );
+
+      // Then
+      await expect(call).resolves.toBeUndefined();
     });
   });
 });

--- a/apps/portal-api/src/security/guard.ts
+++ b/apps/portal-api/src/security/guard.ts
@@ -3,6 +3,7 @@ import {
   OrganizationCapability,
   PortalCapability,
   ServiceDefinitionIdentifier,
+  ServiceRestriction,
 } from '../__generated__/resolvers-types';
 import { requestContext } from '../context/request.context';
 import { OrganizationId } from '../model/kanel/public/Organization';
@@ -116,14 +117,12 @@ export const securityGuard = {
     user: UserLoadUserBy,
     requiredCapabilities: PortalCapability[]
   ) => {
-
     if (isUserAdminPlatform(user)) return;
 
     const requiredCapabilityNames = new Set<string>(requiredCapabilities);
     const hasRequiredPortalCapability = user.capabilities.some(
       (capability) =>
-        capability.name !== null &&
-        requiredCapabilityNames.has(capability.name)
+        capability.name !== null && requiredCapabilityNames.has(capability.name)
     );
 
     if (!hasRequiredPortalCapability) {
@@ -144,13 +143,41 @@ export const assertUserCanManageService = async (
   });
 
   const userServiceCapability =
-    await UserServiceDomain.loadUserServiceCapability(
+    await UserServiceDomain.loadUserServiceGenericCapability(
       user.id,
       subscription.id,
       GenericServiceCapabilityName.MANAGE_ACCESS
     );
 
   if (!userServiceCapability) {
+    throw ForbiddenAccess(ErrorCode.MissingCapabilityOnService);
+  }
+};
+export const assertUserHasCapaOnService = async (
+  user: UserLoadUserBy,
+  serviceInstanceId: ServiceInstanceId,
+  capabilities: ServiceRestriction[]
+) => {
+  if (isUserGranted(user)) return;
+
+  const subscription = await loadSubscriptionBy({
+    service_instance_id: serviceInstanceId,
+    organization_id: user.selected_organization_id,
+  });
+  const [existingUserService] =
+    await UserServiceDomain.loadUserServiceWithCapabilitiesBy({
+      user_id: user.id,
+      subscription_id: subscription.id,
+    });
+
+  if (
+    !existingUserService.user_service_capability.some((c) =>
+      capabilities.includes(
+        c?.subscription_capability?.service_capability
+          ?.name as ServiceRestriction
+      )
+    )
+  ) {
     throw ForbiddenAccess(ErrorCode.MissingCapabilityOnService);
   }
 };

--- a/apps/portal-front/src/components/epic/epic-form.tsx
+++ b/apps/portal-front/src/components/epic/epic-form.tsx
@@ -111,7 +111,10 @@ const EpicForm = ({
   );
   const [selectedProduct, setSelectedProduct] = useState<
     FiligranProductEnum | undefined
-  >(epic?.product as FiligranProductEnum | undefined);
+  >(
+    (epic?.product as FiligranProductEnum | undefined) ??
+      FiligranProductEnum.OPENCTI
+  );
 
   return (
     <AutoForm
@@ -123,15 +126,19 @@ const EpicForm = ({
       }
       onValuesChange={(values) => {
         setIsIntegration(values.is_integration ?? false);
-        setSelectedProduct(values.product as FiligranProductEnum | undefined);
+        setSelectedProduct(
+          (values.product as FiligranProductEnum | undefined) ??
+            FiligranProductEnum.OPENCTI
+        );
       }}
       formSchema={epicFormSchema}
       values={{
         title: epic?.title ?? '',
         short_description: epic?.short_description ?? '',
         description: epic?.description ?? descriptionValue,
-        product: epic?.product as FiligranProductEnum,
-        timeline: epic?.timeline as TimelineEnum,
+        product:
+          (epic?.product as FiligranProductEnum) ?? FiligranProductEnum.OPENCTI,
+        timeline: (epic?.timeline as TimelineEnum) ?? TimelineEnum.NOW,
         active: epic?.active ?? false,
         is_integration: epic?.epic_type === EpicTypeEnum.INTEGRATION,
         illustration_document: undefined,
@@ -158,6 +165,7 @@ const EpicForm = ({
               <ServiceFormDescriptionField
                 field={field}
                 documentType={'Epic'}
+                required
               />
               <p className="font-semibold txt-default mb-xs">
                 {t('Epic.Form.AutomaticallyAdded')}
@@ -177,14 +185,16 @@ const EpicForm = ({
             field: ControllerRenderProps<FieldValues, string>;
           }) => (
             <FormItem>
-              <FormLabel>{t('Epic.Form.FiligranProduct')}</FormLabel>
+              <FormLabel>
+                {t('Epic.Form.FiligranProduct')}
+                <span className="text-sm text-destructive"> *</span>
+              </FormLabel>
               <Select
                 onValueChange={(value) => {
                   field.onChange(value);
                   setSelectedProduct(value as FiligranProductEnum);
                 }}
-                value={field.value}
-                defaultValue={epic?.product}>
+                value={field.value ?? FiligranProductEnum.OPENCTI}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue
@@ -215,10 +225,13 @@ const EpicForm = ({
             field: ControllerRenderProps<FieldValues, string>;
           }) => (
             <FormItem>
-              <FormLabel>{t('Epic.Form.Timeline')}</FormLabel>
+              <FormLabel>
+                {t('Epic.Form.Timeline')}
+                <span className="text-sm text-destructive"> *</span>
+              </FormLabel>
               <Select
                 onValueChange={field.onChange}
-                defaultValue={epic?.timeline}>
+                defaultValue={epic?.timeline ?? TimelineEnum.NOW}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder={t('Epic.Timeline.now')} />

--- a/apps/portal-front/src/components/service/form/description-field.tsx
+++ b/apps/portal-front/src/components/service/form/description-field.tsx
@@ -7,17 +7,22 @@ interface Props {
   field: ControllerRenderProps<FieldValues, string>;
   documentType: string;
   disabled?: boolean;
+  required?: boolean;
 }
 
 export const ServiceFormDescriptionField = ({
   field,
   documentType,
   disabled,
+  required,
 }: Props) => {
   const t = useTranslations();
   return (
     <FormItem>
-      <FormLabel>{t('Service.Form.DescriptionLabel')}</FormLabel>
+      <FormLabel>
+        {t('Service.Form.DescriptionLabel')}
+        {required ? <span className="text-sm text-destructive"> *</span> : null}
+      </FormLabel>
       <FormControl>
         <MarkdownInput
           disabled={disabled}


### PR DESCRIPTION
# Context
> Fix service capa for public roadmap 

## How to test
- Log in a BYPASS or MANAGE_ACCESS on the service user 
- Grant UPSERT and/or DELETE capabilities to one user on public roadmap 
- This user should be able to upsert and/or delete without being BYPASS

## Related issues

- Related to #2219 

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [X] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.