### PR TITLE
[frontend] fix(trial): improve mobile layout of trial welcome header (#2329)

### DIFF
--- a/apps/frontend/app/(public)/cybersecurity-solutions/openaev-free-trial/page.tsx
+++ b/apps/frontend/app/(public)/cybersecurity-solutions/openaev-free-trial/page.tsx
@@ -30,7 +30,6 @@ const Page = async () => {
           actions={
             <GradientButton className="bg-white dark:bg-none">
               <Link href="/redirect/create-openaev-free-trial">
-                {' '}
                 {t('Service.Trials.StartTrial')}
               </Link>
             </GradientButton>

--- a/apps/frontend/src/components/service/trial-instances/TrialsHeader.tsx
+++ b/apps/frontend/src/components/service/trial-instances/TrialsHeader.tsx
@@ -14,14 +14,14 @@ export const TrialsHeader = ({
   const platformName = PlatformMetadataMapping[platformIdentifier].name;
 
   return (
-    <header className="flex justify-between items-start my-xl">
+    <header className="flex flex-col gap-m md:flex-row md:justify-between md:items-start my-xl">
       <div className="flex flex-col">
-        <h2 className="text-blue text-2xl mb-2">Welcome to Filigran</h2>
-        <h1 className="text-3xl">
+        <h2 className="text-blue text-xl md:text-2xl mb-2">Welcome to Filigran</h2>
+        <h1 className="text-2xl md:text-3xl">
           Let&apos;s get you started with your {platformName} free trial!
         </h1>
       </div>
-      <div className="flex gap-s">{actions}</div>
+      <div className="flex flex-wrap gap-s md:flex-nowrap md:shrink-0">{actions}</div>
     </header>
   );
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

This PR fixes the mobile UX of `TrialsHeader`, a shared component used in 4 trial-related pages:
- `/cybersecurity-solutions/opencti-free-trial` (public)
- `/cybersecurity-solutions/openaev-free-trial` (public)
- `/app/service/opencti_registration/[id]` (authenticated)
- `/app/service/openaev_registration/[id]` (authenticated)

**Problem (before)**: on small viewports (≤ ~640px), the layout used `flex-row` + `justify-between` with no responsive breakpoint, which caused:
1. The `<h1>` ("Let's get you started with your {platformName} free trial!") to wrap word-by-word due to `text-3xl` being too large for the available width.
2. The action button(s) to be squashed (down to ~67px wide), forcing the button text itself to wrap on multiple lines (e.g. "Start / your / free / trial").

**Solution (after)**: mobile-first layout — `flex-col` by default, `md:flex-row` from 768px. Title font sizes also scale (`text-xl md:text-2xl` for the `<h2>`, `text-2xl md:text-3xl` for the `<h1>`). The action container uses `flex-wrap` so multiple buttons (e.g. on authenticated trial pages) wrap to the next line gracefully on small screens instead of being squashed.

<img width="388" height="789" alt="image" src="https://github.com/user-attachments/assets/cfb91d63-c125-45d6-be36-b4b6d7dd343e" />

Also fixes an orphan `{' '}` JSX whitespace in the OpenAEV public trial page that was prepending a space before the button label.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Open Chrome/Firefox DevTools in **responsive mode** (Ctrl+Shift+M).

## Related issues

- Related to #2329

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.