### PR TITLE
[frontend] feat(Roadmap): Remove spaces in placeholder (#2334)

### DIFF
--- a/apps/frontend/src/components/epic/EpicForm.tsx
+++ b/apps/frontend/src/components/epic/EpicForm.tsx
@@ -35,7 +35,7 @@ export const descriptionValue =
   '            \n' +
   'Description of pain point(s) felt by the user that this Epic is solving. This pain must be specific to this Epic (not a generic, high level pain such as “*Lack of visibility in my threat landscape*”)\n' +
   '         \n' +
-  '   ### Proposed Solution\n' +
+  '### Proposed Solution\n' +
   'What we are introducing to solve the problem\n' +
   '\n' +
   '### Expected Value\n' +


### PR DESCRIPTION
# Context
> In the roadmap description placeholder, there are 3 spaces that have been removed.  

## How to test
- Connect as a user with UPLOAD capabilities on the roadmap. 
- Add a new epic
- In the description, the part before "Proposed solution" should not start with 3 spaces. 

## Related issues

- Related to #2334

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [X] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
