### PR TITLE
[frontend] fix(copilot): add copilot.filigran.ai to CSP script-src directive (#2380)

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -106,6 +106,7 @@ const nextConfig = {
       "'self'",
       "'unsafe-inline'",
       'https://www.googletagmanager.com',
+      'https://copilot.filigran.ai',
       ...hubspotScriptHosts,
       ...(isDev ? ["'unsafe-eval'"] : []),
     ].join(' ');


### PR DESCRIPTION
The Copilot widget script from https://copilot.filigran.ai was blocked by the Content Security Policy. Add the domain to the script-src allowlist.
