### PR TITLE
[backend] chore: clean up request context and fix capa check for adminUserEdit (#2382)

### DIFF
--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -27,6 +27,33 @@ export default defineConfig([
     '**/src/utils/error/error.util.ts',
   ]),
   {
+    files: ['**/*.ts'],
+    ignores: [
+      '**/model/portal-context.ts',
+      '**/*.resolver.ts',
+      '**/*.resolver.test.ts',
+      '**/security/directive-graphql/**',
+      '**/portal.const.ts',
+      '**/index.ts',
+      '**/pub.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/model/portal-context'],
+              importNames: ['PortalContext'],
+              message:
+                'PortalContext must only be used in the graphql layers (*.resolver.ts, security/directive-graphql/).',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.test.ts', '**/*.test.utils.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',

--- a/apps/backend/knexfile.ts
+++ b/apps/backend/knexfile.ts
@@ -14,7 +14,6 @@ import {
 } from './src/__generated__/resolvers-types';
 import portalConfig from './src/config';
 import { databaseContext } from './src/context/database.context';
-import { requestContext } from './src/context/request.context';
 import { DocumentHelper } from './src/modules/document/document.helper';
 import { INTEGRATION_METADATA_KEYS } from './src/modules/shareable-resource/opencti/integration/integration.model';
 import { logApp } from './src/utils/app-logger.util';
@@ -161,15 +160,11 @@ export function db<T>(
   type: DatabaseType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Knex.QueryBuilder<T, any> {
-  const reqContext = requestContext.get();
-
   const queryContext = database<T>(type).queryContext({
     __typename: type,
   });
 
-  if (reqContext?.trx && !reqContext.trx.isCompleted()) {
-    queryContext.transacting(reqContext.trx);
-  } else if (databaseContext.isInTransaction()) {
+  if (databaseContext.isInTransaction()) {
     queryContext.transacting(databaseContext.getTransaction());
   }
 

--- a/apps/backend/knexfile.ts
+++ b/apps/backend/knexfile.ts
@@ -15,7 +15,6 @@ import {
 import portalConfig from './src/config';
 import { databaseContext } from './src/context/database.context';
 import { requestContext } from './src/context/request.context';
-import { PortalContext } from './src/model/portal-context';
 import { DocumentHelper } from './src/modules/document/document.helper';
 import { INTEGRATION_METADATA_KEYS } from './src/modules/shareable-resource/opencti/integration/integration.model';
 import { logApp } from './src/utils/app-logger.util';
@@ -30,7 +29,6 @@ export interface SecuryQueryOpts {
 
 export interface KnexQueryBuilder extends Knex.QueryBuilder {
   _queryContext?: {
-    context: PortalContext;
     __typename: DatabaseType;
   };
 }
@@ -167,7 +165,6 @@ export function db<T>(
 
   const queryContext = database<T>(type).queryContext({
     __typename: type,
-    context: reqContext?.portalContext,
   });
 
   if (reqContext?.trx && !reqContext.trx.isCompleted()) {

--- a/apps/backend/src/context/request.context.test.ts
+++ b/apps/backend/src/context/request.context.test.ts
@@ -1,5 +1,4 @@
 // lib/Context.test.ts
-import { Knex } from 'knex';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { UserLoadUserBy } from '../model/user';
 import { UnknownErrorCode } from '../utils/error/error.code';
@@ -10,7 +9,7 @@ describe('requestContext', () => {
     id: 1,
     last_name: 'Test User',
   } as unknown as UserLoadUserBy;
-  const mockTrx = {} as Knex.Transaction;
+  const mockCorrelationId = 'test-correlation-id';
 
   beforeEach(() => {
     // Restore original implementations
@@ -31,7 +30,7 @@ describe('requestContext', () => {
     it('should return the current context when set', () => {
       const testContext: RequestContext = {
         user: mockUser,
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       requestContext.set(testContext);
@@ -64,7 +63,7 @@ describe('requestContext', () => {
     it('should set a new context', () => {
       const testContext: RequestContext = {
         user: mockUser,
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       requestContext.set(testContext);
@@ -76,7 +75,7 @@ describe('requestContext', () => {
     it('should replace existing context', () => {
       const firstContext: RequestContext = {
         user: mockUser,
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       const secondContext: RequestContext = {
@@ -100,7 +99,7 @@ describe('requestContext', () => {
       requestContext.set(initialContext);
 
       const updates = {
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       requestContext.update(updates);
@@ -112,25 +111,23 @@ describe('requestContext', () => {
     it('should overwrite existing fields when updating', () => {
       const initialContext: RequestContext = {
         user: mockUser,
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       requestContext.set(initialContext);
 
-      const newTrx = {
-        different: 'transaction',
-      } as unknown as Knex.Transaction;
-      requestContext.update({ trx: newTrx });
+      const newCorrelationId = 'new-correlation-id';
+      requestContext.update({ correlationId: newCorrelationId });
 
       const updatedContext = requestContext.get();
       expect(updatedContext?.user).toBe(mockUser);
-      expect(updatedContext?.trx).toBe(newTrx);
+      expect(updatedContext?.correlationId).toBe(newCorrelationId);
     });
 
     it('should handle empty updates gracefully', () => {
       const initialContext: RequestContext = {
         user: mockUser,
-        trx: mockTrx,
+        correlationId: mockCorrelationId,
       };
 
       requestContext.set(initialContext);
@@ -141,11 +138,9 @@ describe('requestContext', () => {
     });
 
     it('should throw without initial context', () => {
-      // This might throw or handle gracefully depending on implementation
-      // Adjust expectation based on your desired behavior
-      expect(() => requestContext.update({ trx: mockTrx })).toThrow(
-        UnknownErrorCode.NoAsyncContextAvailableError
-      );
+      expect(() =>
+        requestContext.update({ correlationId: mockCorrelationId })
+      ).toThrow(UnknownErrorCode.NoAsyncContextAvailableError);
     });
   });
 

--- a/apps/backend/src/context/request.context.test.ts
+++ b/apps/backend/src/context/request.context.test.ts
@@ -1,7 +1,6 @@
 // lib/Context.test.ts
 import { Knex } from 'knex';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { PortalContext } from '../model/portal-context';
 import { UserLoadUserBy } from '../model/user';
 import { UnknownErrorCode } from '../utils/error/error.code';
 import { requestContext, RequestContext } from './request.context';
@@ -11,9 +10,6 @@ describe('requestContext', () => {
     id: 1,
     last_name: 'Test User',
   } as unknown as UserLoadUserBy;
-  const mockPortalContext = {
-    portalId: 'test-portal',
-  } as unknown as PortalContext;
   const mockTrx = {} as Knex.Transaction;
 
   beforeEach(() => {
@@ -36,7 +32,6 @@ describe('requestContext', () => {
       const testContext: RequestContext = {
         user: mockUser,
         trx: mockTrx,
-        portalContext: mockPortalContext,
       };
 
       requestContext.set(testContext);
@@ -56,7 +51,6 @@ describe('requestContext', () => {
     it('should return context when available', () => {
       const testContext: RequestContext = {
         user: mockUser,
-        portalContext: mockPortalContext,
       };
 
       requestContext.set(testContext);
@@ -87,7 +81,6 @@ describe('requestContext', () => {
 
       const secondContext: RequestContext = {
         user: { id: 2, last_name: 'Second User' } as unknown as UserLoadUserBy,
-        portalContext: mockPortalContext,
       };
 
       requestContext.set(firstContext);
@@ -108,7 +101,6 @@ describe('requestContext', () => {
 
       const updates = {
         trx: mockTrx,
-        portalContext: mockPortalContext,
       };
 
       requestContext.update(updates);
@@ -161,7 +153,6 @@ describe('requestContext', () => {
     it('should execute callback with provided context', () => {
       const testContext: RequestContext = {
         user: mockUser,
-        portalContext: mockPortalContext,
       };
 
       let contextInsideCallback: RequestContext | undefined;
@@ -231,7 +222,6 @@ describe('requestContext', () => {
     it('should maintain context across async operations when using run()', async () => {
       const testContext: RequestContext = {
         user: mockUser,
-        portalContext: mockPortalContext,
       };
 
       await new Promise<void>((resolve) => {

--- a/apps/backend/src/context/request.context.ts
+++ b/apps/backend/src/context/request.context.ts
@@ -1,11 +1,8 @@
-// lib/context.ts
 import { AsyncLocalStorage } from 'async_hooks';
-import { Knex } from 'knex';
 import { UserLoadUserBy } from '../model/user';
 import { UnknownErrorCode } from '../utils/error/error.code';
 export interface RequestContext {
   user: UserLoadUserBy;
-  trx?: Knex.Transaction;
   correlationId?: string;
 }
 

--- a/apps/backend/src/context/request.context.ts
+++ b/apps/backend/src/context/request.context.ts
@@ -1,13 +1,11 @@
 // lib/context.ts
 import { AsyncLocalStorage } from 'async_hooks';
 import { Knex } from 'knex';
-import { PortalContext } from '../model/portal-context';
 import { UserLoadUserBy } from '../model/user';
 import { UnknownErrorCode } from '../utils/error/error.code';
 export interface RequestContext {
   user: UserLoadUserBy;
   trx?: Knex.Transaction;
-  portalContext?: PortalContext;
   correlationId?: string;
 }
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -267,7 +267,6 @@ const middlewareExpress = expressMiddleware(server, {
 
     const portalContext: PortalContext = { user, req, res };
 
-    requestContext.update({ portalContext: portalContext });
     return portalContext;
   },
 });

--- a/apps/backend/src/modules/deployment/deployment.app.test.ts
+++ b/apps/backend/src/modules/deployment/deployment.app.test.ts
@@ -1176,7 +1176,6 @@ describe('deployment app', () => {
 
       requestContext.set({
         user: contextUserWithPersonalOrga.user,
-        portalContext: contextUserWithPersonalOrga,
       });
 
       const trialDeployments = await DeploymentApp.loadTrialDeployments({

--- a/apps/backend/src/modules/document/document-download-endpoint.ts
+++ b/apps/backend/src/modules/document/document-download-endpoint.ts
@@ -5,7 +5,6 @@ import { fromGlobalId } from 'graphql-relay/node/node.js';
 import { Readable } from 'stream';
 import { requestContext } from '../../context/request.context';
 import { DocumentId } from '../../model/kanel/public/Document';
-import { PortalContext } from '../../model/portal-context';
 import { UserLoadUserBy } from '../../model/user';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
@@ -70,12 +69,7 @@ export const documentDownloadEndpoint = (app) => {
           return;
         }
 
-        const context: PortalContext = {
-          user: user,
-          req,
-          res,
-        };
-        requestContext.update({ portalContext: context });
+        requestContext.update({ user });
         const token = extractPlatformToken(req);
         // check only if token is present to keep old OpenCTI versions compatibility
         if (isLoadedFromUserPlatformToken && token) {
@@ -122,12 +116,12 @@ export const documentDownloadEndpoint = (app) => {
           try {
             if (shouldSendEventForService(serviceDefinition.identifier)) {
               const selectedOrga = await OrganizationDomain.loadOrganizationBy({
-                id: context.user.selected_organization_id,
+                id: user.selected_organization_id,
               });
 
               const downloadEvent = await buildDownloadEvent(
                 selectedOrga,
-                context.user.id,
+                user.id,
                 serviceDefinition.identifier,
                 document.id,
                 document.name

--- a/apps/backend/src/modules/document/document-download-endpoint.ts
+++ b/apps/backend/src/modules/document/document-download-endpoint.ts
@@ -7,15 +7,15 @@ import { requestContext } from '../../context/request.context';
 import { DocumentId } from '../../model/kanel/public/Document';
 import { PortalContext } from '../../model/portal-context';
 import { UserLoadUserBy } from '../../model/user';
-import {
-  extractPlatformToken,
-  validateActivePlatformToken,
-} from '../../security/directive-graphql/validator/platform-token-validator';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 import { NotFoundError } from '../../utils/error/error.util';
 import { OrganizationDomain } from '../organization-management/organization/organization.domain';
 import { UserDomain } from '../organization-management/user/user-domain/user.domain';
+import {
+  extractPlatformToken,
+  validateActivePlatformToken,
+} from '../security-management/token/platform-token.util';
 import { loadServiceDefinitionByServiceInstance } from '../service/instance/service-instance.domain';
 import { telemetryApp } from '../telemetry/telemetry.app';
 import {

--- a/apps/backend/src/modules/document/document.test.ts
+++ b/apps/backend/src/modules/document/document.test.ts
@@ -258,10 +258,6 @@ describe('increment shared counter', () => {
   beforeEach(async () => {
     const testContext = {
       user: requestContextSimpleUserSecondOrga.user,
-      portalContext: {
-        ...contextSimpleUserSecondOrga,
-        serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
-      },
     };
     requestContext.set(testContext);
     await DocumentApp.createDocumentWithChildrenAndMetadata<CsvFeed>(

--- a/apps/backend/src/modules/document/visualize-document-endpoint.ts
+++ b/apps/backend/src/modules/document/visualize-document-endpoint.ts
@@ -5,7 +5,6 @@ import { requestContext } from '../../context/request.context';
 import { DocumentId } from '../../model/kanel/public/Document';
 import ServiceDefinition from '../../model/kanel/public/ServiceDefinition';
 import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
-import { PortalContext } from '../../model/portal-context';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 import { NotFoundError } from '../../utils/error/error.util';
@@ -24,12 +23,7 @@ export const documentVisualizeEndpoint = (app) => {
         return;
       }
       try {
-        const context: PortalContext = {
-          user: user,
-          req,
-          res,
-        };
-        requestContext.update({ portalContext: context });
+        requestContext.update({ user: user });
         const document = await DocumentDomain.loadDocumentBy({
           id: extractId<DocumentId>(req.params.filename),
         });

--- a/apps/backend/src/modules/document/visualize-document-endpoint.ts
+++ b/apps/backend/src/modules/document/visualize-document-endpoint.ts
@@ -23,7 +23,7 @@ export const documentVisualizeEndpoint = (app) => {
         return;
       }
       try {
-        requestContext.update({ user: user });
+        requestContext.update({ user });
         const document = await DocumentDomain.loadDocumentBy({
           id: extractId<DocumentId>(req.params.filename),
         });

--- a/apps/backend/src/modules/news-feed/news-feed.resolver.ts
+++ b/apps/backend/src/modules/news-feed/news-feed.resolver.ts
@@ -5,11 +5,11 @@ import {
 } from '../../__generated__/resolvers-types';
 import { NewsFeedItemId } from '../../model/kanel/public/NewsFeedItem';
 import { PortalContext } from '../../model/portal-context';
+import { mapToGraphQLError } from '../../utils/error/error.mapping';
 import {
   extractPlatformId,
   extractPlatformToken,
-} from '../../security/directive-graphql/validator/platform-token-validator';
-import { mapToGraphQLError } from '../../utils/error/error.mapping';
+} from '../security-management/token/platform-token.util';
 import { createRelayIdScalar } from '../../utils/scalar.util';
 import { NewsFeedApp } from './news-feed.app';
 import { NewsFeedDomain } from './news-feed.domain';

--- a/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.test.ts
@@ -192,7 +192,7 @@ describe('users admin app', () => {
           },
         });
 
-        await expect(call).rejects.toThrow('CANT_REMOVE_LAST_ADMINISTRATOR');
+        await expect(call).rejects.toThrow(ErrorCode.CantRemoveLastAdministrator);
       });
     });
   });

--- a/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.test.ts
@@ -4,17 +4,199 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   TEST_ORGANIZATIONS,
   requestContextAdminSecondOrga,
+  // eslint-disable-next-line no-restricted-imports -- needed to test platform admin bypass behavior in editUser authorization
+  requestContextAdminUser,
+  requestContextSimpleUserSecondOrga,
 } from '../../../../../tests/tests.const';
-import { FilterKey } from '../../../../__generated__/resolvers-types';
+import {
+  FilterKey,
+  OrganizationCapability,
+} from '../../../../__generated__/resolvers-types';
 import { requestContext } from '../../../../context/request.context';
+import { OrganizationId } from '../../../../model/kanel/public/Organization';
 import User from '../../../../model/kanel/public/User';
+import { UserLoadUserBy } from '../../../../model/user';
 import { ErrorCode } from '../../../../utils/error/error.code';
 import { OrganizationDomain } from '../../organization/organization.domain';
+import { UserDomain } from '../user-domain/user.domain';
 import * as UsersHelper from '../user.helper';
 import { createNewUserWithPendingOrga, removeUser } from '../user.helper';
 import { UserAdminApp } from './user.admin.app';
 
 describe('users admin app', () => {
+  describe('editUser', () => {
+    describe('authorization', () => {
+      it('should reject a user without org capabilities', async () => {
+        requestContext.set(requestContextSimpleUserSecondOrga);
+
+        const call = UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
+          input: { organization_capabilities: [] },
+        });
+
+        await expect(call).rejects.toThrow(
+          ErrorCode.MissingCapabilityOnOrganization
+        );
+      });
+
+      it('should reject an org admin trying to edit a user from a different organization', async () => {
+        requestContext.set(requestContextAdminSecondOrga);
+
+        const call = UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          input: { organization_capabilities: [] },
+        });
+
+        await expect(call).rejects.toThrow(ErrorCode.UserIsNotInOrganization);
+      });
+
+      it('should reject an org admin trying to set capabilities on an organization they do not control', async () => {
+        requestContext.set(requestContextAdminSecondOrga);
+
+        const call = UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
+          input: {
+            organization_capabilities: [
+              {
+                organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+                capabilities: [],
+              },
+              {
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+                capabilities: [OrganizationCapability.AdministrateOrganization],
+              },
+            ],
+          },
+        });
+
+        await expect(call).rejects.toThrow(
+          ErrorCode.MissingCapabilityOnOrganization
+        );
+      });
+
+      it('should allow a platform admin to edit a user from any organization', async () => {
+        requestContext.set(requestContextAdminUser);
+
+        const call = UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
+          input: { organization_capabilities: [], first_name: 'Updated' },
+        });
+
+        await expect(call).rejects.not.toThrow(
+          ErrorCode.UserIsNotInOrganization
+        );
+      });
+    });
+
+    describe('organization capabilities update', () => {
+      let simpleUser: UserLoadUserBy;
+
+      beforeEach(async () => {
+        requestContext.set(requestContextAdminUser);
+        simpleUser = await UserDomain.loadUserBy({
+          'User.id': TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        });
+      });
+
+      afterEach(async () => {
+        requestContext.set(requestContextAdminUser);
+        await UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          input: {
+            organization_capabilities: (
+              simpleUser.organization_capabilities ?? []
+            ).map((oc) => ({
+              organization_id: oc.organization.id,
+              capabilities: oc.capabilities,
+            })),
+          },
+        });
+      });
+
+      it('should update organization_capabilities', async () => {
+        await UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          input: {
+            organization_capabilities: [
+              {
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE
+                  .ID as unknown as OrganizationId,
+                capabilities: [
+                  OrganizationCapability.ManageAccess,
+                  OrganizationCapability.ManageSubscription,
+                ],
+              },
+              {
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+                capabilities: [
+                  OrganizationCapability.ManageAccess,
+                  OrganizationCapability.ManageSubscription,
+                ],
+              },
+              {
+                organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+                capabilities: [],
+              },
+            ],
+          },
+        });
+        const result = await UserDomain.loadUserBy({
+          'User.id': TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        });
+
+        expect(result.organization_capabilities).toHaveLength(3);
+      });
+
+      it('should not update other user fields', async () => {
+        const result = await UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          input: {
+            organization_capabilities: [
+              {
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE
+                  .ID as unknown as OrganizationId,
+                capabilities: [
+                  OrganizationCapability.ManageAccess,
+                  OrganizationCapability.ManageSubscription,
+                ],
+              },
+              {
+                organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+                capabilities: [
+                  OrganizationCapability.ManageAccess,
+                  OrganizationCapability.ManageSubscription,
+                ],
+              },
+            ],
+          },
+        });
+
+        expect(result.first_name).toBe(simpleUser.first_name);
+        expect(result.email).toBe(simpleUser.email);
+      });
+    });
+
+    describe('last administrator protection', () => {
+      it('should prevent deletion of the last organization administrator', async () => {
+        requestContext.set(requestContextAdminUser);
+
+        const call = UserAdminApp.editUser({
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
+          input: {
+            organization_capabilities: [
+              {
+                organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+                capabilities: [],
+              },
+            ],
+          },
+        });
+
+        await expect(call).rejects.toThrow('CANT_REMOVE_LAST_ADMINISTRATOR');
+      });
+    });
+  });
+
   describe('bulkAcceptPendingUserInOrganization', () => {
     let createdUsers: User[];
     let mockAcceptPendingUser: MockInstance<

--- a/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.ts
+++ b/apps/backend/src/modules/organization-management/user/user-admin/user.admin.app.ts
@@ -17,6 +17,7 @@ import { updateUserSession } from '../../../../session-store-manager';
 import { auth0Client } from '../../../../thirdparty/auth0/client';
 import { logApp } from '../../../../utils/app-logger.util';
 import { ErrorCode } from '../../../../utils/error/error.code';
+import { ForbiddenAccess } from '../../../../utils/error/error.util';
 import { OrganizationDomain } from '../../organization/organization.domain';
 import { UserDomain } from '../user-domain/user.domain';
 import { UserOrganizationDomain } from '../user-organization/user-organization.domain';
@@ -87,6 +88,29 @@ export const UserAdminApp = {
     userId: UserId;
     input: AdminEditUserInput;
   }) => {
+    const { user: contextUser } = requestContext.require();
+    if (!isUserAdminPlatform(contextUser)) {
+      await securityGuard.assertUserCapabilities(
+        [
+          OrganizationCapability.AdministrateOrganization,
+          OrganizationCapability.ManageAccess,
+        ],
+        contextUser.selected_organization_id
+      );
+      const targetUser = await UserDomain.loadUserBy({ 'User.id': userId });
+      await securityGuard.assertUserIsInOrganization(
+        targetUser,
+        contextUser.selected_organization_id
+      );
+
+      const unauthorizedOrg = (input.organization_capabilities ?? []).find(
+        (orgCapa) =>
+          orgCapa.organization_id !== contextUser.selected_organization_id
+      );
+      if (unauthorizedOrg) {
+        throw ForbiddenAccess(ErrorCode.MissingCapabilityOnOrganization);
+      }
+    }
     const { organization_capabilities, ...userInput } = input;
     const mappedCapabilities = (organization_capabilities ?? []).map(
       (orgCapability) => ({

--- a/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
+++ b/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
@@ -18,8 +18,6 @@ import {
   UserWithOrganizationsAndRole,
 } from '../../../../model/user';
 import { ADMIN_UUID, CAPABILITY_BYPASS } from '../../../../portal.const';
-import { isUserAdminPlatform } from '../../../../security/access';
-import { checkUserCapabilities } from '../../../../security/util/user';
 import { auth0Client } from '../../../../thirdparty/auth0/client';
 import { hubspotLoginHook } from '../../../../thirdparty/hubspot/hubspot';
 import { logApp } from '../../../../utils/app-logger.util';
@@ -327,13 +325,6 @@ export const UserDomain = {
   updateUser: async (id: UserId, input: UserMutator): Promise<User> => {
     if (isEmpty(input)) {
       return;
-    }
-    const { user } = requestContext.require();
-    if (!isUserAdminPlatform(user)) {
-      await checkUserCapabilities([
-        OrganizationCapability.AdministrateOrganization,
-        OrganizationCapability.ManageAccess,
-      ]);
     }
 
     const [updatedUser] = await db<User>('User')

--- a/apps/backend/src/modules/organization-management/user/user-organization/user-organization.app.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user-organization/user-organization.app.test.ts
@@ -9,7 +9,6 @@ import {
 import portalConfig from '../../../../config';
 import { requestContext } from '../../../../context/request.context';
 import User, { UserId } from '../../../../model/kanel/public/User';
-import { PortalContext } from '../../../../model/portal-context';
 import * as MailService from '../../../../server/mail-service';
 import { ErrorCode } from '../../../../utils/error/error.code';
 import { UserOrganizationPendingDomain } from '../user-pending/user-organization-pending.domain';
@@ -310,14 +309,8 @@ describe('usersOrganizationApp', () => {
   });
   describe('changeSelectedOrganization', () => {
     it('should allow user to switch to an organization they belong to', async () => {
-      const testContext = {
-        ...contextAdminSecondOrga,
-        req: { session: { user: null, save: vi.fn() } },
-      } as unknown as PortalContext;
-
       requestContext.set({
-        user: testContext.user,
-        portalContext: testContext,
+        user: contextAdminSecondOrga.user,
       });
 
       const updatedUser = await UserOrganizationApp.changeSelectedOrganization(
@@ -332,7 +325,6 @@ describe('usersOrganizationApp', () => {
     it('should reject switching to an organization the user does not belong to', async () => {
       requestContext.set({
         user: contextSimpleUserSecondOrga.user,
-        portalContext: contextSimpleUserSecondOrga,
       });
 
       await expect(

--- a/apps/backend/src/modules/organization-management/user/user-organization/user-organization.app.ts
+++ b/apps/backend/src/modules/organization-management/user/user-organization/user-organization.app.ts
@@ -93,7 +93,7 @@ export const UserOrganizationApp = {
   changeSelectedOrganization: async (
     organization_id: OrganizationId
   ): Promise<UserLoadUserBy> => {
-    const { user, portalContext } = requestContext.require();
+    const { user } = requestContext.require();
 
     await securityGuard.assertUserIsInOrganization(user, organization_id);
 
@@ -103,9 +103,6 @@ export const UserOrganizationApp = {
     const updatedUserLoadUserBy = await UserDomain.loadUserBy({
       'User.id': updatedUser.id,
     });
-    portalContext.req.session.user = updatedUserLoadUserBy;
-    portalContext.req.session.save();
-    portalContext.user = updatedUserLoadUserBy;
     requestContext.update({ user: updatedUserLoadUserBy });
 
     return updatedUserLoadUserBy;

--- a/apps/backend/src/modules/organization-management/user/user.auth.app.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.auth.app.test.ts
@@ -1,4 +1,5 @@
 import config from 'config';
+import express from 'express';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserLoadUserBy } from '../../../model/user';
 import * as UserSecurity from '../../../security/util/user';
@@ -20,10 +21,8 @@ vi.mock('../../../security/util/user', () => ({
   validatePassword: vi.fn(),
 }));
 
-const mockContext = {
-  req: { session: {} },
-  res: { cookie: vi.fn() },
-} as never;
+const mockReq = { session: {} } as unknown as express.Request;
+const mockRes = { cookie: vi.fn() } as unknown as express.Response;
 
 const mockUser = {
   id: 'user-id',
@@ -47,7 +46,7 @@ describe('usersAuthApp', () => {
         (config.get as Mock).mockReturnValue(SSO_ONLY_SETTINGS);
 
         await expect(
-          UserAuthApp.login(mockContext, {
+          UserAuthApp.login(mockReq, mockRes, {
             email: 'user@company.com',
             password: '',
           })
@@ -58,7 +57,7 @@ describe('usersAuthApp', () => {
         (config.get as Mock).mockReturnValue([]);
 
         await expect(
-          UserAuthApp.login(mockContext, {
+          UserAuthApp.login(mockReq, mockRes, {
             email: 'user@company.com',
             password: 'somepassword',
           })
@@ -76,13 +75,13 @@ describe('usersAuthApp', () => {
         vi.mocked(UserDomain.updateUserAtLogin).mockResolvedValue(mockUser);
         vi.mocked(UserSecurity.validatePassword).mockReturnValue(true);
 
-        const result = await UserAuthApp.login(mockContext, {
+        const result = await UserAuthApp.login(mockReq, mockRes, {
           email: 'user@company.com',
           password: 'correctpassword',
         });
 
         expect(result).toBe(mockUser);
-        expect(mockContext.req.session).toMatchObject({ user: mockUser });
+        expect(mockReq.session).toMatchObject({ user: mockUser });
       });
 
       it.each`
@@ -97,7 +96,7 @@ describe('usersAuthApp', () => {
             passwordValid
           );
 
-          const result = await UserAuthApp.login(mockContext, {
+          const result = await UserAuthApp.login(mockReq, mockRes, {
             email: 'user@company.com',
             password: 'wrongpassword',
           });

--- a/apps/backend/src/modules/organization-management/user/user.auth.app.ts
+++ b/apps/backend/src/modules/organization-management/user/user.auth.app.ts
@@ -1,7 +1,7 @@
 import config from 'config';
+import express from 'express';
 import { MutationLoginArgs } from '../../../__generated__/resolvers-types';
 import portalConfig from '../../../config';
-import { PortalContext } from '../../../model/portal-context';
 import { UserLoadUserBy } from '../../../model/user';
 import { validatePassword } from '../../../security/util/user';
 import { ForbiddenAccess } from '../../../utils/error/error.util';
@@ -19,14 +19,14 @@ const isLocalAuthEnabled = (): boolean => {
 
 export const UserAuthApp = {
   login: async (
-    context: PortalContext,
+    req: express.Request,
+    res: express.Response,
     { email, password }: MutationLoginArgs
   ) => {
     if (!isLocalAuthEnabled()) {
       throw ForbiddenAccess('Local authentication is not enabled');
     }
 
-    const { req, res } = context;
     const loggedUser = await UserDomain.loadUserBy({ email });
     if (loggedUser && validPassword(loggedUser, password)) {
       req.session.user = await UserDomain.updateUserAtLogin(loggedUser);
@@ -39,7 +39,11 @@ export const UserAuthApp = {
     return undefined;
   },
 
-  logout: async ({ user, req, res }: PortalContext): Promise<string> => {
+  logout: async (
+    user: UserLoadUserBy,
+    req: express.Request,
+    res: express.Response
+  ): Promise<string> => {
     return new Promise((resolve) => {
       res.clearCookie(portalConfig.session.name);
       req.session.destroy(() => {

--- a/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
@@ -89,7 +89,6 @@ describe('user query resolver', () => {
         };
         requestContext.set({
           user: currentContext.user,
-          portalContext: currentContext,
         });
 
         const response =
@@ -116,7 +115,6 @@ describe('user query resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const email = `testPending${uuidv4()}@second-orga.com`;
       const pendingUser = await loginFromProvider({
@@ -184,7 +182,6 @@ describe('user query resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const response = await usersResolver.Query!.pendingUsers!(
         {},
@@ -230,7 +227,6 @@ describe('user query resolver', () => {
 
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const response = await usersResolver.Query!.pendingUsers!(
         {},
@@ -746,7 +742,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const call = usersResolver.Mutation!.editUserCapabilities!(
         {},
@@ -775,7 +770,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       await usersResolver.Mutation!.editUserCapabilities!(
         {},
@@ -820,7 +814,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const pendingUser = await loginFromProvider({
         email: `testPending${uuidv4()}@second-orga.com`,
@@ -983,7 +976,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const email = `testPending${uuidv4()}@second-orga.com`;
       const pendingUser = await loginFromProvider({
@@ -1025,7 +1017,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
       const email = `testPending${uuidv4()}@second-orga.com`;
       const pendingUser = await loginFromProvider({
@@ -1082,7 +1073,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
 
       await usersResolver.Mutation?.bulkRemovePendingUserFromOrganization!(
@@ -1126,7 +1116,6 @@ describe('user mutation resolver', () => {
       };
       requestContext.set({
         user: testContext.user,
-        portalContext: testContext,
       });
 
       const organizationId = toGlobalId(

--- a/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
@@ -29,11 +29,9 @@ import {
 } from '../../../../tests/tests.const';
 import {
   AddUserInput,
-  AdminEditUserInput,
   FilterKey,
   OrderingMode,
   Organization,
-  OrganizationCapability,
   UserOrdering,
 } from '../../../__generated__/resolvers-types';
 import { requestContext } from '../../../context/request.context';
@@ -47,6 +45,7 @@ import {
   deleteSubscription,
   insertSubscription,
 } from '../../subscription/subscription.helper';
+import { UserAdminApp } from './user-admin/user.admin.app';
 import { UserDomain } from './user-domain/user.domain';
 import { UserOrganizationDomain } from './user-organization/user-organization.domain';
 import { UserOrganizationPendingDomain } from './user-pending/user-organization-pending.domain';
@@ -568,137 +567,25 @@ describe('user mutation resolver', () => {
   });
 
   describe('adminEditUser', () => {
-    let secondOrgaUser: UserLoadUserBy;
-
-    describe('existing user edition', async () => {
-      let fallbackUser: UserLoadUserBy;
-      let response: {
-        organization_capabilities: unknown[];
-        first_name: string;
-        email: string;
+    it('should delegate to UserAdminApp.editUser and return the result', async () => {
+      const mockUser = {
+        id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        email: 'user@test.com',
       };
-      beforeAll(async () => {
-        fallbackUser = await UserDomain.loadUserBy({ email: 'user15@test.fr' });
+      vi.spyOn(UserAdminApp, 'editUser').mockResolvedValue(mockUser as never);
 
-        // @ts-ignore
-        response = await usersResolver.Mutation!.adminEditUser!(
-          undefined,
-          {
-            id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
-            input: {
-              organization_capabilities: [
-                {
-                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
-                  capabilities: [
-                    OrganizationCapability.ManageAccess,
-                    OrganizationCapability.ManageSubscription,
-                  ],
-                },
-                {
-                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-                  capabilities: [
-                    OrganizationCapability.ManageAccess,
-                    OrganizationCapability.ManageSubscription,
-                  ],
-                },
-                {
-                  organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
-                  capabilities: [],
-                },
-              ],
-            } as AdminEditUserInput,
-          },
-          contextBypassUser
-        );
+      // @ts-expect-error adminEditUser is not considered as callable
+      const result = await usersResolver.Mutation!.adminEditUser!(
+        undefined,
+        { id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID, input: {} },
+        contextBypassUser
+      );
 
-        expect(response).toBeTruthy();
+      expect(UserAdminApp.editUser).toHaveBeenCalledWith({
+        userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        input: {},
       });
-
-      afterAll(async () => {
-        // @ts-ignore
-        await usersResolver.Mutation!.adminEditUser!(
-          undefined,
-          {
-            id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
-            input: {
-              organization_capabilities: [
-                {
-                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
-                  capabilities: [
-                    OrganizationCapability.ManageAccess,
-                    OrganizationCapability.ManageSubscription,
-                  ],
-                },
-                {
-                  organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-                  capabilities: [
-                    OrganizationCapability.ManageAccess,
-                    OrganizationCapability.ManageSubscription,
-                  ],
-                },
-              ],
-            } as AdminEditUserInput,
-          },
-          contextBypassUser
-        );
-      });
-
-      it('should have update organisations, first_name and last_name', async () => {
-        expect(response.organization_capabilities).toHaveLength(3);
-      });
-      it('should not have update other fields', async () => {
-        expect(fallbackUser.first_name).toEqual(response.first_name);
-        expect(fallbackUser.email).toEqual(response.email);
-      });
-    });
-
-    describe('administrator deletion', async () => {
-      beforeAll(async () => {
-        secondOrgaUser = await UserDomain.loadUserBy({
-          email: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.EMAIL,
-        });
-      });
-
-      afterEach(async () => {
-        // @ts-expect-error adminEditUser is not considered as callable
-        await usersResolver.Mutation!.adminEditUser!(
-          undefined,
-          {
-            id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
-            input: {
-              organization_capabilities:
-                secondOrgaUser.organization_capabilities!.map(
-                  (organizationCapabilities) => ({
-                    organization_id: organizationCapabilities.organization.id,
-                    capabilities: organizationCapabilities.capabilities,
-                  })
-                ),
-            },
-          },
-          contextBypassUser
-        );
-      });
-
-      it('should prevent deletion of the last organization administrator', async () => {
-        // @ts-expect-error adminEditUser is not considered as callable
-        const call = usersResolver.Mutation!.adminEditUser!(
-          undefined,
-          {
-            id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.ADMIN_ORGA.ID,
-            input: {
-              organization_capabilities: [
-                {
-                  organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
-                  capabilities: [],
-                },
-              ],
-            } as AdminEditUserInput,
-          },
-          contextBypassUser
-        );
-
-        await expect(call).rejects.toThrow('CANT_REMOVE_LAST_ADMINISTRATOR');
-      });
+      expect(result).toEqual(mockUser);
     });
   });
 

--- a/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.resolver.test.ts
@@ -39,6 +39,7 @@ import {
 import { requestContext } from '../../../context/request.context';
 import { SubscriptionId } from '../../../model/kanel/public/Subscription';
 import { UserId } from '../../../model/kanel/public/User';
+import { PortalContext } from '../../../model/portal-context';
 import { UserLoadUserBy } from '../../../model/user';
 import { auth0ClientMock } from '../../../thirdparty/auth0/mock';
 import { loginFromProvider } from '../../security-management/authentication/auth-user';
@@ -1164,6 +1165,43 @@ describe('user mutation resolver', () => {
 
       await removeUser({ email: pendingUser.email });
       await subscriptionSpy.cleanup();
+    });
+  });
+
+  describe('changeSelectedOrganization', () => {
+    it('should update portalContext.user and session.user after switching organization', async () => {
+      // Given
+      const mockSessionSave = vi.fn();
+      const mockPortalContext = {
+        user: { ...contextSimpleUserSecondOrga.user },
+        req: {
+          session: {
+            user: { ...contextSimpleUserSecondOrga.user },
+            save: mockSessionSave,
+          },
+        },
+        res: {},
+      } as unknown as PortalContext;
+      requestContext.set(requestContextSimpleUserSecondOrga);
+      const targetOrgId =
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.PERSONAL_SPACE_ID;
+
+      // When
+      // @ts-ignore
+      const response = await usersResolver.Mutation.changeSelectedOrganization(
+        {},
+        { organization_id: targetOrgId },
+        mockPortalContext,
+        {} as GraphQLResolveInfo
+      );
+
+      // Then
+      expect(response).toBeTruthy();
+      expect(mockPortalContext.user.selected_organization_id).toBe(targetOrgId);
+      expect(mockPortalContext.req.session.user.selected_organization_id).toBe(
+        targetOrgId
+      );
+      expect(mockSessionSave).toHaveBeenCalledOnce();
     });
   });
 });

--- a/apps/backend/src/modules/organization-management/user/user.resolver.ts
+++ b/apps/backend/src/modules/organization-management/user/user.resolver.ts
@@ -166,10 +166,18 @@ const resolvers: Resolvers = {
         throw mapToGraphQLError(error, UnknownErrorCode.TransferMeError);
       }
     },
-    changeSelectedOrganization: async (_, { organization_id }) => {
+    changeSelectedOrganization: async (
+      _,
+      { organization_id },
+      portalContext
+    ) => {
       try {
         const user =
           await UserOrganizationApp.changeSelectedOrganization(organization_id);
+
+        portalContext.req.session.user = user;
+        portalContext.req.session.save();
+        portalContext.user = user;
 
         return mapUserToGraphqlUser(user);
       } catch (error) {

--- a/apps/backend/src/modules/organization-management/user/user.resolver.ts
+++ b/apps/backend/src/modules/organization-management/user/user.resolver.ts
@@ -266,9 +266,9 @@ const resolvers: Resolvers = {
         );
       }
     },
-    login: async (_, args, context) => {
+    login: async (_, args, { req, res }) => {
       try {
-        const loggedUser = await UserAuthApp.login(context, args);
+        const loggedUser = await UserAuthApp.login(req, res, args);
         if (loggedUser) {
           return mapUserToGraphqlUser(loggedUser);
         }
@@ -282,8 +282,8 @@ const resolvers: Resolvers = {
         throw mapToGraphQLError(error);
       }
     },
-    logout: async (_, __, context) => {
-      return UserAuthApp.logout(context);
+    logout: async (_, __, { user, req, res }) => {
+      return UserAuthApp.logout(user, req, res);
     },
     contactUs: async (
       _,

--- a/apps/backend/src/modules/registration/registration.domain.test.ts
+++ b/apps/backend/src/modules/registration/registration.domain.test.ts
@@ -3,7 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestHelper } from '../../../tests/helper/test.helper';
 import {
-  contextRegistererUserSecondOrga,
   contextSimpleUserSecondOrga,
   requestContextRegistererUserSecondOrga,
   SERVICES,
@@ -54,9 +53,6 @@ describe('registration domain', () => {
     it('save registration data', async () => {
       const testContext = {
         user: requestContextRegistererUserSecondOrga.user,
-        portalContext: {
-          ...contextRegistererUserSecondOrga,
-        },
       };
       requestContext.set(testContext);
       await registrationDomain.registerNewPlatform({

--- a/apps/backend/src/modules/security-management/service-capability/service-capability.helper.test.ts
+++ b/apps/backend/src/modules/security-management/service-capability/service-capability.helper.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { ServiceRestriction } from '../../../__generated__/resolvers-types';
 import { requestContext } from '../../../context/request.context';
 import { UserServiceId } from '../../../model/kanel/public/UserService';
-import { PortalContext } from '../../../model/portal-context';
 import { UserLoadUserBy } from '../../../model/user';
 import { UserServiceDomain } from '../../user-service/user-service.domain';
 import * as ServiceCapaDomain from './service-capability.domain';
@@ -35,7 +34,6 @@ describe('willManageAccessBeConserved', () => {
       const result = async () => {
         requestContext.set({
           user: { id: 'theSame' } as UserLoadUserBy,
-          portalContext: { user: { id: 'theSame' } } as PortalContext,
         });
         await willManageAccessBeConserved(
           'userServiceId' as UserServiceId,

--- a/apps/backend/src/modules/security-management/token/platform-token.util.test.ts
+++ b/apps/backend/src/modules/security-management/token/platform-token.util.test.ts
@@ -1,0 +1,228 @@
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { describe, expect, it, vi } from 'vitest';
+import { ServiceConfigurationStatus } from '../../../__generated__/resolvers-types';
+import DeploymentRequest from '../../../model/kanel/public/DeploymentRequest';
+import ServiceConfiguration from '../../../model/kanel/public/ServiceConfiguration';
+import { DeploymentRequestDomain } from '../../../modules/deployment/deployment.domain';
+import { ServiceConfigurationDomain } from '../../../modules/registration/service-configuration/service-configuration.domain';
+import {
+  PLATFORM_ID_HEADER,
+  PLATFORM_TOKEN_HEADER,
+  validateActivePlatformToken,
+  validateAndGetRequestedPlatformToken,
+} from './platform-token.util';
+
+describe('platform Token Validation', () => {
+  describe('validateActivePlatformToken', () => {
+    it('should return false when platform token header is missing', async () => {
+      const req: express.Request = {
+        headers: {},
+      } as unknown as express.Request;
+
+      const result = await validateActivePlatformToken(req);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when platform id header is missing', async () => {
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: 'anything',
+        },
+      } as unknown as express.Request;
+
+      const result = await validateActivePlatformToken(req);
+
+      expect(result).toBe(false);
+    });
+    it('should return false when headers are valid but no matching platform found', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+      vi.spyOn(
+        ServiceConfigurationDomain,
+        'loadConfigurationByPlatformAndToken'
+      ).mockResolvedValue(undefined);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateActivePlatformToken(req);
+
+      expect(result).toBe(false);
+    });
+    it('should return false when platform is found but inactive', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+      vi.spyOn(
+        ServiceConfigurationDomain,
+        'loadConfigurationByPlatformAndToken'
+      ).mockResolvedValue({
+        config: { platform_id: platformId },
+        status: ServiceConfigurationStatus.Inactive,
+      } as unknown as ServiceConfiguration);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateActivePlatformToken(req);
+
+      expect(result).toBe(false);
+    });
+    it('should return true when valid header for registered platform are provided', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+      vi.spyOn(
+        ServiceConfigurationDomain,
+        'loadConfigurationByPlatformAndToken'
+      ).mockResolvedValue({
+        config: { platform_id: platformId },
+        status: ServiceConfigurationStatus.Active,
+      } as unknown as ServiceConfiguration);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateActivePlatformToken(req);
+
+      expect(result).toBe(true);
+    });
+  });
+  describe('validateAndGetRequestedPlatformToken', () => {
+    it('should return null when headers are missing', async () => {
+      const req: express.Request = {
+        headers: {},
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when platform id header is missing', async () => {
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: 'anything',
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when platform token header is missing', async () => {
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_ID_HEADER]: 'anything',
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return true when valid header for requested are provided', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+
+      vi.spyOn(
+        DeploymentRequestDomain,
+        'loadDeploymentRequestBy'
+      ).mockResolvedValue({
+        platform_id: platformId,
+      } as DeploymentRequest);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should return null when platform id header provided is unknown', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+
+      vi.spyOn(
+        DeploymentRequestDomain,
+        'loadDeploymentRequestBy'
+      ).mockResolvedValue(undefined);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when platform id header provided is not matching token', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+
+      vi.spyOn(
+        DeploymentRequestDomain,
+        'loadDeploymentRequestBy'
+      ).mockResolvedValue({
+        platform_id: uuidv4(),
+      } as DeploymentRequest);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when deployment request has no platform_id yet', async () => {
+      const platformId = uuidv4();
+      const platformToken = uuidv4();
+
+      vi.spyOn(
+        DeploymentRequestDomain,
+        'loadDeploymentRequestBy'
+      ).mockResolvedValue({
+        platform_id: null,
+      } as DeploymentRequest);
+
+      const req: express.Request = {
+        headers: {
+          [PLATFORM_TOKEN_HEADER]: platformToken,
+          [PLATFORM_ID_HEADER]: platformId,
+        },
+      } as unknown as express.Request;
+
+      const result = await validateAndGetRequestedPlatformToken(req);
+
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/apps/backend/src/modules/security-management/token/platform-token.util.ts
+++ b/apps/backend/src/modules/security-management/token/platform-token.util.ts
@@ -1,0 +1,68 @@
+import express from 'express';
+import { ServiceConfigurationStatus } from '../../../__generated__/resolvers-types';
+import { logApp } from '../../../utils/app-logger.util';
+import { DeploymentRequestDomain } from '../../deployment/deployment.domain';
+import { ServiceConfigurationDomain } from '../../registration/service-configuration/service-configuration.domain';
+
+export const PLATFORM_TOKEN_HEADER = 'xtm-hub-platform-token';
+export const PLATFORM_ID_HEADER = 'xtm-hub-platform-id';
+
+export const extractPlatformToken = (req: express.Request): string | null => {
+  return (req?.headers?.[PLATFORM_TOKEN_HEADER] as string) || null;
+};
+
+export const extractPlatformId = (req: express.Request): string | null => {
+  return (req?.headers?.[PLATFORM_ID_HEADER] as string) || null;
+};
+
+export const validateExistsToken = (req: express.Request): boolean => {
+  const token = extractPlatformToken(req);
+  if (!token) {
+    logApp.warn('[validatePlatformToken] Missing platformToken header');
+    return false;
+  }
+
+  const platformId = extractPlatformId(req);
+  if (!platformId) {
+    logApp.warn('[validatePlatformToken] Missing platformId header');
+    return false;
+  }
+  return true;
+};
+
+export const validateActivePlatformToken = async (
+  req: express.Request
+): Promise<boolean> => {
+  if (!validateExistsToken(req)) return false;
+
+  const serviceConfiguration =
+    await ServiceConfigurationDomain.loadConfigurationByPlatformAndToken({
+      platform_id: extractPlatformId(req),
+      token: extractPlatformToken(req),
+    });
+
+  return serviceConfiguration?.status === ServiceConfigurationStatus.Active;
+};
+
+export const validateAndGetRequestedPlatformToken = async (
+  req: express.Request
+) => {
+  if (!validateExistsToken(req)) return null;
+
+  const deploymentRequest =
+    await DeploymentRequestDomain.loadDeploymentRequestBy({
+      platform_token: extractPlatformToken(req),
+    });
+
+  const isValid =
+    deploymentRequest &&
+    deploymentRequest.platform_id !== null &&
+    deploymentRequest.platform_id === extractPlatformId(req);
+  if (!isValid) {
+    logApp.warn(
+      '[validatePlatformToken] No registration matching token, or invalid platformId provided'
+    );
+  }
+
+  return isValid ? deploymentRequest : null;
+};

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/ingest-manifest/ingest-manifest.domain.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/ingest-manifest/ingest-manifest.domain.test.ts
@@ -26,7 +26,6 @@ describe('upsertConnectors', () => {
     beforeAll(async () => {
       requestContext.set({
         user: SYSTEM_USER_CONTEXT.user,
-        portalContext: SYSTEM_USER_CONTEXT,
       });
       result = await upsertConnectors(
         sampleExtractedManifest as ManifestInformation[]
@@ -167,7 +166,6 @@ describe('upsertConnectors', () => {
       // First creation
       requestContext.set({
         user: SYSTEM_USER_CONTEXT.user,
-        portalContext: SYSTEM_USER_CONTEXT,
       });
       firstResult = await upsertConnectors(
         sampleExtractedManifest as ManifestInformation[]

--- a/apps/backend/src/security/directive-graphql/validator/platform-token-validator.test.ts
+++ b/apps/backend/src/security/directive-graphql/validator/platform-token-validator.test.ts
@@ -1,228 +1,154 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { describe, expect, it, vi } from 'vitest';
-import { ServiceConfigurationStatus } from '../../../__generated__/resolvers-types';
+import { requestContext } from '../../../context/request.context';
 import DeploymentRequest from '../../../model/kanel/public/DeploymentRequest';
+import Organization from '../../../model/kanel/public/Organization';
 import ServiceConfiguration from '../../../model/kanel/public/ServiceConfiguration';
+import type { PortalContext } from '../../../model/portal-context';
+import type { UserLoadUserBy } from '../../../model/user';
 import { DeploymentRequestDomain } from '../../../modules/deployment/deployment.domain';
+import { OrganizationDomain } from '../../../modules/organization-management/organization/organization.domain';
 import { ServiceConfigurationDomain } from '../../../modules/registration/service-configuration/service-configuration.domain';
 import {
   PLATFORM_ID_HEADER,
   PLATFORM_TOKEN_HEADER,
-  validateActivePlatformToken,
-  validateAndGetRequestedPlatformToken,
-} from './platform-token-validator';
+} from '../../../modules/security-management/token/platform-token.util';
+import { createPlatformTokenResolver } from './platform-token-validator';
 
-describe('platform Token Validation', () => {
-  describe('validateActivePlatformToken', () => {
-    it('should return false when platform token header is missing', async () => {
-      const req: express.Request = {
-        headers: {},
-      } as unknown as express.Request;
+const platformId = uuidv4();
+const platformToken = uuidv4();
 
-      const result = await validateActivePlatformToken(req);
+const validHeaders = {
+  [PLATFORM_TOKEN_HEADER]: platformToken,
+  [PLATFORM_ID_HEADER]: platformId,
+};
 
-      expect(result).toBe(false);
-    });
+const makePortalContext = (
+  headers: Record<string, string> = {}
+): PortalContext => ({
+  user: {} as UserLoadUserBy,
+  req: { headers, session: {} } as unknown as express.Request,
+  res: {} as express.Response,
+});
 
-    it('should return false when platform id header is missing', async () => {
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: 'anything',
-        },
-      } as unknown as express.Request;
-
-      const result = await validateActivePlatformToken(req);
-
-      expect(result).toBe(false);
-    });
-    it('should return false when headers are valid but no matching platform found', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
-      vi.spyOn(
-        ServiceConfigurationDomain,
-        'loadConfigurationByPlatformAndToken'
-      ).mockResolvedValue(undefined);
-
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
-
-      const result = await validateActivePlatformToken(req);
-
-      expect(result).toBe(false);
-    });
-    it('should return false when platform is found but inactive', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
-      vi.spyOn(
-        ServiceConfigurationDomain,
-        'loadConfigurationByPlatformAndToken'
-      ).mockResolvedValue({
-        config: { platform_id: platformId },
-        status: ServiceConfigurationStatus.Inactive,
-      } as unknown as ServiceConfiguration);
-
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
-
-      const result = await validateActivePlatformToken(req);
-
-      expect(result).toBe(false);
-    });
-    it('should return true when valid header for registered platform are provided', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
-      vi.spyOn(
-        ServiceConfigurationDomain,
-        'loadConfigurationByPlatformAndToken'
-      ).mockResolvedValue({
-        config: { platform_id: platformId },
-        status: ServiceConfigurationStatus.Active,
-      } as unknown as ServiceConfiguration);
-
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
-
-      const result = await validateActivePlatformToken(req);
-
-      expect(result).toBe(true);
+const runResolver = <T>(
+  resolver: (
+    source: unknown,
+    args: unknown,
+    ctx: PortalContext,
+    info: unknown
+  ) => Promise<T>,
+  context: PortalContext
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    requestContext.run({ user: {} as UserLoadUserBy }, async () => {
+      try {
+        resolve(await resolver({}, {}, context, {}));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
-  describe('validateAndGetRequestedPlatformToken', () => {
-    it('should return null when headers are missing', async () => {
-      const req: express.Request = {
-        headers: {},
-      } as unknown as express.Request;
 
-      const result = await validateAndGetRequestedPlatformToken(req);
+describe('createPlatformTokenResolver', () => {
+  describe('loadOrganizationFromPlatformIdAndTokenHeaders', () => {
+    it('should throw when platform token header is missing', async () => {
+      const resolver = createPlatformTokenResolver(vi.fn());
+      const context = makePortalContext({ [PLATFORM_ID_HEADER]: platformId });
 
-      expect(result).toBe(null);
+      await expect(runResolver(resolver, context)).rejects.toThrow(
+        'Invalid platform token provided'
+      );
     });
 
-    it('should return null when platform id header is missing', async () => {
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: 'anything',
-        },
-      } as unknown as express.Request;
+    it('should throw when platform id header is missing', async () => {
+      const resolver = createPlatformTokenResolver(vi.fn());
+      const context = makePortalContext({
+        [PLATFORM_TOKEN_HEADER]: platformToken,
+      });
 
-      const result = await validateAndGetRequestedPlatformToken(req);
-
-      expect(result).toBe(null);
+      await expect(runResolver(resolver, context)).rejects.toThrow(
+        'Invalid platform token provided'
+      );
     });
 
-    it('should return null when platform token header is missing', async () => {
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_ID_HEADER]: 'anything',
-        },
-      } as unknown as express.Request;
-
-      const result = await validateAndGetRequestedPlatformToken(req);
-
-      expect(result).toBe(null);
-    });
-
-    it('should return true when valid header for requested are provided', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
+    it('should load org via deployment request when a matching request is found', async () => {
+      const orgId = uuidv4();
+      const org = { id: orgId } as Organization;
 
       vi.spyOn(
         DeploymentRequestDomain,
         'loadDeploymentRequestBy'
       ).mockResolvedValue({
         platform_id: platformId,
-      } as DeploymentRequest);
+        organization_requester_id: orgId,
+      } as unknown as DeploymentRequest);
 
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
+      vi.spyOn(OrganizationDomain, 'loadOrganizationBy').mockResolvedValue(org);
 
-      const result = await validateAndGetRequestedPlatformToken(req);
+      const resolverSpy = vi.fn(async (_s, _a, ctx: PortalContext) => ctx.user);
+      const resolver = createPlatformTokenResolver(resolverSpy);
+      const context = makePortalContext(validHeaders);
 
-      expect(result).toBeTruthy();
+      const result = await runResolver(resolver, context);
+
+      expect(OrganizationDomain.loadOrganizationBy).toHaveBeenCalledWith({
+        id: orgId,
+      });
+      expect(result.selected_organization_id).toBe(orgId);
     });
 
-    it('should return null when platform id header provided is unknown', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
+    it('should load org via service configuration when no deployment request matches', async () => {
+      const serviceInstanceId = uuidv4();
+      const orgId = uuidv4();
+      const org = { id: orgId } as Organization;
 
       vi.spyOn(
         DeploymentRequestDomain,
         'loadDeploymentRequestBy'
       ).mockResolvedValue(undefined);
 
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
+      vi.spyOn(
+        ServiceConfigurationDomain,
+        'loadConfigurationByPlatformAndToken'
+      ).mockResolvedValue({
+        service_instance_id: serviceInstanceId,
+      } as ServiceConfiguration);
 
-      const result = await validateAndGetRequestedPlatformToken(req);
+      vi.spyOn(
+        OrganizationDomain,
+        'loadOrganizationSubscribedToServiceInstance'
+      ).mockResolvedValue(org);
 
-      expect(result).toBe(null);
+      const resolverSpy = vi.fn(async (_s, _a, ctx: PortalContext) => ctx.user);
+      const resolver = createPlatformTokenResolver(resolverSpy);
+      const context = makePortalContext(validHeaders);
+
+      const result = await runResolver(resolver, context);
+
+      expect(
+        OrganizationDomain.loadOrganizationSubscribedToServiceInstance
+      ).toHaveBeenCalledWith(serviceInstanceId);
+      expect(result.selected_organization_id).toBe(orgId);
     });
 
-    it('should return null when platform id header provided is not matching token', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
-
+    it('should throw when neither a deployment request nor a service configuration is found', async () => {
       vi.spyOn(
         DeploymentRequestDomain,
         'loadDeploymentRequestBy'
-      ).mockResolvedValue({
-        platform_id: uuidv4(),
-      } as DeploymentRequest);
-
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
-
-      const result = await validateAndGetRequestedPlatformToken(req);
-
-      expect(result).toBe(null);
-    });
-
-    it('should return null when deployment request has no platform_id yet', async () => {
-      const platformId = uuidv4();
-      const platformToken = uuidv4();
-
+      ).mockResolvedValue(undefined);
       vi.spyOn(
-        DeploymentRequestDomain,
-        'loadDeploymentRequestBy'
-      ).mockResolvedValue({
-        platform_id: null,
-      } as DeploymentRequest);
+        ServiceConfigurationDomain,
+        'loadConfigurationByPlatformAndToken'
+      ).mockResolvedValue(undefined);
 
-      const req: express.Request = {
-        headers: {
-          [PLATFORM_TOKEN_HEADER]: platformToken,
-          [PLATFORM_ID_HEADER]: platformId,
-        },
-      } as unknown as express.Request;
+      const resolver = createPlatformTokenResolver(vi.fn());
+      const context = makePortalContext(validHeaders);
 
-      const result = await validateAndGetRequestedPlatformToken(req);
-
-      expect(result).toBe(null);
+      await expect(runResolver(resolver, context)).rejects.toThrow(
+        'Invalid token provided'
+      );
     });
   });
 });

--- a/apps/backend/src/security/directive-graphql/validator/platform-token-validator.ts
+++ b/apps/backend/src/security/directive-graphql/validator/platform-token-validator.ts
@@ -90,7 +90,6 @@ export const createPlatformTokenResolver = (originalResolve) => {
     };
     requestContext.update({
       user: platformUser,
-      portalContext: enhancedContext,
     });
 
     return originalResolve(source, args, enhancedContext, info);

--- a/apps/backend/src/security/directive-graphql/validator/platform-token-validator.ts
+++ b/apps/backend/src/security/directive-graphql/validator/platform-token-validator.ts
@@ -1,81 +1,29 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  OrganizationCapability,
-  ServiceConfigurationStatus,
-} from '../../../__generated__/resolvers-types';
+import { OrganizationCapability } from '../../../__generated__/resolvers-types';
 import { requestContext } from '../../../context/request.context';
 import { PortalContext } from '../../../model/portal-context';
 import { UserLoadUserBy } from '../../../model/user';
-import { DeploymentRequestDomain } from '../../../modules/deployment/deployment.domain';
 import { OrganizationDomain } from '../../../modules/organization-management/organization/organization.domain';
 import { ServiceConfigurationDomain } from '../../../modules/registration/service-configuration/service-configuration.domain';
+import {
+  extractPlatformId,
+  extractPlatformToken,
+  validateAndGetRequestedPlatformToken,
+  validateExistsToken,
+} from '../../../modules/security-management/token/platform-token.util';
 import { PLATFORM_USER_EMAIL, PLATFORM_USER_UUID } from '../../../portal.const';
-import { logApp } from '../../../utils/app-logger.util';
 
-export const PLATFORM_TOKEN_HEADER = 'xtm-hub-platform-token';
-export const PLATFORM_ID_HEADER = 'xtm-hub-platform-id';
+export {
+  extractPlatformId,
+  extractPlatformToken,
+  PLATFORM_ID_HEADER,
+  PLATFORM_TOKEN_HEADER,
+  validateActivePlatformToken,
+  validateAndGetRequestedPlatformToken,
+  validateExistsToken,
+} from '../../../modules/security-management/token/platform-token.util';
 export const PLATFORM_TOKEN_DIRECTIVE_NAME = 'platform_token';
-
-export const extractPlatformToken = (req: express.Request): string | null => {
-  return (req?.headers?.[PLATFORM_TOKEN_HEADER] as string) || null;
-};
-
-export const extractPlatformId = (req: express.Request): string | null => {
-  return (req?.headers?.[PLATFORM_ID_HEADER] as string) || null;
-};
-
-const validateExistsToken = (req: express.Request): boolean => {
-  const token = extractPlatformToken(req);
-  if (!token) {
-    logApp.warn('[validatePlatformToken] Missing platformToken header');
-    return false;
-  }
-
-  const platformId = extractPlatformId(req);
-  if (!platformId) {
-    logApp.warn('[validatePlatformToken] Missing platformId header');
-    return false;
-  }
-  return true;
-};
-
-export const validateActivePlatformToken = async (
-  req: express.Request
-): Promise<boolean> => {
-  if (!validateExistsToken(req)) return false;
-
-  const serviceConfiguration =
-    await ServiceConfigurationDomain.loadConfigurationByPlatformAndToken({
-      platform_id: extractPlatformId(req),
-      token: extractPlatformToken(req),
-    });
-
-  return serviceConfiguration?.status === ServiceConfigurationStatus.Active;
-};
-
-export const validateAndGetRequestedPlatformToken = async (
-  req: express.Request
-) => {
-  if (!validateExistsToken(req)) return null;
-
-  const deploymentRequest =
-    await DeploymentRequestDomain.loadDeploymentRequestBy({
-      platform_token: extractPlatformToken(req),
-    });
-
-  const isValid =
-    deploymentRequest &&
-    deploymentRequest.platform_id !== null &&
-    deploymentRequest.platform_id === extractPlatformId(req);
-  if (!isValid) {
-    logApp.warn(
-      '[validatePlatformToken] No registration matching token, or invalid platformId provided'
-    );
-  }
-
-  return isValid ? deploymentRequest : null;
-};
 
 const loadOrganizationFromPlatformIdAndTokenHeaders = async (
   req: express.Request

--- a/apps/backend/src/security/directive-graphql/validator/system-token.validator.ts
+++ b/apps/backend/src/security/directive-graphql/validator/system-token.validator.ts
@@ -77,7 +77,6 @@ export const createSystemTokenResolver = (
     };
     requestContext.update({
       user: scopedSystemUser,
-      portalContext: enhancedContext,
     });
 
     return originalResolve(source, args, enhancedContext, info);

--- a/apps/backend/src/security/util/user.ts
+++ b/apps/backend/src/security/util/user.ts
@@ -1,31 +1,4 @@
 import crypto from 'node:crypto';
-import { db } from '../../../knexfile';
-import { OrganizationCapability } from '../../__generated__/resolvers-types';
-import { requestContext } from '../../context/request.context';
-import { ForbiddenAccess } from '../../utils/error/error.util';
-
-export const checkUserCapabilities = async (
-  requiredCapabilities: OrganizationCapability[]
-) => {
-  const { user } = requestContext.require();
-  // TODO Replace this query by adding a mapping org/capa and check the user capabilities depending of the organization
-  const getUserCapability = await db('User')
-    .leftJoin('User_Organization', 'User.id', 'User_Organization.user_id')
-    .leftJoin(
-      'UserOrganization_Capability',
-      'User_Organization.id',
-      'UserOrganization_Capability.user_organization_id'
-    )
-    .where({
-      'User.id': user.id,
-    })
-    .whereIn('UserOrganization_Capability.name', requiredCapabilities)
-    .first();
-
-  if (!getUserCapability) {
-    throw ForbiddenAccess('Not authorized');
-  }
-};
 
 export const validatePassword = (salt, tentativePassword, realPassword) => {
   const hash = crypto


### PR DESCRIPTION
# Context
- limit portalContext usage to graphql layer:
  - update last places where is it wrongly used
  -  add eslint rule
- Fix adminEditUser security: check capa on the right orga.
- removed unused trx from requestContext

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
- Test there is no regression on adminEditUser
- test there is no regression elsewhere, mainly login/logout/switch orga

## Related issues

- Related to #2382

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.