### PR TITLE
[frontend] feat(integration feeds): allow redirection with filters (#2181)

### DIFF
--- a/apps/frontend/app/(application)/app/(user)/service/opencti_integrations/[serviceInstanceId]/page-loader.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/opencti_integrations/[serviceInstanceId]/page-loader.tsx
@@ -1,18 +1,16 @@
 'use client';
 
 import { DocumentsListQuery } from '@/components/service/document/document.graphql';
+import IntegrationsList from '@/components/service/integrations/[serviceInstanceId]/IntegrationsList';
+import { useIntegrationListStorage } from '@/components/service/integrations/[serviceInstanceId]/use-integration-list-storage';
+import { useIntegrationListUrlFilters } from '@/components/service/integrations/[serviceInstanceId]/use-integration-list-url-filters';
+import { useLogicalFiltersFromStorage } from '@/hooks/use-logical-filters-from-storage';
 import { ServiceSlug } from '@/utils/shareable-resources/shareable-resources.types';
 import { Skeleton } from '@filigran/ui';
 import { documentsQuery } from '@generated/documentsQuery.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { useEffect } from 'react';
 import { useQueryLoader } from 'react-relay';
-import IntegrationsList from '@/components/service/integrations/[serviceInstanceId]/IntegrationsList';
-import { useLogicalFiltersFromStorage } from '@/hooks/use-logical-filters-from-storage';
-import {
-  ServiceListLocalStorageKey,
-  useServiceListLocalStorage,
-} from '@/hooks/use-service-list-local-storage';
 
 interface PageLoaderProps {
   serviceInstance: serviceInstance_fragment$data;
@@ -32,9 +30,18 @@ const PageLoader = ({ serviceInstance }: PageLoaderProps) => {
     verified,
     orderBy,
     orderMode,
-  } = useServiceListLocalStorage(
-    ServiceListLocalStorageKey.OpenCTIIntegrationFeeds
-  );
+    resetAll,
+    filters,
+    setFilters,
+    setSelectedFilters,
+  } = useIntegrationListStorage();
+
+  useIntegrationListUrlFilters({
+    filters,
+    resetAll,
+    setFilters,
+    setSelectedFilters,
+  });
 
   const logicalFilters = useLogicalFiltersFromStorage({
     serviceInstanceSlug: ServiceSlug.OPEN_CTI_INTEGRATIONS,

--- a/apps/frontend/app/redirect/[identifier]/resource.test.ts
+++ b/apps/frontend/app/redirect/[identifier]/resource.test.ts
@@ -1,7 +1,7 @@
+import { serverMutateGraphQL } from '@/relay/server-portal-api-fetch';
 import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { serverMutateGraphQL } from '@/relay/server-portal-api-fetch';
 import { redirectToResource } from './resource';
 import {
   loadBaseUrlFront,
@@ -179,4 +179,52 @@ describe('redirectToResource', () => {
       expect(response.headers.get('location')).toBe(expectedLocation);
     }
   );
+
+  it.each`
+    pathAndQuery                                                                                         | expectedLocation                                                                         | description
+    ${`/redirect/${IDENTIFIER}?label=foo&deployable=true`}                                               | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target?label=foo&deployable=true`}     | ${'forwards extra params'}
+    ${`/redirect/${IDENTIFIER}?platform_id=platform-1&label=foo`}                                        | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target?label=foo`}                     | ${'strips internal platform_id, keeps extra params'}
+    ${`/redirect/${IDENTIFIER}?opencti_platform_id=opencti-1&oaev_instance_id=oaev-1&label=bar`}         | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target?label=bar`}                     | ${'strips all internal params, keeps extra params'}
+    ${`/redirect/${IDENTIFIER}?platform_id=platform-1&tenant_id=tenant-1&oaev_instance_id=oaev-1`}       | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target`}                               | ${'strips all internal params, no extra params → no query string'}
+    ${`/redirect/${IDENTIFIER}?platform_id=platform-1&tenant_id=tenant-1&label=foo&integrationType=bar`} | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target?label=foo&integrationType=bar`} | ${'strips internal params, forwards multiple extra params'}
+    ${`/redirect/${IDENTIFIER}?label=foo&label=bar`}                                                     | ${`${BASE_URL}/app/service/${IDENTIFIER}/instance-target?label=foo&label=bar`}           | ${'preserves repeated params'}
+  `(
+    'forwards query params correctly to the instance redirect ($description)',
+    async ({ pathAndQuery, expectedLocation }) => {
+      // Given
+      vi.mocked(loadServiceInstances).mockResolvedValue([
+        {
+          id: 'instance-target',
+          service_definition: {
+            identifier: ServiceDefinitionIdentifierEnum.OPENAEV_SCENARIOS,
+          },
+        },
+      ] as LoadServiceInstancesResult);
+
+      // When
+      const response = await redirectToResource(
+        { identifier: IDENTIFIER },
+        makeRequest(pathAndQuery)
+      );
+
+      // Then
+      expect(response.headers.get('location')).toBe(expectedLocation);
+    }
+  );
+
+  it('does not forward extra params to the fallback /app redirect when no instance exists', async () => {
+    // Given
+    vi.mocked(loadServiceInstances).mockResolvedValue(
+      [] as LoadServiceInstancesResult
+    );
+
+    // When
+    const response = await redirectToResource(
+      { identifier: IDENTIFIER },
+      makeRequest(`/redirect/${IDENTIFIER}?label=foo&deployable=true`)
+    );
+
+    // Then
+    expect(response.headers.get('location')).toBe(`${BASE_URL}/app`);
+  });
 });

--- a/apps/frontend/app/redirect/[identifier]/resource.ts
+++ b/apps/frontend/app/redirect/[identifier]/resource.ts
@@ -1,11 +1,11 @@
+import { serverMutateGraphQL } from '@/relay/server-portal-api-fetch';
+import { isValueInEnum } from '@/utils/is-value-in-enum';
 import { APP_PATH } from '@/utils/path/constant';
 import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import OrganizationSwitcherMutation, {
   OrganizationSwitcherMutation as OrganizationSwitcherMutationType,
 } from '@generated/OrganizationSwitcherMutation.graphql';
 import { NextRequest, NextResponse } from 'next/server';
-import { serverMutateGraphQL } from '@/relay/server-portal-api-fetch';
-import { isValueInEnum } from '@/utils/is-value-in-enum';
 import {
   loadBaseUrlFront,
   loadMeUser,
@@ -47,6 +47,21 @@ export const redirectToResource = async (
   const platform_id = searchParams.get('platform_id');
   const tenant_id = searchParams.get('tenant_id');
 
+  // Build forwarded params: all params except the internal routing ones
+  const internalParams = new Set([
+    'opencti_platform_id',
+    'oaev_instance_id',
+    'platform_id',
+    'tenant_id',
+  ]);
+  const forwardedParams = new URLSearchParams();
+  searchParams.forEach((value, key) => {
+    if (!internalParams.has(key)) {
+      forwardedParams.append(key, value);
+    }
+  });
+  const queryString = forwardedParams.toString();
+
   const organizationId: string | undefined = await loadPlatformOrganizationId(
     opencti_platform_id ?? oaev_instance_id ?? platform_id,
     tenant_id
@@ -69,10 +84,6 @@ export const redirectToResource = async (
     return NextResponse.redirect(new URL(`/${APP_PATH}`, baseUrlFront));
   }
 
-  return NextResponse.redirect(
-    new URL(
-      `/${APP_PATH}/service/${identifier}/${serviceInstances[0].id}`,
-      baseUrlFront
-    )
-  );
+  const targetPath = `/${APP_PATH}/service/${identifier}/${serviceInstances[0].id}${queryString ? `?${queryString}` : ''}`;
+  return NextResponse.redirect(new URL(targetPath, baseUrlFront));
 };

--- a/apps/frontend/src/components/service/integrations/[serviceInstanceId]/IntegrationsList.tsx
+++ b/apps/frontend/src/components/service/integrations/[serviceInstanceId]/IntegrationsList.tsx
@@ -1,19 +1,16 @@
-import { useActiveAndDraftSplit } from '@/components/service/components/service-list-utils';
-import {
-  ServiceListLocalStorageKey,
-  useServiceListLocalStorage,
-} from '@/hooks/use-service-list-local-storage';
-import { PaginationControls } from '@/components/ui/pagination/PaginationControls';
-import { IntegrationDeployableFilter } from '@/components/ui/shareable-resource/integration/IntegrationDeployableFilter';
-import { IntegrationFilters } from '@/components/ui/shareable-resource/integration/IntegrationFilters';
-import { ProductVersionFilter } from '@/components/ui/shareable-resource/ProductVersionFilter';
 import {
   ServiceListFilterKey,
   ServiceListFilterMap,
 } from '@/components/service/components/header/ServiceListHeader';
+import { useActiveAndDraftSplit } from '@/components/service/components/service-list-utils';
 import { AppServiceContext } from '@/components/service/components/ServiceContext';
 import ServiceList from '@/components/service/components/ServiceList';
 import { AppServiceListLocalStorageKeyContext } from '@/components/service/components/ServiceListLocalStorageKeyContext';
+import { useIntegrationListStorage } from '@/components/service/integrations/[serviceInstanceId]/use-integration-list-storage';
+import { PaginationControls } from '@/components/ui/pagination/PaginationControls';
+import { IntegrationDeployableFilter } from '@/components/ui/shareable-resource/integration/IntegrationDeployableFilter';
+import { IntegrationFilters } from '@/components/ui/shareable-resource/integration/IntegrationFilters';
+import { ProductVersionFilter } from '@/components/ui/shareable-resource/ProductVersionFilter';
 
 import {
   documentItem,
@@ -21,6 +18,7 @@ import {
   DocumentsListQuery,
 } from '@/components/service/document/document.graphql';
 import { useDocumentContext } from '@/components/service/document/use-document-context';
+import { IntegrationVerifiedFilter } from '@/components/ui/shareable-resource/integration/IntegrationVerifiedFilter';
 import { ShareableResourceType } from '@/utils/shareable-resources/shareable-resources.types';
 import {
   documentItem_fragment$data,
@@ -40,7 +38,6 @@ import {
   usePreloadedQuery,
   useRefetchableFragment,
 } from 'react-relay';
-import { IntegrationVerifiedFilter } from '@/components/ui/shareable-resource/integration/IntegrationVerifiedFilter';
 
 interface IntegrationsListProps {
   queryRef: PreloadedQuery<documentsQuery>;
@@ -78,8 +75,6 @@ const IntegrationsList = ({
     type: ShareableResourceType.OPENCTI_INTEGRATION,
   });
 
-  const localStorageKey = ServiceListLocalStorageKey.OpenCTIIntegrationFeeds;
-
   const {
     removeIntegrationTypes,
     removeProductVersions,
@@ -87,7 +82,8 @@ const IntegrationsList = ({
     removeVerified,
     pageSize,
     setPageSize,
-  } = useServiceListLocalStorage(localStorageKey);
+    localStorageKey,
+  } = useIntegrationListStorage();
 
   const filters: ServiceListFilterMap = {
     [ServiceListFilterKey.IntegrationType]: {

--- a/apps/frontend/src/components/service/integrations/[serviceInstanceId]/integration-list-url-filters.utils.test.ts
+++ b/apps/frontend/src/components/service/integrations/[serviceInstanceId]/integration-list-url-filters.utils.test.ts
@@ -1,0 +1,185 @@
+import { IntegrationSubTypeEnum } from '@generated/models/IntegrationSubType.enum';
+import { IntegrationTypeEnum } from '@generated/models/IntegrationType.enum';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  allFiltersKey,
+  buildAllFiltersSearchParams,
+  DEPLOYABLE_PARAM,
+  emptyFilters,
+  INTEGRATION_TYPE_PARAM,
+  LABEL_PARAM,
+  parseAllFiltersFromWindowSearch,
+  parseSelection,
+  serializeSelection,
+  VERIFIED_PARAM,
+} from './integration-list-url-filters.utils';
+
+describe('serializeSelection', () => {
+  it.each`
+    description                   | input                                                                                                                        | expected
+    ${'empty'}                    | ${{}}                                                                                                                        | ${''}
+    ${'key with no subtypes'}     | ${{ csv_feed: [] }}                                                                                                          | ${'csv_feed'}
+    ${'key with one subtype'}     | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.EXTERNAL_IMPORT] }}                                             | ${'connector:EXTERNAL_IMPORT'}
+    ${'subtypes are sorted'}      | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.INTERNAL_ENRICHMENT, IntegrationSubTypeEnum.EXTERNAL_IMPORT] }} | ${'connector:EXTERNAL_IMPORT|INTERNAL_ENRICHMENT'}
+    ${'multiple keys are sorted'} | ${{ rss_feed: [], csv_feed: [] }}                                                                                            | ${'csv_feed,rss_feed'}
+    ${'mixed keys and subtypes'}  | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.EXTERNAL_IMPORT], [IntegrationTypeEnum.CSV_FEED]: [] }}         | ${'connector:EXTERNAL_IMPORT,csv_feed'}
+  `('$description', ({ input, expected }) => {
+    expect(serializeSelection(input)).toBe(expected);
+  });
+});
+
+describe('parseSelection (integrationType)', () => {
+  it.each`
+    description                     | raw                                                | expected
+    ${'null'}                       | ${null}                                            | ${{}}
+    ${'single type'}                | ${'csv_feed'}                                      | ${{ [IntegrationTypeEnum.CSV_FEED]: [] }}
+    ${'type with one subtype'}      | ${'connector:EXTERNAL_IMPORT'}                     | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.EXTERNAL_IMPORT] }}
+    ${'type with several subtypes'} | ${'connector:EXTERNAL_IMPORT|INTERNAL_ENRICHMENT'} | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.EXTERNAL_IMPORT, IntegrationSubTypeEnum.INTERNAL_ENRICHMENT] }}
+    ${'multiple types'}             | ${'csv_feed,rss_feed'}                             | ${{ [IntegrationTypeEnum.CSV_FEED]: [], [IntegrationTypeEnum.RSS_FEED]: [] }}
+    ${'invalid type is dropped'}    | ${'not_a_type'}                                    | ${{}}
+    ${'invalid subtype is dropped'} | ${'connector:NOT_VALID|EXTERNAL_IMPORT'}           | ${{ [IntegrationTypeEnum.CONNECTOR]: [IntegrationSubTypeEnum.EXTERNAL_IMPORT] }}
+  `('$description', ({ raw, expected }) => {
+    expect(parseSelection(raw, INTEGRATION_TYPE_PARAM)).toEqual(expected);
+  });
+});
+
+describe('parseSelection (simple filter)', () => {
+  it.each`
+    description        | raw          | expected
+    ${'null'}          | ${null}      | ${{}}
+    ${'single key'}    | ${'id1'}     | ${{ id1: [] }}
+    ${'multiple keys'} | ${'id1,id2'} | ${{ id1: [], id2: [] }}
+    ${'empty entry'}   | ${',id1'}    | ${{ id1: [] }}
+  `('$description', ({ raw, expected }) => {
+    expect(parseSelection(raw, LABEL_PARAM)).toEqual(expected);
+  });
+});
+
+describe('buildAllFiltersSearchParams', () => {
+  it('returns empty string for empty filters', () => {
+    expect(buildAllFiltersSearchParams(emptyFilters())).toBe('');
+  });
+
+  it('round-trips through parseSelection', () => {
+    const filters = {
+      ...emptyFilters(),
+      [INTEGRATION_TYPE_PARAM]: {
+        [IntegrationTypeEnum.CONNECTOR]: [
+          IntegrationSubTypeEnum.EXTERNAL_IMPORT,
+        ],
+        [IntegrationTypeEnum.CSV_FEED]: [],
+      },
+      [LABEL_PARAM]: { id1: [], id2: [] },
+    };
+    const params = new URLSearchParams(buildAllFiltersSearchParams(filters));
+    expect(
+      parseSelection(params.get(INTEGRATION_TYPE_PARAM), INTEGRATION_TYPE_PARAM)
+    ).toEqual(filters[INTEGRATION_TYPE_PARAM]);
+    expect(parseSelection(params.get(LABEL_PARAM), LABEL_PARAM)).toEqual(
+      filters[LABEL_PARAM]
+    );
+  });
+});
+
+describe('allFiltersKey', () => {
+  it('is empty for empty filters', () => {
+    expect(allFiltersKey(emptyFilters())).toBe('||||||||');
+  });
+
+  it('differs when any filter changes', () => {
+    const base = allFiltersKey(emptyFilters());
+    expect(
+      allFiltersKey({ ...emptyFilters(), [LABEL_PARAM]: { id1: [] } })
+    ).not.toBe(base);
+    expect(
+      allFiltersKey({
+        ...emptyFilters(),
+        [INTEGRATION_TYPE_PARAM]: { [IntegrationTypeEnum.CONNECTOR]: [] },
+      })
+    ).not.toBe(base);
+  });
+
+  it('is stable regardless of key insertion order', () => {
+    const a = { ...emptyFilters(), [LABEL_PARAM]: { b: [], a: [] } };
+    const b = { ...emptyFilters(), [LABEL_PARAM]: { a: [], b: [] } };
+    expect(allFiltersKey(a)).toBe(allFiltersKey(b));
+  });
+});
+
+describe('parseAllFiltersFromWindowSearch', () => {
+  afterEach(() => {
+    window.history.pushState({}, '', '/');
+  });
+
+  it('returns empty filters when no params are present', () => {
+    expect(parseAllFiltersFromWindowSearch()).toEqual(emptyFilters());
+  });
+
+  it('parses a single integration type', () => {
+    window.history.pushState({}, '', `?${INTEGRATION_TYPE_PARAM}=csv_feed`);
+    const result = parseAllFiltersFromWindowSearch();
+    expect(result[INTEGRATION_TYPE_PARAM]).toEqual({
+      [IntegrationTypeEnum.CSV_FEED]: [],
+    });
+  });
+
+  it('parses an integration type with subtypes', () => {
+    window.history.pushState(
+      {},
+      '',
+      `?${INTEGRATION_TYPE_PARAM}=connector:EXTERNAL_IMPORT|INTERNAL_ENRICHMENT`
+    );
+    const result = parseAllFiltersFromWindowSearch();
+    expect(result[INTEGRATION_TYPE_PARAM]).toEqual({
+      [IntegrationTypeEnum.CONNECTOR]: [
+        IntegrationSubTypeEnum.EXTERNAL_IMPORT,
+        IntegrationSubTypeEnum.INTERNAL_ENRICHMENT,
+      ],
+    });
+  });
+
+  it('parses simple filters alongside integration filter', () => {
+    window.history.pushState(
+      {},
+      '',
+      `?${INTEGRATION_TYPE_PARAM}=csv_feed&${LABEL_PARAM}=id1,id2&${DEPLOYABLE_PARAM}=true&${VERIFIED_PARAM}=true`
+    );
+    const result = parseAllFiltersFromWindowSearch();
+    expect(result[INTEGRATION_TYPE_PARAM]).toEqual({
+      [IntegrationTypeEnum.CSV_FEED]: [],
+    });
+    expect(result[LABEL_PARAM]).toEqual({ id1: [], id2: [] });
+    expect(result[DEPLOYABLE_PARAM]).toEqual({ true: [] });
+    expect(result[VERIFIED_PARAM]).toEqual({ true: [] });
+  });
+
+  it('ignores unrelated query params', () => {
+    window.history.pushState(
+      {},
+      '',
+      `?${INTEGRATION_TYPE_PARAM}=csv_feed&someOtherParam=value`
+    );
+    const result = parseAllFiltersFromWindowSearch();
+    expect(result[INTEGRATION_TYPE_PARAM]).toEqual({
+      [IntegrationTypeEnum.CSV_FEED]: [],
+    });
+  });
+
+  it('round-trips through buildAllFiltersSearchParams', () => {
+    const original = {
+      ...emptyFilters(),
+      [INTEGRATION_TYPE_PARAM]: {
+        [IntegrationTypeEnum.CONNECTOR]: [
+          IntegrationSubTypeEnum.EXTERNAL_IMPORT,
+        ],
+      },
+      [LABEL_PARAM]: { id1: [], id2: [] },
+    };
+    window.history.pushState(
+      {},
+      '',
+      `?${buildAllFiltersSearchParams(original)}`
+    );
+    expect(parseAllFiltersFromWindowSearch()).toEqual(original);
+  });
+});

--- a/apps/frontend/src/components/service/integrations/[serviceInstanceId]/integration-list-url-filters.utils.ts
+++ b/apps/frontend/src/components/service/integrations/[serviceInstanceId]/integration-list-url-filters.utils.ts
@@ -1,0 +1,107 @@
+import { LogicalMultiSelectSelection } from '@/components/ui/shareable-resource/logical-multi-select/LogicalMultiSelectFormField';
+import { IntegrationSubTypeEnum } from '@generated/models/IntegrationSubType.enum';
+import { IntegrationTypeEnum } from '@generated/models/IntegrationType.enum';
+
+export const INTEGRATION_TYPE_PARAM = 'integrationType';
+export const LABEL_PARAM = 'label';
+export const DEPLOYABLE_PARAM = 'deployable';
+export const VERIFIED_PARAM = 'verified';
+export const PRODUCT_VERSION_PARAM = 'productVersion';
+
+export const ALL_FILTER_PARAMS = [
+  INTEGRATION_TYPE_PARAM,
+  LABEL_PARAM,
+  DEPLOYABLE_PARAM,
+  VERIFIED_PARAM,
+  PRODUCT_VERSION_PARAM,
+] as const;
+
+export type FilterParamName = (typeof ALL_FILTER_PARAMS)[number];
+
+const validIntegrationTypes = new Set(Object.values(IntegrationTypeEnum));
+const validIntegrationSubTypes = new Set(Object.values(IntegrationSubTypeEnum));
+
+/**
+ * Serializes a LogicalMultiSelectSelection to a compact string.
+ * Entries are comma-separated; subtypes within an entry are pipe-separated.
+ *
+ * Example: { connector: ['EXTERNAL_IMPORT', 'INTERNAL_ENRICHMENT'], csv_feed: [] }
+ *   → 'connector:EXTERNAL_IMPORT|INTERNAL_ENRICHMENT,csv_feed'
+ */
+export const serializeSelection = (
+  selection: LogicalMultiSelectSelection
+): string =>
+  Object.entries(selection)
+    .map(([key, subtypes]) =>
+      subtypes.length > 0 ? `${key}:${[...subtypes].sort().join('|')}` : key
+    )
+    .sort()
+    .join(',');
+
+/**
+ * Parses a compact param string into a LogicalMultiSelectSelection.
+ * For integrationType, validates types and subtypes against known enums.
+ * For other params, accepts any non-empty key.
+ *
+ * Example: 'connector:EXTERNAL_IMPORT|INTERNAL_ENRICHMENT,csv_feed'
+ *   → { connector: ['EXTERNAL_IMPORT', 'INTERNAL_ENRICHMENT'], csv_feed: [] }
+ */
+export const parseSelection = (
+  raw: string | null,
+  paramName: FilterParamName
+): LogicalMultiSelectSelection => {
+  if (!raw) return {};
+  const result: LogicalMultiSelectSelection = {};
+  for (const entry of raw.split(',')) {
+    const colonIndex = entry.indexOf(':');
+    const key = colonIndex === -1 ? entry : entry.slice(0, colonIndex);
+    const subtypesRaw = colonIndex === -1 ? '' : entry.slice(colonIndex + 1);
+
+    if (paramName === INTEGRATION_TYPE_PARAM) {
+      if (!validIntegrationTypes.has(key as IntegrationTypeEnum)) continue;
+      result[key] = subtypesRaw
+        ? subtypesRaw
+            .split('|')
+            .filter((s) =>
+              validIntegrationSubTypes.has(s as IntegrationSubTypeEnum)
+            )
+        : [];
+    } else {
+      if (!key) continue;
+      result[key] = [];
+    }
+  }
+  return result;
+};
+
+export type AllFilters = Record<FilterParamName, LogicalMultiSelectSelection>;
+
+export const emptyFilters = (): AllFilters =>
+  Object.fromEntries(ALL_FILTER_PARAMS.map((p) => [p, {}])) as AllFilters;
+
+export const parseAllFiltersFromWindowSearch = (): AllFilters => {
+  const params =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+  return Object.fromEntries(
+    ALL_FILTER_PARAMS.map((name) => [
+      name,
+      parseSelection(params.get(name), name),
+    ])
+  ) as AllFilters;
+};
+
+export const buildAllFiltersSearchParams = (filters: AllFilters): string => {
+  const params = new URLSearchParams();
+  for (const paramName of ALL_FILTER_PARAMS) {
+    const serialized = serializeSelection(filters[paramName] ?? {});
+    if (serialized) params.set(paramName, serialized);
+  }
+  return params.toString();
+};
+
+export const allFiltersKey = (filters: AllFilters): string =>
+  ALL_FILTER_PARAMS.map((name) => serializeSelection(filters[name] ?? {})).join(
+    '||'
+  );

--- a/apps/frontend/src/components/service/integrations/[serviceInstanceId]/use-integration-list-storage.ts
+++ b/apps/frontend/src/components/service/integrations/[serviceInstanceId]/use-integration-list-storage.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  AllFilters,
+  DEPLOYABLE_PARAM,
+  INTEGRATION_TYPE_PARAM,
+  LABEL_PARAM,
+  PRODUCT_VERSION_PARAM,
+  VERIFIED_PARAM,
+} from '@/components/service/integrations/[serviceInstanceId]/integration-list-url-filters.utils';
+import {
+  ServiceListLocalStorageKey,
+  useServiceListLocalStorage,
+} from '@/hooks/use-service-list-local-storage';
+import { useCallback, useMemo } from 'react';
+
+export const useIntegrationListStorage = () => {
+  const localStorageKey = ServiceListLocalStorageKey.OpenCTIIntegrationFeeds;
+  const store = useServiceListLocalStorage(localStorageKey);
+
+  const {
+    integrationTypes,
+    labels,
+    deployable,
+    verified,
+    productVersions,
+    setIntegrationTypes,
+    setLabels,
+    setDeployable,
+    setVerified,
+    setProductVersions,
+  } = store;
+
+  const filters = useMemo<AllFilters>(
+    () => ({
+      [INTEGRATION_TYPE_PARAM]: integrationTypes,
+      [LABEL_PARAM]: labels,
+      [DEPLOYABLE_PARAM]: deployable,
+      [VERIFIED_PARAM]: verified,
+      [PRODUCT_VERSION_PARAM]: productVersions,
+    }),
+    [integrationTypes, labels, deployable, verified, productVersions]
+  );
+
+  const setFilters = useCallback(
+    (value: AllFilters) => {
+      setIntegrationTypes(value[INTEGRATION_TYPE_PARAM] ?? {});
+      setLabels(value[LABEL_PARAM] ?? {});
+      setDeployable(value[DEPLOYABLE_PARAM] ?? {});
+      setVerified(value[VERIFIED_PARAM] ?? {});
+      setProductVersions(value[PRODUCT_VERSION_PARAM] ?? {});
+    },
+    [
+      setIntegrationTypes,
+      setLabels,
+      setDeployable,
+      setVerified,
+      setProductVersions,
+    ]
+  );
+
+  return { ...store, filters, setFilters, localStorageKey };
+};

--- a/apps/frontend/src/components/service/integrations/[serviceInstanceId]/use-integration-list-url-filters.ts
+++ b/apps/frontend/src/components/service/integrations/[serviceInstanceId]/use-integration-list-url-filters.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { ServiceListFilterKey } from '@/components/service/components/header/ServiceListHeader';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  ALL_FILTER_PARAMS,
+  AllFilters,
+  allFiltersKey,
+  buildAllFiltersSearchParams,
+  DEPLOYABLE_PARAM,
+  FilterParamName,
+  INTEGRATION_TYPE_PARAM,
+  LABEL_PARAM,
+  parseAllFiltersFromWindowSearch,
+  PRODUCT_VERSION_PARAM,
+  VERIFIED_PARAM,
+} from './integration-list-url-filters.utils';
+
+const FILTER_KEY_MAP: Record<FilterParamName, ServiceListFilterKey | null> = {
+  [INTEGRATION_TYPE_PARAM]: ServiceListFilterKey.IntegrationType,
+  [LABEL_PARAM]: ServiceListFilterKey.Label,
+  [DEPLOYABLE_PARAM]: ServiceListFilterKey.ManagerSupported,
+  [VERIFIED_PARAM]: ServiceListFilterKey.Verified,
+  [PRODUCT_VERSION_PARAM]: ServiceListFilterKey.ProductVersion,
+};
+
+interface UseIntegrationListUrlFiltersParams {
+  filters: AllFilters;
+  resetAll: () => void;
+  setFilters: (value: AllFilters) => void;
+  setSelectedFilters: (value: ServiceListFilterKey[]) => void;
+}
+
+export const useIntegrationListUrlFilters = ({
+  filters,
+  resetAll,
+  setFilters,
+  setSelectedFilters,
+}: UseIntegrationListUrlFiltersParams) => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [filtersFromUrl] = useState<AllFilters>(
+    parseAllFiltersFromWindowSearch
+  );
+  const lastSyncedKey = useRef<string>(allFiltersKey(filtersFromUrl));
+
+  useLayoutEffect(() => {
+    const hasAnyFilter = ALL_FILTER_PARAMS.some(
+      (name) => Object.keys(filtersFromUrl[name]).length > 0
+    );
+    if (!hasAnyFilter) return;
+
+    resetAll();
+    setFilters(filtersFromUrl);
+
+    const activeFilters = ALL_FILTER_PARAMS.flatMap((name) => {
+      const filterKey = FILTER_KEY_MAP[name];
+      return Object.keys(filtersFromUrl[name]).length > 0 && filterKey
+        ? [filterKey]
+        : [];
+    });
+    setSelectedFilters(activeFilters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Intentionally empty: runs once on mount only.
+
+  useEffect(() => {
+    const currentKey = allFiltersKey(filters);
+    if (currentKey === lastSyncedKey.current) return;
+    lastSyncedKey.current = currentKey;
+
+    const params = new URLSearchParams(window.location.search);
+    for (const name of ALL_FILTER_PARAMS) params.delete(name);
+
+    new URLSearchParams(buildAllFiltersSearchParams(filters)).forEach(
+      (value, key) => {
+        params.set(key, value);
+      }
+    );
+
+    const newSearch = params.toString();
+    router.replace(`${pathname}${newSearch ? `?${newSearch}` : ''}`, {
+      scroll: false,
+    });
+  }, [filters, pathname, router]);
+};

--- a/apps/frontend/src/hooks/use-service-list-local-storage.ts
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.ts
@@ -1,12 +1,13 @@
-import { DocumentOrderingEnum } from '@generated/models/DocumentOrdering.enum';
-import { OrderingModeEnum } from '@generated/models/OrderingMode.enum';
-import { useLocalStorage } from 'usehooks-ts';
 import { ServiceListFilterKey } from '@/components/service/components/header/ServiceListHeader';
 import {
   isLogicalMultiSelectSelection,
   LogicalMultiSelectSelection,
 } from '@/components/ui/shareable-resource/logical-multi-select/LogicalMultiSelectFormField';
 import usePublicPath from '@/hooks/use-public-path';
+import { DocumentOrderingEnum } from '@generated/models/DocumentOrdering.enum';
+import { OrderingModeEnum } from '@generated/models/OrderingMode.enum';
+import { useCallback } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
 
 export enum ServiceListLocalStorageKey {
   OpenCTICustomDashboards = 'OpenCTICustomDashboards',
@@ -137,17 +138,31 @@ export const useServiceListLocalStorage = (
       OrderingModeEnum.ASC
     );
 
-  const resetAll = () => {
+  const resetAll = useCallback(() => {
     removeCount();
     removePageSize();
     removeSearch();
     removeLabels();
     removeSelectedFilters();
     removeIntegrationTypes();
+    removeProductVersions();
     removeDeployable();
+    removeVerified();
     removeOrderBy();
     removeOrderMode();
-  };
+  }, [
+    removeCount,
+    removePageSize,
+    removeSearch,
+    removeLabels,
+    removeSelectedFilters,
+    removeIntegrationTypes,
+    removeProductVersions,
+    removeDeployable,
+    removeVerified,
+    removeOrderBy,
+    removeOrderMode,
+  ]);
 
   return {
     count,


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.
For Import from hub from opencti to redirect to the correct resources to import in xtmhub, we need to allow filtering to be done by query params, and redirection to pass these params

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
- On integration feeds page (private only), you can set filters in the query params in the url, and that setting the filters well updates the url. 
- Check redirection to integration feeds redirect to filtered integration feeds. Example:
`/redirect/opencti_integrations?platform_id=<platformId>&integrationType=stream`

## Related issues

- Related to #2181

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.