### PR TITLE
[frontend] refactor(test): mutualize duplicated library mocks (#2375)

### DIFF
--- a/apps/frontend/app/redirect/[identifier]/utils/url.test.ts
+++ b/apps/frontend/app/redirect/[identifier]/utils/url.test.ts
@@ -1,15 +1,7 @@
 import { decodeSafeRedirect } from '@/utils/redirect';
 import { NextRequest } from 'next/server';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getLoginRedirectionURL } from './url';
-
-vi.mock('@/components/error-frontend-log.graphql', () => ({
-  logFrontendError: vi.fn(),
-}));
-
-vi.mock('@/relay/environment/registry', () => ({
-  getClientEnvironment: vi.fn(() => null),
-}));
 
 const BASE_URL = 'http://localhost:3002';
 

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -8,6 +8,63 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const restrictedGlobalTestMocks = new Set([
+  'next-intl',
+  'next/navigation',
+  '@/relay/environment/registry',
+  '@/components/error-frontend-log.graphql',
+]);
+
+const getStringLiteralValue = (node) => {
+  if (node?.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+
+  return null;
+};
+
+const localTestRulesPlugin = {
+  rules: {
+    'no-remock-shared-globals': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Disallow re-mocking modules already mocked globally in setup-vitest.ts',
+        },
+        schema: [],
+      },
+      create(context) {
+        return {
+          CallExpression(node) {
+            if (
+              node.callee.type !== 'MemberExpression' ||
+              node.callee.object.type !== 'Identifier' ||
+              node.callee.object.name !== 'vi' ||
+              node.callee.property.type !== 'Identifier' ||
+              node.callee.property.name !== 'mock'
+            ) {
+              return;
+            }
+
+            const moduleName = getStringLiteralValue(node.arguments[0]);
+            if (!moduleName || !restrictedGlobalTestMocks.has(moduleName)) {
+              return;
+            }
+
+            context.report({
+              node: node.arguments[0],
+              message:
+                "'{{moduleName}}' is already mocked in setup-vitest.ts. Reuse the shared mock and override it with vi.mocked(...) in tests.",
+              data: { moduleName },
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
 const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
@@ -94,6 +151,15 @@ const eslintConfig = [
     files: ['**/components/**/*.tsx'],
     rules: {
       'unicorn/filename-case': ['error', { case: 'pascalCase' }],
+    },
+  },
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    plugins: {
+      'xtm-hub-test-rules': localTestRulesPlugin,
+    },
+    rules: {
+      'xtm-hub-test-rules/no-remock-shared-globals': 'error',
     },
   },
 

--- a/apps/frontend/setup-vitest.ts
+++ b/apps/frontend/setup-vitest.ts
@@ -3,6 +3,76 @@ import * as matchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
 
+import {
+  getClientEnvironment,
+  registerClientEnvironment,
+} from '@/relay/environment/registry';
+
+import '@testing-library/jest-dom';
+
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from 'next/navigation';
+
+vi.mock('@/components/error-frontend-log.graphql', () => ({
+  logFrontendError: vi.fn(),
+}));
+
+vi.mock('next/navigation', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('next/navigation')>()),
+  usePathname: vi.fn(),
+  useRouter: vi.fn(),
+  useParams: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock('next-intl', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('next-intl')>()),
+  useTranslations: () => (key: string) => key,
+}));
+
+const relayRegistryMocks = vi.hoisted(() => ({
+  getClientEnvironment: vi.fn(),
+  registerClientEnvironment: vi.fn(),
+}));
+
+vi.mock('@/relay/environment/registry', () => relayRegistryMocks);
+
+let mockedClientEnvironment: ReturnType<typeof getClientEnvironment> = null;
+type RegisterClientEnvironment = Parameters<
+  typeof registerClientEnvironment
+>[0];
+
+const setDefaultGlobalMocks = () => {
+  vi.mocked(usePathname).mockReturnValue('/mock');
+  vi.mocked(useRouter).mockReturnValue({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  });
+  vi.mocked(useParams).mockReturnValue({});
+  vi.mocked(useSearchParams).mockReturnValue(
+    new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>
+  );
+  vi.mocked(registerClientEnvironment).mockImplementation(
+    (environment: RegisterClientEnvironment) => {
+      mockedClientEnvironment = environment;
+    }
+  );
+  vi.mocked(getClientEnvironment).mockImplementation(
+    () => mockedClientEnvironment
+  );
+  registerClientEnvironment(null);
+};
+
+setDefaultGlobalMocks();
+
 // relay-test-utils expects a global jest object internally.
 // @ts-expect-error
 global.jest = vi;
@@ -14,6 +84,8 @@ beforeAll(() => {
 });
 
 afterEach(() => {
+  vi.resetAllMocks();
+  setDefaultGlobalMocks();
   cleanup();
   mswServer.resetHandlers();
 });

--- a/apps/frontend/src/components/Navigation.test.tsx
+++ b/apps/frontend/src/components/Navigation.test.tsx
@@ -1,27 +1,13 @@
+import { NavigationApp } from '@/components/Navigation';
 import testRender from '@/utils/test/test-render';
 import { screen } from '@testing-library/react';
-import { describe, it, vi } from 'vitest';
-import { NavigationApp } from '@/components/Navigation';
-
-// Mock next/navigation properly for App Router
-vi.mock('next/navigation', () => ({
-  usePathname: vi.fn(() => '/mock'),
-  useRouter: vi.fn(() => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    prefetch: vi.fn(),
-    back: vi.fn(),
-    forward: vi.fn(),
-    refresh: vi.fn(),
-  })),
-  useParams: vi.fn(() => ({})),
-}));
+import { describe, it } from 'vitest';
 
 describe('NavigationApp display', () => {
   it('should not render admin panel without capabilities ', async () => {
     const { container } = testRender(<NavigationApp open={true} />);
     expect(container).toBeTruthy();
-    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Settings')).not.toBeInTheDocument();
   });
   it('should render admin panel with BYPASS capabilities', async () => {
     const { container } = testRender(<NavigationApp open={true} />, {
@@ -34,7 +20,7 @@ describe('NavigationApp display', () => {
       },
     });
     expect(container).toBeTruthy();
-    expect(screen.queryByText('Settings')).toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Settings')).toBeInTheDocument();
   });
   it('should render admin panel with READ_TRIALS capabilities', async () => {
     const { container } = testRender(<NavigationApp open={true} />, {
@@ -47,6 +33,6 @@ describe('NavigationApp display', () => {
       },
     });
     expect(container).toBeTruthy();
-    expect(screen.queryByText('Settings')).toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Settings')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/admin/news-feed/NewsFeedList.test.tsx
+++ b/apps/frontend/src/components/admin/news-feed/NewsFeedList.test.tsx
@@ -19,12 +19,6 @@ const mocks = vi.hoisted(() => ({
   newsFeedItems: [] as NewsFeedItem[],
 }));
 
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal()),
-  useTranslations: () => (key: string, values?: { title?: string }) =>
-    values?.title ? `${key}:${values.title}` : key,
-}));
-
 vi.mock('@/utils/date', () => ({
   formatDate: (date: string) => `formatted:${date}`,
 }));
@@ -219,9 +213,7 @@ describe('NewsFeedList', () => {
 
     const dialog = await screen.findByRole('alertdialog');
     expect(
-      within(dialog).getByText(
-        'NewsFeedAdminPage.DeleteDialog.Text:Active news'
-      )
+      within(dialog).getByText('NewsFeedAdminPage.DeleteDialog.Text')
     ).toBeInTheDocument();
 
     await user.click(
@@ -245,7 +237,7 @@ describe('NewsFeedList', () => {
 
     await waitFor(() => {
       expect(mocks.toast).toHaveBeenCalledWith({
-        title: 'NewsFeedAdminPage.DeleteSuccess:Active news',
+        title: 'NewsFeedAdminPage.DeleteSuccess',
       });
       expect(mocks.refetch).toHaveBeenCalledWith(
         {

--- a/apps/frontend/src/components/admin/use-case/AddUseCase.test.tsx
+++ b/apps/frontend/src/components/admin/use-case/AddUseCase.test.tsx
@@ -13,14 +13,18 @@ describe('AddUseCase', () => {
     const { user } = testRender(<AddUseCase />);
 
     // Given
-    const addButton = screen.getByRole('button', { name: 'Add use case' });
+    const addButton = screen.getByRole('button', {
+      name: 'UseCaseActions.AddUseCase',
+    });
 
     // When
     await user.click(addButton);
 
     // Then
-    expect(screen.getByRole('heading', { name: 'Add use case' })).toBeTruthy();
-    expect(screen.getByLabelText('Name')).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: 'UseCaseActions.AddUseCase' })
+    ).toBeTruthy();
+    expect(screen.getByLabelText('UseCaseForm.Name')).toBeTruthy();
   });
 
   it('should submit UseCaseAdd mutation and close sheet on success', async () => {
@@ -41,15 +45,17 @@ describe('AddUseCase', () => {
 
     const { user } = testRender(<AddUseCase />);
 
-    await user.click(screen.getByRole('button', { name: 'Add use case' }));
+    await user.click(
+      screen.getByRole('button', { name: 'UseCaseActions.AddUseCase' })
+    );
 
     const colorInput = screen.getByDisplayValue('#FFFFFF');
-    await user.type(screen.getByLabelText(/Name/i), 'Threat Hunting');
+    await user.type(screen.getByLabelText(/UseCaseForm.Name/i), 'Threat Hunting');
     fireEvent.change(colorInput, { target: { value: '#11aa22' } });
-    await user.click(screen.getByRole('button', { name: /Validate/i }));
+    await user.click(screen.getByRole('button', { name: /Utils.Validate/i }));
 
     await waitFor(() => {
-      expect(screen.queryByLabelText(/Name/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/UseCaseForm.Name/i)).not.toBeInTheDocument();
     });
   });
 
@@ -63,13 +69,15 @@ describe('AddUseCase', () => {
 
     const { user } = testRender(<AddUseCase />);
 
-    await user.click(screen.getByRole('button', { name: 'Add use case' }));
+    await user.click(
+      screen.getByRole('button', { name: 'UseCaseActions.AddUseCase' })
+    );
 
     const colorInput = screen.getByDisplayValue('#FFFFFF');
-    await user.type(screen.getByLabelText(/Name/i), 'Threat Hunting');
+    await user.type(screen.getByLabelText(/UseCaseForm.Name/i), 'Threat Hunting');
     fireEvent.change(colorInput, { target: { value: '#11aa22' } });
-    await user.click(screen.getByRole('button', { name: /Validate/i }));
+    await user.click(screen.getByRole('button', { name: /Utils.Validate/i }));
 
-    expect(await screen.findByLabelText(/Name/i)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/UseCaseForm.Name/i)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/admin/use-case/EditUseCase.test.tsx
+++ b/apps/frontend/src/components/admin/use-case/EditUseCase.test.tsx
@@ -29,7 +29,7 @@ describe('EditUseCase', () => {
     );
 
     // Then
-    expect(screen.getByLabelText('Name')).toBeTruthy();
+    expect(screen.getByLabelText('UseCaseForm.Name')).toBeTruthy();
     expect(screen.getByDisplayValue('Threat hunting')).toBeTruthy();
   });
 
@@ -58,10 +58,10 @@ describe('EditUseCase', () => {
       />
     );
 
-    const nameInput = screen.getByLabelText(/Name/i);
+    const nameInput = screen.getByLabelText(/UseCaseForm.Name/i);
     await user.clear(nameInput);
     await user.type(nameInput, 'Updated UseCase');
-    await user.click(screen.getByRole('button', { name: /Validate/i }));
+    await user.click(screen.getByRole('button', { name: /Utils.Validate/i }));
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -91,8 +91,8 @@ describe('EditUseCase', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /^Delete$/i }));
-    await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+    await user.click(screen.getByRole('button', { name: /^MenuActions.Delete$/i }));
+    await user.click(screen.getByRole('button', { name: /^MenuActions.Delete$/i }));
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/components/admin/use-case/UseCaseForm.test.tsx
+++ b/apps/frontend/src/components/admin/use-case/UseCaseForm.test.tsx
@@ -30,7 +30,7 @@ describe('UseCaseForm', () => {
 
       await user.type(screen.getByLabelText(/Name/i), name);
       await user.type(colorInput, color);
-      await user.click(screen.getByRole('button', { name: /Validate/i }));
+      await user.click(screen.getByRole('button', { name: 'Utils.Validate' }));
     };
 
     it.each`
@@ -85,7 +85,7 @@ describe('UseCaseForm', () => {
         />
       );
 
-      await user.click(screen.getByRole('button', { name: /Cancel/i }));
+      await user.click(screen.getByRole('button', { name: 'Utils.Cancel' }));
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
@@ -100,8 +100,12 @@ describe('UseCaseForm', () => {
         />
       );
 
-      await user.click(screen.getByRole('button', { name: /^Delete$/i }));
-      await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+      await user.click(
+        screen.getByRole('button', { name: 'MenuActions.Delete' })
+      );
+      await user.click(
+        screen.getByRole('button', { name: 'MenuActions.Delete' })
+      );
 
       expect(mockHandleDelete).toHaveBeenCalledTimes(1);
     });

--- a/apps/frontend/src/components/admin/use-case/UseCases.test.tsx
+++ b/apps/frontend/src/components/admin/use-case/UseCases.test.tsx
@@ -52,7 +52,7 @@ describe('UseCases', () => {
       await screen.findByRole('row', { name: 'Incident Response #3344ff' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Add use case' })
+      screen.getByRole('button', { name: 'UseCaseActions.AddUseCase' })
     ).toBeInTheDocument();
   });
 
@@ -66,6 +66,6 @@ describe('UseCases', () => {
 
     renderComponent();
 
-    expect(await screen.findByText('Error')).toBeInTheDocument();
+    expect(await screen.findByText('Utils.Error')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/competitor/CompetitorForm.test.tsx
+++ b/apps/frontend/src/components/competitor/CompetitorForm.test.tsx
@@ -1,6 +1,6 @@
+import CompetitorForm from '@/components/competitor/CompetitorForm';
 import testRender from '@/utils/test/test-render';
 import { screen } from '@testing-library/react';
-import CompetitorForm from '@/components/competitor/CompetitorForm';
 
 describe('CompetitorForm', () => {
   describe('domain field validation', () => {
@@ -19,9 +19,17 @@ describe('CompetitorForm', () => {
         />
       );
 
-      await user.type(screen.getByLabelText(/Name/i), 'Acme Corp');
-      await user.type(screen.getByLabelText(/Domain/i), domainValue);
-      await user.click(screen.getByRole('button', { name: /Add competitor/i }));
+      await user.type(
+        screen.getByLabelText(/CompetitorForm.Name/i),
+        'Acme Corp'
+      );
+      await user.type(
+        screen.getByLabelText(/CompetitorForm.Domain/i),
+        domainValue
+      );
+      await user.click(
+        screen.getByRole('button', { name: 'CompetitorForm.AddButton' })
+      );
     };
 
     it.each([['example.com'], ['my-company.io'], ['sub.example.co.uk']])(

--- a/apps/frontend/src/components/epic/epic-item/DeleteEpic.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/DeleteEpic.test.tsx
@@ -1,9 +1,9 @@
+import { DeleteEpic } from '@/components/epic/epic-item/DeleteEpic';
 import testRender from '@/utils/test/test-render';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { screen } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { describe, expect, it, vi } from 'vitest';
-import { DeleteEpic } from '@/components/epic/epic-item/DeleteEpic';
 const commitDeleteEpicMutationMock = vi.fn();
 vi.mock('react-relay', async () => {
   const actual =
@@ -35,7 +35,7 @@ describe('DeleteEpic', () => {
       { relayConfig: environment }
     );
     // When
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.Cancel' }));
 
     // Then
     expect(setOpen).toHaveBeenCalledOnce();
@@ -59,7 +59,7 @@ describe('DeleteEpic', () => {
     );
 
     // When
-    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.Delete' }));
 
     // Then
     expect(commitDeleteEpicMutationMock).toHaveBeenCalledExactlyOnceWith(

--- a/apps/frontend/src/components/epic/epic-item/EpicAdminMenu.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicAdminMenu.test.tsx
@@ -1,9 +1,9 @@
+import { EpicAdminMenu } from '@/components/epic/epic-item/EpicAdminMenu';
 import testRender from '@/utils/test/test-render';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { screen } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EpicAdminMenu } from '@/components/epic/epic-item/EpicAdminMenu';
 
 const useEpicListContextMock = vi.fn();
 const useEpicFilterMock = vi.fn();
@@ -62,7 +62,7 @@ describe('EpicAdminMenu', () => {
       );
 
       // When
-      const menuButton = queryByRole('button', { name: 'Open menu' });
+      const menuButton = queryByRole('button', { name: 'Utils.OpenMenu' });
 
       if (shouldRender) {
         expect(menuButton).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('EpicAdminMenu', () => {
     );
 
     // Then
-    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.getByText('Epic.Timeline.draft')).toBeInTheDocument();
   });
 
   it('opens update sheet when clicking on update action', async () => {
@@ -104,11 +104,13 @@ describe('EpicAdminMenu', () => {
     );
 
     // When
-    await user.click(screen.getByRole('button', { name: 'Open menu' }));
-    await user.click(await screen.findByRole('menuitem', { name: 'Update' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'Utils.Update' })
+    );
 
     // Then
-    expect(screen.getByText(/Update an epic/i)).toBeInTheDocument();
+    expect(screen.getByText('Epic.EpicActions.UpdateEpic')).toBeInTheDocument();
   });
 
   it('opens delete dialog when clicking on delete action', async () => {
@@ -120,11 +122,13 @@ describe('EpicAdminMenu', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Open menu' }));
-    await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'Utils.Delete' })
+    );
 
     expect(
-      screen.getByText(/are you sure you want to delete/i)
+      screen.getByText('Epic.EpicActions.SureDeleteEpic')
     ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
@@ -96,7 +96,7 @@ describe('EpicItemCard', () => {
     );
 
     // When
-    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
 
     // Then
     expect(setIsOpen).not.toHaveBeenCalled();

--- a/apps/frontend/src/components/epic/epic-item/EpicItemDetailed.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemDetailed.test.tsx
@@ -72,7 +72,7 @@ describe('EpicItemDetailed', () => {
 
       // Then
       const communityLink = screen.getByRole('link', {
-        name: 'Stay in the loop on the Filigran Community',
+        name: 'Epic.JoinCommunity',
       });
 
       expect(communityLink).toHaveAttribute('href', expectedLink);

--- a/apps/frontend/src/components/menu/MenuAdmin.test.tsx
+++ b/apps/frontend/src/components/menu/MenuAdmin.test.tsx
@@ -17,9 +17,11 @@ describe('render MenuAdmin', () => {
       },
     });
     expect(container).toBeTruthy();
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Settings')).toBeInTheDocument();
 
-    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    const settingsButton = screen.getByRole('button', {
+      name: 'MenuLinks.Settings',
+    });
 
     // Click it
     await user.click(settingsButton);
@@ -29,15 +31,14 @@ describe('render MenuAdmin', () => {
       expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       expect(settingsButton).toHaveAttribute('data-state', 'open');
     });
-    expect(screen.getByText('Parameter')).toBeInTheDocument();
-    expect(screen.getByText('Security')).toBeInTheDocument();
-    expect(screen.getByText('Use Case')).toBeInTheDocument();
-    expect(screen.getByText('Organization')).toBeInTheDocument();
-    expect(screen.getByText('Service')).toBeInTheDocument();
-    expect(screen.getByText('OpenCTI Trial')).toBeInTheDocument();
-    expect(screen.getByText('OpenAEV Trial')).toBeInTheDocument();
-    expect(screen.getByText('Competitor')).toBeInTheDocument();
-    expect(screen.getByText('News Feed')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Parameter')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Security')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.UseCase')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Organization')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Service')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.OpenCTITrial')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.OpenAEVTrial')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Competitor')).toBeInTheDocument();
   });
 
   it('should render admin panel with only Trials dashboard in the menu with READ_TRIALS capabilities', async () => {
@@ -52,9 +53,11 @@ describe('render MenuAdmin', () => {
       },
     });
     expect(container).toBeTruthy();
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Settings')).toBeInTheDocument();
 
-    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    const settingsButton = screen.getByRole('button', {
+      name: 'MenuLinks.Settings',
+    });
 
     // Click it
     await user.click(settingsButton);
@@ -64,15 +67,16 @@ describe('render MenuAdmin', () => {
       expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       expect(settingsButton).toHaveAttribute('data-state', 'open');
     });
-    expect(screen.queryByText('Parameter')).not.toBeInTheDocument();
-    expect(screen.queryByText('Security')).not.toBeInTheDocument();
-    expect(screen.queryByText('Use Case')).not.toBeInTheDocument();
-    expect(screen.queryByText('Organization')).not.toBeInTheDocument();
-    expect(screen.queryByText('Service')).not.toBeInTheDocument();
-    expect(screen.getByText('OpenCTI Trial')).toBeInTheDocument();
-    expect(screen.getByText('OpenAEV Trial')).toBeInTheDocument();
-    expect(screen.queryByText('Competitor')).not.toBeInTheDocument();
-    expect(screen.queryByText('News Feed')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Parameter')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Security')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.UseCase')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('MenuLinks.Organization')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Service')).not.toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.OpenCTITrial')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.OpenAEVTrial')).toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Competitor')).not.toBeInTheDocument();
   });
   it('should render admin panel with only Trials dashboards and competitors in the menu with MANAGE_COMPETITOR capabilities', async () => {
     const user = userEvent.setup();
@@ -86,9 +90,11 @@ describe('render MenuAdmin', () => {
       },
     });
     expect(container).toBeTruthy();
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Settings')).toBeInTheDocument();
 
-    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    const settingsButton = screen.getByRole('button', {
+      name: 'MenuLinks.Settings',
+    });
 
     // Click it
     await user.click(settingsButton);
@@ -98,14 +104,19 @@ describe('render MenuAdmin', () => {
       expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
       expect(settingsButton).toHaveAttribute('data-state', 'open');
     });
-    expect(screen.queryByText('Parameter')).not.toBeInTheDocument();
-    expect(screen.queryByText('Security')).not.toBeInTheDocument();
-    expect(screen.queryByText('Use Case')).not.toBeInTheDocument();
-    expect(screen.queryByText('Organization')).not.toBeInTheDocument();
-    expect(screen.queryByText('Service')).not.toBeInTheDocument();
-    expect(screen.queryByText('OpenCTI Trial')).not.toBeInTheDocument();
-    expect(screen.queryByText('OpenAEV Trial')).not.toBeInTheDocument();
-    expect(screen.getByText('Competitor')).toBeInTheDocument();
-    expect(screen.queryByText('News Feed')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Parameter')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Security')).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.UseCase')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('MenuLinks.Organization')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('MenuLinks.Service')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('MenuLinks.OpenCTITrial')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('MenuLinks.OpenAEVTrial')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('MenuLinks.Competitor')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/registration/Layout.test.tsx
+++ b/apps/frontend/src/components/registration/Layout.test.tsx
@@ -1,15 +1,10 @@
+import { RegistrationContext } from '@/components/registration/Context';
+import { RegistrationLayout } from '@/components/registration/Layout';
 import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { RegistrationContext } from '@/components/registration/Context';
-import { RegistrationLayout } from '@/components/registration/Layout';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 const renderLayout = (
   props: { cancel?: () => void; confirm?: () => void } = {}

--- a/apps/frontend/src/components/registration/register/MissingCapability.test.tsx
+++ b/apps/frontend/src/components/registration/register/MissingCapability.test.tsx
@@ -1,16 +1,11 @@
+import { RegistrationContext } from '@/components/registration/Context';
 import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { RegisterStateMissingCapability } from '@/components/registration/register/MissingCapability';
 import testRender from '@/utils/test/test-render';
 import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { RegistrationContext } from '@/components/registration/Context';
-import { RegisterStateMissingCapability } from '@/components/registration/register/MissingCapability';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('react-relay', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-relay')>()),

--- a/apps/frontend/src/components/registration/register/OrganizationForm.test.tsx
+++ b/apps/frontend/src/components/registration/register/OrganizationForm.test.tsx
@@ -1,17 +1,12 @@
+import { RegistrationContext } from '@/components/registration/Context';
 import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { RegisterOrganizationForm } from '@/components/registration/register/OrganizationForm';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { organizationListUserOrganizationsQuery$data } from '@generated/organizationListUserOrganizationsQuery.graphql';
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { RegistrationContext } from '@/components/registration/Context';
-import { RegisterOrganizationForm } from '@/components/registration/register/OrganizationForm';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('@filigran/ui/clients', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@filigran/ui/clients')>()),

--- a/apps/frontend/src/components/registration/unregister/Confirm.test.tsx
+++ b/apps/frontend/src/components/registration/unregister/Confirm.test.tsx
@@ -1,15 +1,10 @@
+import { RegistrationContext } from '@/components/registration/Context';
 import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { UnregisterConfirm } from '@/components/registration/unregister/Confirm';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { RegistrationContext } from '@/components/registration/Context';
-import { UnregisterConfirm } from '@/components/registration/unregister/Confirm';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('../../organization/Organization.service', () => ({
   getOrganization: vi.fn(() => ({ id: 'org-id', name: 'Test Organization' })),

--- a/apps/frontend/src/components/registration/unregister/MissingCapability.test.tsx
+++ b/apps/frontend/src/components/registration/unregister/MissingCapability.test.tsx
@@ -1,16 +1,11 @@
+import { RegistrationContext } from '@/components/registration/Context';
 import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { UnregisterMissingCapability } from '@/components/registration/unregister/MissingCapability';
 import testRender from '@/utils/test/test-render';
 import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { RegistrationContext } from '@/components/registration/Context';
-import { UnregisterMissingCapability } from '@/components/registration/unregister/MissingCapability';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('react-relay', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-relay')>()),

--- a/apps/frontend/src/components/registration/unregister/PlatformNotRegistered.test.tsx
+++ b/apps/frontend/src/components/registration/unregister/PlatformNotRegistered.test.tsx
@@ -1,12 +1,7 @@
+import { UnregisterPlatformNotRegistered } from '@/components/registration/unregister/PlatformNotRegistered';
 import testRender from '@/utils/test/test-render';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { UnregisterPlatformNotRegistered } from '@/components/registration/unregister/PlatformNotRegistered';
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () => (key: string) => key,
-}));
 
 describe('UnregisterPlatformNotRegistered', () => {
   it('renders the not-registered title and description', () => {

--- a/apps/frontend/src/components/service/components/ServiceDelete.test.tsx
+++ b/apps/frontend/src/components/service/components/ServiceDelete.test.tsx
@@ -1,10 +1,10 @@
+import { ServiceDelete } from '@/components/service/components/ServiceDelete';
 import { ShareableResourceType } from '@/utils/shareable-resources/shareable-resources.types';
 import testRender from '@/utils/test/test-render';
 import { IntegrationTypeEnum } from '@generated/models/IntegrationType.enum';
 import { screen, within } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { describe, expect, it, vi } from 'vitest';
-import { ServiceDelete } from '@/components/service/components/ServiceDelete';
 
 describe('ServiceDelete', () => {
   it.each`
@@ -28,10 +28,10 @@ describe('ServiceDelete', () => {
       );
 
       // Then
-      const deleteButton = queryByRole('button', { name: 'Delete' });
+      const deleteButton = queryByRole('button', { name: 'Utils.Delete' });
 
       if (shouldRender) {
-        expect(deleteButton).toMatchObject({ textContent: 'Delete' });
+        expect(deleteButton).toHaveTextContent('Utils.Delete');
         return;
       }
 
@@ -40,18 +40,18 @@ describe('ServiceDelete', () => {
   );
 
   it.each`
-    shareableResourceType                             | type
-    ${IntegrationTypeEnum.CSV_FEED}                   | ${'CSV Feed'}
-    ${IntegrationTypeEnum.CONNECTOR}                  | ${'Connector'}
-    ${IntegrationTypeEnum.TAXII_FEED}                 | ${'TAXII Feed'}
-    ${IntegrationTypeEnum.RSS_FEED}                   | ${'RSS Feed'}
-    ${IntegrationTypeEnum.STREAM}                     | ${'Stream'}
-    ${IntegrationTypeEnum.THIRD_PARTY_INTEGRATION}    | ${'Third Party Integration'}
-    ${ShareableResourceType.OPENCTI_CUSTOM_DASHBOARD} | ${'dashboard'}
-    ${ShareableResourceType.OPENAEV_SCENARIO}         | ${'scenario'}
+    shareableResourceType                             | expectedTextKey
+    ${IntegrationTypeEnum.CSV_FEED}                   | ${'Service.CsvFeed.SureDeleteService'}
+    ${IntegrationTypeEnum.CONNECTOR}                  | ${'Service.Connector.SureDeleteService'}
+    ${IntegrationTypeEnum.TAXII_FEED}                 | ${'Service.TaxiiFeed.SureDeleteService'}
+    ${IntegrationTypeEnum.RSS_FEED}                   | ${'Service.RssFeed.SureDeleteService'}
+    ${IntegrationTypeEnum.STREAM}                     | ${'Service.Stream.SureDeleteService'}
+    ${IntegrationTypeEnum.THIRD_PARTY_INTEGRATION}    | ${'Service.ThirdPartyIntegration.SureDeleteService'}
+    ${ShareableResourceType.OPENCTI_CUSTOM_DASHBOARD} | ${'Service.OpenctiCustomDashboards.SureDeleteService'}
+    ${ShareableResourceType.OPENAEV_SCENARIO}         | ${'Service.OpenAEVScenario.SureDeleteService'}
   `(
     'maps deletion texts for shareableResourceType=shareableResourceType',
-    async ({ shareableResourceType, type }) => {
+    async ({ shareableResourceType, expectedTextKey }) => {
       // Given
       const environment = createMockEnvironment();
       const serviceName = 'another service name';
@@ -65,14 +65,10 @@ describe('ServiceDelete', () => {
       );
 
       // When
-      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      await user.click(screen.getByRole('button', { name: 'Utils.Delete' }));
 
       // Then
-      expect(
-        await screen.findByText(
-          `Are you sure you want to delete the ${type} ${serviceName}?`
-        )
-      ).toBeInTheDocument();
+      expect(await screen.findByText(expectedTextKey)).toBeInTheDocument();
     }
   );
 
@@ -91,11 +87,11 @@ describe('ServiceDelete', () => {
     );
 
     // When
-    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Utils.Delete' }));
 
     const alertDialog = await screen.findByRole('alertdialog');
     await user.click(
-      within(alertDialog).getByRole('button', { name: 'Delete' })
+      within(alertDialog).getByRole('button', { name: 'Utils.Delete' })
     );
 
     // Then

--- a/apps/frontend/src/components/service/components/header/ServiceListIntegrationDropdown.test.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListIntegrationDropdown.test.tsx
@@ -1,9 +1,9 @@
+import { ServiceListIntegrationDropdown } from '@/components/service/components/header/ServiceListIntegrationDropdown';
 import testRender from '@/utils/test/test-render';
 import { IntegrationTypeEnum } from '@generated/models/IntegrationType.enum';
 import { screen, waitFor } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { describe, expect, it, vi } from 'vitest';
-import { ServiceListIntegrationDropdown } from '@/components/service/components/header/ServiceListIntegrationDropdown';
 
 describe('Button with dropdown to add any kind of integration in the lib', () => {
   it('renders the trigger button', async () => {
@@ -22,7 +22,9 @@ describe('Button with dropdown to add any kind of integration in the lib', () =>
     );
 
     // Then
-    const dropdownButton = await queryByText('Add new Integration');
+    const dropdownButton = await queryByText(
+      'Service.OpenctiIntegrations.AddService'
+    );
     expect(dropdownButton).toBeInTheDocument();
   });
 
@@ -31,7 +33,7 @@ describe('Button with dropdown to add any kind of integration in the lib', () =>
     const environment = createMockEnvironment();
     const onIntegrationTypeSelect = vi.fn();
 
-    const { user, getByRole, getByText } = testRender(
+    const { user, getByRole } = testRender(
       <ServiceListIntegrationDropdown
         onIntegrationTypeSelect={onIntegrationTypeSelect}
       />,
@@ -39,21 +41,25 @@ describe('Button with dropdown to add any kind of integration in the lib', () =>
     );
 
     // When
-    await user.click(getByRole('button', { name: 'Add new Integration' }));
+    await user.click(
+      getByRole('button', { name: 'Service.OpenctiIntegrations.AddService' })
+    );
 
     // Then
     await waitFor(() => {
-      expect(getByText('Integration type')).toBeInTheDocument();
+      expect(
+        screen.getByText('Service.OpenctiIntegrations.IntegrationType')
+      ).toBeInTheDocument();
     });
   });
 
   it.each`
-    label                         | expectedEnum
-    ${'CSV Feeds'}                | ${IntegrationTypeEnum.CSV_FEED}
-    ${'TAXII Feeds'}              | ${IntegrationTypeEnum.TAXII_FEED}
-    ${'OpenCTI Streams'}          | ${IntegrationTypeEnum.STREAM}
-    ${'Third party integrations'} | ${IntegrationTypeEnum.THIRD_PARTY_INTEGRATION}
-    ${'RSS Feeds'}                | ${IntegrationTypeEnum.RSS_FEED}
+    label                                                         | expectedEnum
+    ${'Service.OpenctiIntegrations.Type.csv_feed'}                | ${IntegrationTypeEnum.CSV_FEED}
+    ${'Service.OpenctiIntegrations.Type.taxii_feed'}              | ${IntegrationTypeEnum.TAXII_FEED}
+    ${'Service.OpenctiIntegrations.Type.stream'}                  | ${IntegrationTypeEnum.STREAM}
+    ${'Service.OpenctiIntegrations.Type.third_party_integration'} | ${IntegrationTypeEnum.THIRD_PARTY_INTEGRATION}
+    ${'Service.OpenctiIntegrations.Type.rss_feed'}                | ${IntegrationTypeEnum.RSS_FEED}
   `(
     'clicking "$label" calls onIntegrationTypeSelect with $expectedEnum',
     async ({ label, expectedEnum }) => {
@@ -70,7 +76,9 @@ describe('Button with dropdown to add any kind of integration in the lib', () =>
 
       // When
       await user.click(
-        screen.getByRole('button', { name: 'Add new Integration' })
+        screen.getByRole('button', {
+          name: 'Service.OpenctiIntegrations.AddService',
+        })
       );
 
       await screen.findByText(label);
@@ -96,14 +104,20 @@ describe('Button with dropdown to add any kind of integration in the lib', () =>
 
     // When
     await user.click(
-      screen.getByRole('button', { name: 'Add new Integration' })
+      screen.getByRole('button', {
+        name: 'Service.OpenctiIntegrations.AddService',
+      })
     );
 
     await waitFor(() => {
-      expect(screen.getByText('JSON Feeds (coming soon)')).toBeInTheDocument();
+      expect(
+        screen.getByText('Service.OpenctiIntegrations.Type.json_feed')
+      ).toBeInTheDocument();
     });
 
-    const disabledItem = screen.getByText('JSON Feeds (coming soon)');
+    const disabledItem = screen.getByText(
+      'Service.OpenctiIntegrations.Type.json_feed'
+    );
 
     // Then
     expect(disabledItem.closest('[aria-disabled="true"]')).toBeInTheDocument();

--- a/apps/frontend/src/components/service/document/ShareableResourceSlug.test.tsx
+++ b/apps/frontend/src/components/service/document/ShareableResourceSlug.test.tsx
@@ -1,3 +1,5 @@
+import ShareableResourceSlug from '@/components/service/document/ShareableResourceSlug';
+import { SettingsContext } from '@/components/settings/EnvPortalContext';
 import testRender from '@/utils/test/test-render';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
 import { IntegrationTypeEnum } from '@generated/models/IntegrationType.enum';
@@ -5,8 +7,6 @@ import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragme
 import { screen } from '@testing-library/react';
 import { ComponentPropsWithoutRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { SettingsContext } from '@/components/settings/EnvPortalContext';
-import ShareableResourceSlug from '@/components/service/document/ShareableResourceSlug';
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////// Mock hooks /////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -19,14 +19,6 @@ vi.mock('../../../hooks/use-decoded-params', () => ({
     serviceInstanceId: 'test-service-id',
   }),
 }));
-
-vi.mock('next-intl', async () => {
-  const actual = await vi.importActual('next-intl');
-  return {
-    ...actual,
-    useTranslations: () => (key: string) => key,
-  };
-});
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////// Mock children components ///////////////////////////////////////

--- a/apps/frontend/src/components/service/document/ui/ShareableResourceDetailMetadataItem.test.tsx
+++ b/apps/frontend/src/components/service/document/ui/ShareableResourceDetailMetadataItem.test.tsx
@@ -4,11 +4,6 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ShareableResourceDetailMetadataItem } from './ShareableResourceDetailMetadataItem';
 
-// Mock useTranslations from next-intl
-vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => `translated:${key}`,
-}));
-
 // Mock ShareableResourceDetailsLink
 vi.mock('../ShareableResourceDetailsLink', () => ({
   ShareableResourceDetailsLink: ({ url }: { url: string }) => (
@@ -58,7 +53,7 @@ describe('ShareableResourceDetailMetadataItem', () => {
       />
     );
     expect(screen.getByTestId('label')).toHaveTextContent(
-      'translated:Service.ShareableResources.Details.label'
+      'Service.ShareableResources.Details.label'
     );
     expect(screen.getByTestId('content')).toHaveTextContent('Some text');
   });

--- a/apps/frontend/src/components/service/form/UseServiceFormFields.test.tsx
+++ b/apps/frontend/src/components/service/form/UseServiceFormFields.test.tsx
@@ -3,10 +3,6 @@ import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useServiceFormFields } from './UseServiceFormFields';
 
-vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key,
-}));
-
 vi.mock('../../ui/SheetWithPreventingDialog', () => ({
   useDialogContext: () => ({
     setIsDirty: vi.fn(),

--- a/apps/frontend/src/components/service/registration/RegistrationDetails.test.tsx
+++ b/apps/frontend/src/components/service/registration/RegistrationDetails.test.tsx
@@ -8,22 +8,11 @@ import { PortalCapabilityEnum } from '@generated/models/PortalCapability.enum';
 import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import { registeredPlatformByServiceInstanceId_fragment$data } from '@generated/registeredPlatformByServiceInstanceId_fragment.graphql';
 import { screen } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
 import { createMockEnvironment } from 'relay-test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
-
-const mockUseSearchParams = vi.fn(() => new URLSearchParams());
-
-vi.mock('next/navigation', () => ({
-  useSearchParams: () => mockUseSearchParams(),
-  useRouter: vi.fn(() => ({ push: vi.fn() })),
-}));
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal()),
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('@/components/service/components/PlatformUpdateSheet', () => ({
   PlatformUpdateSheet: () => null,
@@ -312,7 +301,11 @@ describe('RegistrationDetails', () => {
 
   describe('openForm search param', () => {
     it('should pass defaultOpen=true to TrialsManageUsersDialog when openForm=true', () => {
-      mockUseSearchParams.mockReturnValue(new URLSearchParams('openForm=true'));
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('openForm=true') as unknown as ReturnType<
+          typeof useSearchParams
+        >
+      );
       renderDetails(trialPlatform, {
         selected_org_capabilities: [
           OrganizationCapabilityEnum.ADMINISTRATE_ORGANIZATION,
@@ -324,7 +317,9 @@ describe('RegistrationDetails', () => {
     });
 
     it('should pass defaultOpen=false to TrialsManageUsersDialog when openForm is absent', () => {
-      mockUseSearchParams.mockReturnValue(new URLSearchParams());
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>
+      );
       renderDetails(trialPlatform, {
         selected_org_capabilities: [
           OrganizationCapabilityEnum.ADMINISTRATE_ORGANIZATION,

--- a/apps/frontend/src/components/service/registration/UnregisterButton.test.tsx
+++ b/apps/frontend/src/components/service/registration/UnregisterButton.test.tsx
@@ -1,17 +1,10 @@
+import { UnregisterButton } from '@/components/service/registration/UnregisterButton';
 import testRender from '@/utils/test/test-render';
 import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { PlatformContractEnum } from '@generated/models/PlatformContract.enum';
 import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import { registeredPlatformByServiceInstanceId_fragment$data } from '@generated/registeredPlatformByServiceInstanceId_fragment.graphql';
 import { createMockEnvironment } from 'relay-test-utils';
-import { vi } from 'vitest';
-import { UnregisterButton } from '@/components/service/registration/UnregisterButton';
-
-vi.mock('next/navigation', () => ({
-  useRouter: vi.fn(() => ({
-    push: vi.fn(),
-  })),
-}));
 
 describe('Display unregister button', () => {
   const registeredPlatform = {

--- a/apps/frontend/src/components/service/trial-instances/TrialCancelSheet.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/TrialCancelSheet.test.tsx
@@ -7,17 +7,6 @@ import { TrialCancelSheet } from './TrialCancelSheet';
 
 let lastCancelDeploymentRequestVariables: Record<string, unknown> | null = null;
 
-vi.mock('next/navigation', (importOriginal) => ({
-  ...importOriginal(),
-  useRouter: () => ({
-    push: vi.fn(),
-  }),
-}));
-
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal()),
-  useTranslations: () => (key: string) => key,
-}));
 vi.mock('@/components/service/trial-instances/useOrgaFreeTrials', () => ({
   useOrgaFreeTrial: () => ({ refetch: vi.fn() }),
 }));

--- a/apps/frontend/src/components/service/trial-instances/TryFiligranProductForm.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/TryFiligranProductForm.test.tsx
@@ -10,11 +10,6 @@ import { createMockEnvironment } from 'relay-test-utils';
 import { describe, expect, it, vi } from 'vitest';
 import { TryFiligranProductForm } from './TryFiligranProductForm';
 
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal()),
-  useTranslations: () => (key: string) => key,
-}));
-
 vi.mock('react-relay', async (importOriginal) => ({
   ...(await importOriginal()),
   usePreloadedQuery: () => ({ deploymentRequestsAvailable: [] }),

--- a/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.test.tsx
@@ -1,6 +1,6 @@
+import { PublicTryFiligranProductsBanner } from '@/components/service/trial-instances/banner/PublicTryFiligranProductsBanner';
 import testRender from '@/utils/test/test-render';
 import { createMockEnvironment } from 'relay-test-utils';
-import { PublicTryFiligranProductsBanner } from '@/components/service/trial-instances/banner/PublicTryFiligranProductsBanner';
 
 describe('Filigran product banner text on public pages', () => {
   it('should render the correct text on the banner', async () => {
@@ -12,9 +12,7 @@ describe('Filigran product banner text on public pages', () => {
     });
 
     // Then
-    const bannerText = await queryByText(
-      'Explore OpenCTI or OpenAEV platform with 30 days'
-    );
+    const bannerText = await queryByText('Service.Trials.ExploreProducts');
     expect(bannerText).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/service/trial-instances/banner/StartTrialBannerButton.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/StartTrialBannerButton.test.tsx
@@ -1,16 +1,9 @@
+import { StartTrialBannerButton } from '@/components/service/trial-instances/banner/StartTrialBannerButton';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
-import { StartTrialBannerButton } from '@/components/service/trial-instances/banner/StartTrialBannerButton';
-
-vi.mock('next/navigation', (importOriginal) => ({
-  ...importOriginal(),
-  useRouter: () => ({
-    push: vi.fn(),
-  }),
-}));
 
 describe('Start trial button in the banner', () => {
   it('should display dropdown menu when no trial', async () => {
@@ -42,7 +35,7 @@ describe('Start trial button in the banner', () => {
 
     // WHEN
     // The user clicks on start a trial
-    const startTrialButton = await findByText(/Start your free trial/i);
+    const startTrialButton = await findByText('Service.Trials.StartTrial');
     const user = userEvent.setup();
     await user.click(startTrialButton);
 
@@ -93,7 +86,7 @@ describe('Start trial button in the banner', () => {
     // THEN
     // The button should be disabled
     const startTrialButton = getByRole('button', {
-      name: /Start your free trial/i,
+      name: 'Service.Trials.StartTrial',
     });
     expect(startTrialButton).toBeDisabled();
   });
@@ -127,7 +120,7 @@ describe('Start trial button in the banner', () => {
     });
     // WHEN
     // The user clicks on start a trial
-    const startTrialButton = await findByText(/Start your free trial/i);
+    const startTrialButton = await findByText('Service.Trials.StartTrial');
     const user = userEvent.setup();
     await user.click(startTrialButton);
 

--- a/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.test.tsx
@@ -1,16 +1,9 @@
+import { TryFiligranProductsBanner } from '@/components/service/trial-instances/banner/TryFiligranProductsBanner';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
-import { TryFiligranProductsBanner } from '@/components/service/trial-instances/banner/TryFiligranProductsBanner';
-
-vi.mock('next/navigation', (importOriginal) => ({
-  ...importOriginal(),
-  useRouter: () => ({
-    push: vi.fn(),
-  }),
-}));
 
 const OpenCTITrial = {
   serviceInstanceId: 'id',
@@ -23,10 +16,10 @@ const OpenAEVTrial = {
 
 describe('Filigran product banner text', () => {
   it.each`
-    availableTrials                                                     | registeredPlatforms | expectedText                                           | nonExpectedText
-    ${[PlatformIdentifierEnum.OPENAEV]}                                 | ${[OpenCTITrial]}   | ${/Explore OpenAEV platform with 30 days/i}            | ${'OpenCTI'}
-    ${[PlatformIdentifierEnum.OPENCTI]}                                 | ${[OpenAEVTrial]}   | ${/Explore OpenCTI platform with 30 days/i}            | ${'OpenAEV'}
-    ${[PlatformIdentifierEnum.OPENCTI, PlatformIdentifierEnum.OPENAEV]} | ${[]}               | ${/Explore OpenCTI or OpenAEV platform with 30 days/i} | ${null}
+    availableTrials                                                     | registeredPlatforms | expectedText                        | nonExpectedText
+    ${[PlatformIdentifierEnum.OPENAEV]}                                 | ${[OpenCTITrial]}   | ${'Service.Trials.ExplorePlatform'} | ${'Service.Trials.ExploreProducts'}
+    ${[PlatformIdentifierEnum.OPENCTI]}                                 | ${[OpenAEVTrial]}   | ${'Service.Trials.ExplorePlatform'} | ${'Service.Trials.ExploreProducts'}
+    ${[PlatformIdentifierEnum.OPENCTI, PlatformIdentifierEnum.OPENAEV]} | ${[]}               | ${'Service.Trials.ExploreProducts'} | ${null}
   `(
     'should render the correct text depending the registration',
     async ({
@@ -130,7 +123,9 @@ describe('Filigran product banner text', () => {
 
     // WHEN
     // The user clicks on learn more
-    const learnMoreButton = await findByRole('button', { name: /Learn more/i });
+    const learnMoreButton = await findByRole('button', {
+      name: 'Service.Trials.LearnMore.Link',
+    });
     const user = userEvent.setup();
     await user.click(learnMoreButton);
 
@@ -177,7 +172,7 @@ describe('Filigran product banner text', () => {
 
       // Then
       const learnMoreLink = getByRole('link', {
-        name: /Learn more/i,
+        name: 'Service.Trials.LearnMore.Link',
       });
       const href = learnMoreLink.getAttribute('href');
       expect(href).toContain(linkToLearnMore);
@@ -224,7 +219,7 @@ describe('Filigran product banner text', () => {
       });
 
       // Then
-      const startTrialButton = await queryByText(/Start your free trial/i);
+      const startTrialButton = await queryByText('Service.Trials.StartTrial');
       shouldDisplayStartTrialButton
         ? expect(startTrialButton).toBeInTheDocument()
         : expect(startTrialButton).not.toBeInTheDocument();

--- a/apps/frontend/src/components/trials/tab/TrialsTab.test.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsTab.test.tsx
@@ -1,15 +1,11 @@
+import TrialsTab from '@/components/trials/tab/TrialsTab';
 import { TrialsTabType } from '@/components/trials/trials.const';
 import testRender from '@/utils/test/test-render';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import TrialsTab from '@/components/trials/tab/TrialsTab';
 
 // Mocks
-vi.mock('next-intl', async (importOriginal) => ({
-  ...(await importOriginal()),
-  useTranslations: () => (key: string) => key,
-}));
 vi.mock(
   '@/components/service/trial-instances/manage-users/trials-manage-users-dialog',
   () => ({ TrialsManageUsersDialog: () => <div>ManageUsersDialog</div> })

--- a/apps/frontend/src/hooks/use-admin-path.test.tsx
+++ b/apps/frontend/src/hooks/use-admin-path.test.tsx
@@ -1,16 +1,13 @@
+import useAdminPath from '@/hooks/use-admin-path';
+import { useAdminByPass } from '@/hooks/use-portal-capability';
 import { APP_PATH } from '@/utils/path/constant';
 import { PortalCapabilityEnum } from '@generated/models/PortalCapability.enum';
 import { renderHook } from '@testing-library/react';
 import { usePathname } from 'next/navigation';
 import { describe, expect, it, vi } from 'vitest';
-import useAdminPath from '@/hooks/use-admin-path';
-import { useAdminByPass } from '@/hooks/use-portal-capability';
 
 vi.mock('./use-portal-capability', () => ({
   useAdminByPass: vi.fn(),
-}));
-vi.mock('next/navigation', () => ({
-  usePathname: vi.fn(),
 }));
 
 describe('useAdminPath', () => {

--- a/apps/frontend/src/hooks/use-decoded-params.test.ts
+++ b/apps/frontend/src/hooks/use-decoded-params.test.ts
@@ -3,8 +3,6 @@ import { useParams } from 'next/navigation';
 import { describe, expect, it, vi } from 'vitest';
 import useDecodedParams from './use-decoded-params';
 
-vi.mock('next/navigation');
-
 describe('useDecodedParams', () => {
   it('should decode URL-encoded parameter values', () => {
     vi.mocked(useParams).mockReturnValue({

--- a/apps/frontend/src/hooks/use-decoded-query.test.ts
+++ b/apps/frontend/src/hooks/use-decoded-query.test.ts
@@ -3,8 +3,6 @@ import { useSearchParams } from 'next/navigation';
 import { describe, expect, it, vi } from 'vitest';
 import useDecodedQuery from './use-decoded-query';
 
-vi.mock('next/navigation');
-
 describe('useDecodedQuery', () => {
   it('should decode URL-encoded query parameters', () => {
     const mockSearchParams = new URLSearchParams(

--- a/apps/frontend/src/hooks/use-epic-filter.test.ts
+++ b/apps/frontend/src/hooks/use-epic-filter.test.ts
@@ -4,8 +4,6 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEpicFilter } from './use-epic-filter';
 
-vi.mock('next/navigation');
-
 describe('useEpicFilter', () => {
   const mockReplace = vi.fn();
 

--- a/apps/frontend/src/hooks/use-public-path.test.tsx
+++ b/apps/frontend/src/hooks/use-public-path.test.tsx
@@ -4,8 +4,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { usePathname } from 'next/navigation';
 import usePublicPath from './use-public-path';
 
-vi.mock('next/navigation');
-
 describe('usePublicPath', () => {
   it.each`
     expected | path
@@ -21,7 +19,7 @@ describe('usePublicPath', () => {
     ${false} | ${'/something/cybersecurity-solutions'}
     ${false} | ${'/ja/app/something'}
   `('should return $expected for pathname $path', ({ expected, path }) => {
-    usePathname.mockReturnValue(path);
+    vi.mocked(usePathname).mockReturnValue(path);
 
     const { result } = renderHook(() => usePublicPath());
 

--- a/apps/frontend/src/utils/redirect.test.ts
+++ b/apps/frontend/src/utils/redirect.test.ts
@@ -1,20 +1,11 @@
+import { logFrontendError } from '@/components/error-frontend-log.graphql';
+import { getClientEnvironment } from '@/relay/environment/registry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildLoginRedirect,
   decodeSafeRedirect,
   isSafeRedirect,
 } from './redirect';
-
-vi.mock('@/components/error-frontend-log.graphql', () => ({
-  logFrontendError: vi.fn(),
-}));
-
-vi.mock('@/relay/environment/registry', () => ({
-  getClientEnvironment: vi.fn(() => null),
-}));
-
-import { logFrontendError } from '@/components/error-frontend-log.graphql';
-import { getClientEnvironment } from '@/relay/environment/registry';
 
 describe('isSafeRedirect', () => {
   it.each([


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


This PR centralizes commonly duplicated frontend test mocks (notably `next-intl`, `next/navigation`, and Relay environment registry access) into the global Vitest setup, reducing per-test boilerplate and aligning assertions with i18n key-based output.

**Changes:**

- Added shared global mocks in `apps/frontend/setup-vitest.ts` for `next-intl`, `next/navigation`, Relay registry, and frontend error logging.
- Removed duplicated `vi.mock(...)` blocks from many test files and adjusted expectations to match the shared `useTranslations: key => key` behavior.
- Updated several tests to assert against translation keys (and related accessible names) instead of localized strings.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Frontend tests update only, no need to do manual tests.

## Related issues

- Related to #2375 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.