### PR TITLE
[backend] fix: restrict login endpoint access to when form is available (#2231)

### DIFF
--- a/apps/portal-api/src/modules/organization-management/users/users.auth.app.test.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.auth.app.test.ts
@@ -1,0 +1,107 @@
+import config from 'config';
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserLoadUserBy } from '../../../model/user';
+import * as UserSecurity from '../../../security/util/user';
+import * as UserDomain from './user-domain/users.domain';
+import { UsersAuthApp } from './users.auth.app';
+
+vi.mock('config', () => ({
+  default: { get: vi.fn() },
+}));
+
+vi.mock('./user-domain/users.domain', () => ({
+  loadUserBy: vi.fn(),
+  updateUserAtLogin: vi.fn(),
+}));
+
+vi.mock('../../../security/util/user', () => ({
+  validatePassword: vi.fn(),
+}));
+
+const mockContext = {
+  req: { session: {} },
+} as never;
+
+const mockUser = {
+  id: 'user-id',
+  email: 'user@company.com',
+  salt: 'somesalt',
+  password: 'somehash',
+} as UserLoadUserBy;
+
+const SSO_ONLY_SETTINGS = [{ provider: 'oidc' }];
+const LOCAL_SETTINGS = [{ provider: 'local' }, { provider: 'oidc' }];
+
+describe('usersAuthApp', () => {
+  describe('login', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    describe('when local auth is not enabled (SSO-only config)', () => {
+      it('should throw ForbiddenAccess regardless of credentials', async () => {
+        (config.get as Mock).mockReturnValue(SSO_ONLY_SETTINGS);
+
+        await expect(
+          UsersAuthApp.login(mockContext, {
+            email: 'user@company.com',
+            password: '',
+          })
+        ).rejects.toThrow('Local authentication is not enabled');
+      });
+
+      it('should throw even if login_settings is empty', async () => {
+        (config.get as Mock).mockReturnValue([]);
+
+        await expect(
+          UsersAuthApp.login(mockContext, {
+            email: 'user@company.com',
+            password: 'somepassword',
+          })
+        ).rejects.toThrow('Local authentication is not enabled');
+      });
+    });
+
+    describe('when local auth is enabled', () => {
+      beforeEach(() => {
+        (config.get as Mock).mockReturnValue(LOCAL_SETTINGS);
+      });
+
+      it('should return the user when credentials are valid', async () => {
+        vi.mocked(UserDomain.loadUserBy).mockResolvedValue(mockUser);
+        vi.mocked(UserDomain.updateUserAtLogin).mockResolvedValue(mockUser);
+        vi.mocked(UserSecurity.validatePassword).mockReturnValue(true);
+
+        const result = await UsersAuthApp.login(mockContext, {
+          email: 'user@company.com',
+          password: 'correctpassword',
+        });
+
+        expect(result).toBe(mockUser);
+        expect(mockContext.req.session).toMatchObject({ user: mockUser });
+      });
+
+      it.each`
+        reason              | user        | passwordValid
+        ${'user not found'} | ${null}     | ${false}
+        ${'wrong password'} | ${mockUser} | ${false}
+      `(
+        'should return undefined when $reason',
+        async ({ user, passwordValid }) => {
+          vi.mocked(UserDomain.loadUserBy).mockResolvedValue(user);
+          vi.mocked(UserSecurity.validatePassword).mockReturnValue(
+            passwordValid
+          );
+
+          const result = await UsersAuthApp.login(mockContext, {
+            email: 'user@company.com',
+            password: 'wrongpassword',
+          });
+
+          expect(result).toBeUndefined();
+          expect(UserDomain.updateUserAtLogin).not.toHaveBeenCalled();
+        }
+      );
+    });
+  });
+});

--- a/apps/portal-api/src/modules/organization-management/users/users.auth.app.ts
+++ b/apps/portal-api/src/modules/organization-management/users/users.auth.app.ts
@@ -1,12 +1,20 @@
+import config from 'config';
 import { MutationLoginArgs } from '../../../__generated__/resolvers-types';
 import portalConfig from '../../../config';
 import { PortalContext } from '../../../model/portal-context';
 import { UserLoadUserBy } from '../../../model/user';
 import { validatePassword } from '../../../security/util/user';
+import { ForbiddenAccess } from '../../../utils/error/error.util';
 import { loadUserBy, updateUserAtLogin } from './user-domain/users.domain';
 
 const validPassword = (user: UserLoadUserBy, password: string): boolean => {
   return validatePassword(user.salt, password, user.password);
+};
+
+const isLocalAuthEnabled = (): boolean => {
+  const loginSettings =
+    config.get<{ provider: string }[]>('login_settings') ?? [];
+  return loginSettings.some((entry) => entry.provider === 'local');
 };
 
 export const UsersAuthApp = {
@@ -14,6 +22,10 @@ export const UsersAuthApp = {
     context: PortalContext,
     { email, password }: MutationLoginArgs
   ) => {
+    if (!isLocalAuthEnabled()) {
+      throw ForbiddenAccess('Local authentication is not enabled');
+    }
+
     const { req } = context;
     const loggedUser = await loadUserBy({ email });
     if (loggedUser && validPassword(loggedUser, password)) {


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to https://github.com/FiligranHQ/xtm-hub-private/issues/22
- Related to  https://github.com/FiligranHQ/xtm-hub/pull/2232

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.