### PR TITLE
[frontend] feat(Roadmap): Add button manage user (#2419)

### DIFF
--- a/apps/frontend/src/components/epic/EpicFormSheet.tsx
+++ b/apps/frontend/src/components/epic/EpicFormSheet.tsx
@@ -127,7 +127,7 @@ export const EpicFormSheet = ({
           triggerElement || (
             <Button
               variant="ghost-primary"
-              className="border">
+              className="border cursor-pointer">
               <AddIcon className="size-4 mr-s" />
               {t('Utils.Create')}
             </Button>

--- a/apps/frontend/src/components/epic/EpicList.tsx
+++ b/apps/frontend/src/components/epic/EpicList.tsx
@@ -9,9 +9,13 @@ import {
   useCountEpicsByProduct,
   useDraftAndTimelineEpics,
 } from '@/components/epic/epic-list-utils';
+import { PortalContext } from '@/components/me/AppPortalContext';
+import { useAdminByPass } from '@/hooks/use-portal-capability';
 import useServiceCapability from '@/hooks/use-service-capability';
 import { DEBOUNCE_TIME } from '@/utils/constant';
+import { APP_PATH } from '@/utils/path/constant';
 import {
+  Button,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -19,11 +23,13 @@ import {
 } from '@filigran/ui';
 import { Separator } from '@filigran/ui/clients';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
+import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapability.enum';
 import { TimelineEnum } from '@generated/models/Timeline.enum';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useCallback, useContext, useMemo, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 
 interface EpicListProps {
@@ -36,6 +42,10 @@ interface EpicListProps {
   onSearch: (searchTerm: string) => void;
 }
 
+const isServiceInstanceWithSubscriptions = (
+  instance: serviceInstance_fragment$data | seoServiceInstanceFragment$data
+): instance is serviceInstance_fragment$data => 'subscriptions' in instance;
+
 export const EpicList = ({
   epics,
   serviceInstance,
@@ -46,14 +56,37 @@ export const EpicList = ({
   const t = useTranslations();
   const [openSheet, setOpenSheet] = useState(false);
   const [showFinished, setShowFinished] = useState(false);
+  const detailedServiceInstance = isServiceInstanceWithSubscriptions(
+    serviceInstance
+  )
+    ? serviceInstance
+    : undefined;
+
   const userCanUpdate = useServiceCapability(
     ServiceRestrictionEnum.UPSERT,
-    serviceInstance as serviceInstance_fragment$data
+    detailedServiceInstance
   );
   const userCanDelete = useServiceCapability(
     ServiceRestrictionEnum.DELETE,
-    serviceInstance as serviceInstance_fragment$data
+    detailedServiceInstance
   );
+  const { me, hasOrganizationCapability } = useContext(PortalContext);
+
+  const canManageService =
+    useServiceCapability(
+      ServiceRestrictionEnum.MANAGE_ACCESS,
+      detailedServiceInstance
+    ) ||
+    (hasOrganizationCapability &&
+      (hasOrganizationCapability(
+        OrganizationCapabilityEnum.ADMINISTRATE_ORGANIZATION
+      ) ||
+        hasOrganizationCapability(
+          OrganizationCapabilityEnum.MANAGE_SUBSCRIPTION
+        )));
+
+  const isBypass = useAdminByPass();
+
   const filteredEpics =
     !selectedProduct || selectedProduct === 'all'
       ? epics
@@ -105,18 +138,33 @@ export const EpicList = ({
     DEBOUNCE_TIME
   );
 
+  const currentSubscription = detailedServiceInstance?.subscriptions?.find(
+    (sub) => sub?.organization_id === me?.selected_organization_id
+  );
+
   return (
     <>
       <div className="flex m-s">
         <h1>{t('Epic.XTMRoadmap')}</h1>
-        {userCanUpdate && (
-          <div className="ml-auto">
+        <div className="ml-auto flex items-center justify-center gap-s">
+          {userCanUpdate && (
             <EpicFormSheet
               open={openSheet}
               setOpen={setOpenSheet}
             />
-          </div>
-        )}
+          )}
+          {(canManageService || isBypass) && currentSubscription?.id && (
+            <Button
+              asChild
+              variant="outline"
+              className="">
+              <Link
+                href={`/${APP_PATH}/manage/service/${serviceInstance.id}/subscription/${currentSubscription.id}`}>
+                {t('Service.Capabilities.ManageAccessName')}
+              </Link>
+            </Button>
+          )}
+        </div>
       </div>
       <EpicFilter
         selectedFilter={selectedProduct}

--- a/apps/frontend/src/components/service/service.graphql.ts
+++ b/apps/frontend/src/components/service/service.graphql.ts
@@ -46,6 +46,7 @@ export const serviceInstanceFragment = graphql`
     capabilities
     subscriptions {
       id
+      organization_id
       user_service {
         user {
           id


### PR DESCRIPTION
# Context
> Add the button manage user from Epic Roadmap

## How to test
- Connect as BYPASS on the roadmap: you should see the button "Manage User" and be able to add a userService. 
- Connect as a user with the capa MANAGE_ACCESS on the service Roadmap. You should see the button "Manage User" and be able to add a userService. 
- Connect as a user with the capa ADMIN_ORGA on the organisation. you should see the button "Manage User" and be able to add a userService. 
- Connect as a user with the capa MANAGE_SUBSCRIPTION on the organisation. you should see the button "Manage User" and be able to add a userService. 
- Connect with the capa MANAGE_PLATFORM_REGISTRATION on the organisation. You should not see the button Manage User. 
- Connect with no capa. You should not see the button Manage User. 

## Related issues

- Related to #2419

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests