### PR TITLE
[backend] refactor(role-portal): wrap domain function into one object const (#2455)

### DIFF
--- a/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
+++ b/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
@@ -26,7 +26,7 @@ import { ErrorCode } from '../../../../utils/error/error.code';
 import { formatRawAggObject } from '../../../../utils/query-raw.util';
 import { addPrefixToObject } from '../../../../utils/typescript';
 import { isEmpty } from '../../../../utils/utils';
-import { isAdmin } from '../../../role-portal/role-portal.domain';
+import { RolePortalDomain } from '../../../role-portal/role-portal.domain';
 import { telemetryApp } from '../../../telemetry/telemetry.app';
 import { buildLoginEvent } from '../../../telemetry/telemetry.helper';
 
@@ -292,7 +292,7 @@ export const UserDomain = {
       ])
       .groupBy(['User.id']);
 
-    if (!isAdmin()) {
+    if (!RolePortalDomain.isAdmin()) {
       const { user } = requestContext.require();
       loadUserQuery.where(
         'UserOrg.organization_id',

--- a/apps/backend/src/modules/role-portal/role-portal.domain.test.ts
+++ b/apps/backend/src/modules/role-portal/role-portal.domain.test.ts
@@ -1,51 +1,58 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { db } from '../../../knexfile';
 import { TestHelper } from '../../../tests/helper/test.helper';
-import { loadRolePortalsBySSOGroups } from './role-portal.domain';
+import { RolePortalDomain } from './role-portal.domain';
 
-describe('loadRolePortalsBySSOGroups', () => {
-  beforeEach(async () => {
-    // eslint-disable-next-line no-restricted-syntax
-    await db('SSOGroup_RolePortal').del();
-    await TestHelper.rolePortal.delete({});
-    await TestHelper.rolePortal.create({
-      name: 'POTATO_PEELER',
+describe('role portal domain tests', () => {
+  describe('loadRolePortalsBySSOGroups', () => {
+    beforeEach(async () => {
+      // eslint-disable-next-line no-restricted-syntax
+      await db('SSOGroup_RolePortal').del();
+      await TestHelper.rolePortal.delete({});
+      await TestHelper.rolePortal.create({
+        name: 'POTATO_PEELER',
+      });
+      await TestHelper.rolePortal.create({
+        name: 'UNICORN_RIDER',
+      });
+      await TestHelper.rolePortal.create({
+        name: 'BANANA_INSPECTOR',
+      });
+
+      // eslint-disable-next-line no-restricted-syntax
+      await db('SSOGroup_RolePortal').insert([
+        { SSOGroup: 'purple-elephants-club', RolePortal: 'POTATO_PEELER' },
+        { SSOGroup: 'flying-pizza-society', RolePortal: 'POTATO_PEELER' },
+        { SSOGroup: 'moonlight-dancers', RolePortal: 'UNICORN_RIDER' },
+        {
+          SSOGroup: 'coffee-addicts-anonymous',
+          RolePortal: 'BANANA_INSPECTOR',
+        },
+      ]);
     });
-    await TestHelper.rolePortal.create({
-      name: 'UNICORN_RIDER',
+
+    it('should return null when user has no SSO group', async () => {
+      const result = await RolePortalDomain.loadRolePortalsBySSOGroups([]);
+
+      expect(result?.roles).toBeNull();
     });
-    await TestHelper.rolePortal.create({
-      name: 'BANANA_INSPECTOR',
+
+    it('should return role when user has a single SSO group', async () => {
+      const result = await RolePortalDomain.loadRolePortalsBySSOGroups([
+        'moonlight-dancers',
+      ]);
+
+      expect(result?.roles).toEqual(['UNICORN_RIDER']);
     });
 
-    // eslint-disable-next-line no-restricted-syntax
-    await db('SSOGroup_RolePortal').insert([
-      { SSOGroup: 'purple-elephants-club', RolePortal: 'POTATO_PEELER' },
-      { SSOGroup: 'flying-pizza-society', RolePortal: 'POTATO_PEELER' },
-      { SSOGroup: 'moonlight-dancers', RolePortal: 'UNICORN_RIDER' },
-      { SSOGroup: 'coffee-addicts-anonymous', RolePortal: 'BANANA_INSPECTOR' },
-    ]);
-  });
+    it('should avoid duplication when user has multiple SSO groups with same role', async () => {
+      const result = await RolePortalDomain.loadRolePortalsBySSOGroups([
+        'purple-elephants-club',
+        'flying-pizza-society',
+      ]);
 
-  it('should return null when user has no SSO group', async () => {
-    const result = await loadRolePortalsBySSOGroups([]);
-
-    expect(result?.roles).toBeNull();
-  });
-
-  it('should return role when user has a single SSO group', async () => {
-    const result = await loadRolePortalsBySSOGroups(['moonlight-dancers']);
-
-    expect(result?.roles).toEqual(['UNICORN_RIDER']);
-  });
-
-  it('should avoid duplication when user has multiple SSO groups with same role', async () => {
-    const result = await loadRolePortalsBySSOGroups([
-      'purple-elephants-club',
-      'flying-pizza-society',
-    ]);
-
-    expect(result?.roles).toEqual(['POTATO_PEELER']);
-    expect(result?.roles).toHaveLength(1);
+      expect(result?.roles).toEqual(['POTATO_PEELER']);
+      expect(result?.roles).toHaveLength(1);
+    });
   });
 });

--- a/apps/backend/src/modules/role-portal/role-portal.domain.ts
+++ b/apps/backend/src/modules/role-portal/role-portal.domain.ts
@@ -3,25 +3,27 @@ import { requestContext } from '../../context/request.context';
 import RolePortal from '../../model/kanel/public/RolePortal';
 import { ROLE_ADMIN } from '../../portal.const';
 
-export const isAdmin = () => {
-  const { user } = requestContext.require();
-  return user.roles_portal.some((role) => role.id === ROLE_ADMIN.id);
-};
+export const RolePortalDomain = {
+  isAdmin: () => {
+    const { user } = requestContext.require();
+    return user.roles_portal.some((role) => role.id === ROLE_ADMIN.id);
+  },
 
-export const loadRolePortalsBySSOGroups = async (
-  ssoGroups: string[]
-): Promise<{ roles: string[] | null }> => {
-  return db<RolePortal>('RolePortal')
-    .join(
-      'SSOGroup_RolePortal',
-      'RolePortal.name',
-      'SSOGroup_RolePortal.RolePortal'
-    )
-    .whereIn('SSOGroup_RolePortal.SSOGroup', ssoGroups)
-    .select(dbRaw('array_agg(DISTINCT "RolePortal".name) as roles'))
-    .first();
-};
+  loadRolePortalsBySSOGroups: async (
+    ssoGroups: string[]
+  ): Promise<{ roles: string[] | null }> => {
+    return db<RolePortal>('RolePortal')
+      .join(
+        'SSOGroup_RolePortal',
+        'RolePortal.name',
+        'SSOGroup_RolePortal.RolePortal'
+      )
+      .whereIn('SSOGroup_RolePortal.SSOGroup', ssoGroups)
+      .select(dbRaw('array_agg(DISTINCT "RolePortal".name) as roles'))
+      .first();
+  },
 
-export const removeAllUserRolePortal = (user_id) => {
-  return db('User_RolePortal').where({ user_id }).del();
+  removeAllUserRolePortal: (user_id: string) => {
+    return db('User_RolePortal').where({ user_id }).del();
+  },
 };

--- a/apps/backend/src/modules/security-management/authentication/auth-user.ts
+++ b/apps/backend/src/modules/security-management/authentication/auth-user.ts
@@ -10,7 +10,7 @@ import { ForbiddenAccess } from '../../../utils/error/error.util';
 import { isEmptyField } from '../../../utils/utils';
 import { UserDomain } from '../../organization-management/user/user-domain/user.domain';
 import { getOrCreateUser } from '../../organization-management/user/user.helper';
-import { removeAllUserRolePortal } from '../../role-portal/role-portal.domain';
+import { RolePortalDomain } from '../../role-portal/role-portal.domain';
 
 export const loginFromProvider = async (userInfo: UserInfo) => {
   // region test the groups existence and eventually auto create groups
@@ -31,7 +31,7 @@ export const loginFromProvider = async (userInfo: UserInfo) => {
   // Check if the user has the admin role, so in creation we create user then add admin role
   if (isFiligranUser) {
     await ensureUserOrganizationExist(user.id, PLATFORM_ORGANIZATION_UUID);
-    await removeAllUserRolePortal(user.id);
+    await RolePortalDomain.removeAllUserRolePortal(user.id);
     if (userInfo.roles.length > 0) {
       await Promise.all(
         userInfo.roles.map((role) => addRoleToUser(user.id, role))

--- a/apps/backend/src/modules/security-management/authentication/provider/oidc.ts
+++ b/apps/backend/src/modules/security-management/authentication/provider/oidc.ts
@@ -6,7 +6,7 @@ import {
 } from 'openid-client/passport';
 import { PassportStatic } from 'passport';
 import { logApp } from '../../../../utils/app-logger.util';
-import { loadRolePortalsBySSOGroups } from '../../../role-portal/role-portal.domain';
+import { RolePortalDomain } from '../../../role-portal/role-portal.domain';
 import { providerLoginHandler } from '../login-handle';
 import { extractRole } from '../mapping-roles';
 
@@ -50,9 +50,10 @@ export const addOIDCStrategy = async (
         const extractedRoles = extractRole(
           userinfo['https://xtm-hub-development/roles'] as string[]
         );
-        const loadedRolesFromSSOGroup = await loadRolePortalsBySSOGroups(
-          userinfo['https://xtm-hub-development/groups'] as string[]
-        );
+        const loadedRolesFromSSOGroup =
+          await RolePortalDomain.loadRolePortalsBySSOGroups(
+            userinfo['https://xtm-hub-development/groups'] as string[]
+          );
 
         const rolePortal = loadedRolesFromSSOGroup.roles ?? [];
 


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


Refactors the backend `role-portal` module to expose its domain functions through a single `RolePortalDomain` object, and updates all internal call sites and unit tests accordingly.

**Changes:**

- Wrapped `isAdmin`, `loadRolePortalsBySSOGroups`, and `removeAllUserRolePortal` into `RolePortalDomain`.
- Updated authentication/OIDC and user domain code to call `RolePortalDomain.*` instead of importing standalone functions.
- Updated `role-portal.domain` unit tests to target the new `RolePortalDomain` export.


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Nothing to test, code move only.

## Related issues

- Related to #2455 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.