### PR TITLE
[backend] fix(registration): fix decoding error on organizationid (#2341)

### DIFF
--- a/apps/backend/src/__generated__/resolvers-types.ts
+++ b/apps/backend/src/__generated__/resolvers-types.ts
@@ -1765,7 +1765,7 @@ export type RefreshUserPlatformTokenResponse = {
 
 export type RegisterPlatformInput = {
   identifier: PlatformIdentifier;
-  organizationId: Scalars['OrganizationId']['input'];
+  organizationId: Scalars['ID']['input'];
   platform: PlatformInput;
 };
 

--- a/apps/backend/src/modules/registration/registration.graphql
+++ b/apps/backend/src/modules/registration/registration.graphql
@@ -35,7 +35,7 @@ enum PlatformIdentifier {
 }
 
 input RegisterPlatformInput {
-  organizationId: OrganizationId!
+  organizationId: ID!
   platform: PlatformInput!
   identifier: PlatformIdentifier!
 }

--- a/apps/backend/src/modules/registration/registration.resolver.ts
+++ b/apps/backend/src/modules/registration/registration.resolver.ts
@@ -1,3 +1,4 @@
+import { fromGlobalId } from 'graphql-relay/node/node.js';
 import {
   AutoRegisterPlatformInput,
   Resolvers,
@@ -85,7 +86,12 @@ const resolvers: Resolvers = {
   Mutation: {
     registerPlatform: async (_, { input }) => {
       try {
-        const token = await registrationApp.registerPlatform(input);
+        const payload = {
+          ...input,
+          // type may not be an OrganizationId, but can be a IsPlatformRegisteredOrganization
+          organizationId: fromGlobalId(input.organizationId).id,
+        };
+        const token = await registrationApp.registerPlatform(payload);
         return { token };
       } catch (error) {
         throw mapToGraphQLError(

--- a/apps/backend/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
+++ b/apps/backend/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
@@ -1,3 +1,4 @@
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -16,9 +17,10 @@ import { registrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.registerPlatform', () => {
-  it('should return the token', async () => {
+  it('should decode organizationId from global ID before calling registrationApp and return the token', async () => {
     // Given
-    const orgId = TEST_ORGANIZATIONS.FILIGRAN.ID;
+    const rawOrgId = TEST_ORGANIZATIONS.FILIGRAN.ID;
+    const globalOrgId = toGlobalId('Organization', rawOrgId);
     const generatedToken = uuidv4();
     const platformInput = {
       id: uuidv4(),
@@ -28,7 +30,7 @@ describe('mutation.registerPlatform', () => {
       version: '1.0.0',
     };
     const input: RegisterPlatformInput = {
-      organizationId: orgId,
+      organizationId: globalOrgId,
       platform: platformInput,
       identifier: PlatformIdentifier.Opencti,
     };
@@ -47,7 +49,7 @@ describe('mutation.registerPlatform', () => {
     // Then
     expect(registrationApp.registerPlatform).toHaveBeenCalledWith({
       ...input,
-      organizationId: orgId,
+      organizationId: rawOrgId,
     });
     expect(result).toMatchObject({ token: generatedToken });
   });
@@ -55,7 +57,10 @@ describe('mutation.registerPlatform', () => {
   it('should map to BadRequest for InvalidPlatformVersion error', async () => {
     // Given
     const input: RegisterPlatformInput = {
-      organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      organizationId: toGlobalId(
+        'Organization',
+        TEST_ORGANIZATIONS.FILIGRAN.ID
+      ),
       platform: {
         id: uuidv4(),
         url: 'http://example.com',

--- a/apps/frontend/schema.graphql
+++ b/apps/frontend/schema.graphql
@@ -867,7 +867,7 @@ enum PlatformIdentifier {
 }
 
 input RegisterPlatformInput {
-  organizationId: OrganizationId!
+  organizationId: ID!
   platform: PlatformInput!
   identifier: PlatformIdentifier!
 }


### PR DESCRIPTION

# Context
regression from https://github.com/FiligranHQ/xtm-hub/pull/2331 : registering a platform fails because of the decoding of the organizationId (it's not of type `OrganizationId`, but of type `IsPlatformRegisteredOrganization`. 


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
Register a platform, check it works.

## Related issues

- Related to #2341

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.