### PR TITLE
[frontend] fix(autoform): bump @filigran/ui to 1.1.2 to fix file field validation (#2298)

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@filigran/chatbot": "3.2.1",
     "@filigran/icon": "0.22.6",
-    "@filigran/ui": "1.1.1",
+    "@filigran/ui": "1.1.2",
     "@hookform/resolvers": "5.2.2",
     "@svgr/webpack": "8.1.0",
     "@tailwindcss/postcss": "4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,9 +2953,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/ui@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@filigran/ui@npm:1.1.1"
+"@filigran/ui@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@filigran/ui@npm:1.1.2"
   dependencies:
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/modifiers": "npm:9.0.0"
@@ -2998,7 +2998,7 @@ __metadata:
     react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0
     react-hook-form: ^7.68.0
     zod: ^4.1.13
-  checksum: 10/ee30f3265a84bbd1ad29c38ba3011b48d3a0eeee24bb66d426c367ca7ab69001f92abd1f2e9d7b3a34174d3a1e9aa653f61da7c2c3f6e10ab1b30ed291d2c8db
+  checksum: 10/f406ea9673d5d015a521fedb4e912c3d63fbe2c99fe61a9c7b7dd944ca265cb38a48a7d02466389ef880320fdc29d6ace4f03d62ca125908d5fd102ff6c17e55
   languageName: node
   linkType: hard
 
@@ -8582,7 +8582,7 @@ __metadata:
   dependencies:
     "@filigran/chatbot": "npm:3.2.1"
     "@filigran/icon": "npm:0.22.6"
-    "@filigran/ui": "npm:1.1.1"
+    "@filigran/ui": "npm:1.1.2"
     "@hookform/resolvers": "npm:5.2.2"
     "@svgr/webpack": "npm:8.1.0"
     "@tailwindcss/postcss": "npm:4.2.4"


### PR DESCRIPTION
# Context

This PR closes #2298 by bumping `@filigran/ui` from `1.1.1` to `1.1.2`, which includes the upstream fix in `AutoForm` for required file fields silently blocking form submission.

The bug affected the 6 resource creation forms in XTM Hub (CSV Feed, RSS Feed, TAXII Feed, Stream, OpenAEV Scenario, Custom Dashboard). Users clicked **Validate** on an incomplete form and nothing happened — no error message, no feedback — making the form feel broken.

**Root cause** (fixed upstream in `@filigran/ui` v1.1.2, see FiligranHQ/filigran-ui#<NUMERO-PR-FILIGRAN-UI>):

`AutoForm` rendered required file inputs as `<input type="file" required class="hidden">`. The browser's HTML5 pre-validation tried to focus the empty required input to display its native error tooltip, failed because the input was hidden, and cancelled the submit silently — before `react-hook-form` could run. Zod never evaluated, no `FormMessage` was displayed.


## How to test

1. Pull the branch and run `yarn install`
2. Run `yarn dev:front` (with the API running)
3. Open `localhost:3002` and navigate to `OpenCTI Integrations Library`
4. Click `Add new Integration` and pick any type (CSV Feed for instance)
5. Fill `Name`, `Slug`, `Short Description`, `Author` but **leave Description empty and don't select a JSON file**
6. Click `Validate`

**Expected:**
- ✅ Red error message under `Description`
- ✅ Red error message under `Select JSON file`
- ✅ DevTools console clean — no more `An invalid form control with name='document' is not focusable` warnings

Repeat on Custom Dashboard and OpenAEV Scenario creation forms to confirm the fix covers all impacted forms.

## Related issues
- Closes #2298

# Checklist
## Quality
- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing
- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made
- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
