### PR TITLE
feat(roadmap): add share button in the roadmap Epics (#2418)

### DIFF
--- a/apps/frontend/src/components/epic/epic-item/EpicAdminMenu.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicAdminMenu.tsx
@@ -1,6 +1,7 @@
 import { EpicFormSheet } from '@/components/epic/EpicFormSheet';
 import { DeleteEpic } from '@/components/epic/epic-item/DeleteEpic';
 import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
+import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
 import { useEpicListContext } from '@/hooks/use-epic-list-context';
 import { MoreVertIcon } from '@filigran/icon';
 import { Badge } from '@filigran/ui/servers';
@@ -28,6 +29,14 @@ export const EpicAdminMenu = ({
   const [updateEpic, setUpdateEpic] = useState<epic_fragment$data | undefined>(
     undefined
   );
+
+  let shareableUrl = '';
+  if (typeof window !== 'undefined') {
+    const url = new URL(window.location.href);
+    url.searchParams.set('epicId', epic.id);
+    shareableUrl = url.toString();
+  }
+
   return (
     <>
       <div
@@ -44,6 +53,10 @@ export const EpicAdminMenu = ({
             {t('Epic.Timeline.draft')}
           </Badge>
         )}
+        <ShareLinkButton
+          url={shareableUrl}
+          documentId={epic.document_id}
+        />
         {(userCanDelete || userCanUpdate) && (
           <IconActions
             icon={

--- a/apps/frontend/src/components/epic/epic-item/EpicItem.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItem.test.tsx
@@ -33,7 +33,7 @@ describe('EpicItem', () => {
     userCanUpdate: false,
   };
 
-  const mockPush = vi.fn();
+  const mockReplace = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,11 +45,11 @@ describe('EpicItem', () => {
     vi.mocked(usePathname).mockReturnValue('/epics');
 
     vi.mocked(useRouter).mockReturnValue({
-      push: mockPush,
+      push: vi.fn(),
       back: vi.fn(),
       forward: vi.fn(),
       refresh: vi.fn(),
-      replace: vi.fn(),
+      replace: mockReplace,
       prefetch: vi.fn(),
     });
 
@@ -86,8 +86,8 @@ describe('EpicItem', () => {
     await user.click(within(card).getByText(epic.title));
 
     // Then
-    expect(mockPush).toHaveBeenCalledOnce();
-    expect(mockPush).toHaveBeenCalledWith('/epics?epicId=epic-1', {
+    expect(mockReplace).toHaveBeenCalledOnce();
+    expect(mockReplace).toHaveBeenCalledWith('/epics?epicId=epic-1', {
       scroll: false,
     });
   });
@@ -111,7 +111,7 @@ describe('EpicItem', () => {
     await user.click(screen.getByRole('button', { name: 'Close' }));
 
     // Then
-    expect(mockPush).toHaveBeenCalledOnce();
-    expect(mockPush).toHaveBeenCalledWith('/epics?', { scroll: false });
+    expect(mockReplace).toHaveBeenCalledOnce();
+    expect(mockReplace).toHaveBeenCalledWith('/epics', { scroll: false });
   });
 });

--- a/apps/frontend/src/components/epic/epic-item/EpicItem.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItem.test.tsx
@@ -5,6 +5,7 @@ import { EditionTypeEnum } from '@generated/models/EditionType.enum';
 import { EpicTypeEnum } from '@generated/models/EpicType.enum';
 import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { screen, within } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { createMockEnvironment } from 'relay-test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -32,12 +33,30 @@ describe('EpicItem', () => {
     userCanUpdate: false,
   };
 
+  const mockPush = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
     useEpicListContextMock.mockReturnValue({
       connectionID: 'connection-id-1',
       filterByProduct: vi.fn(),
     });
+
+    vi.mocked(usePathname).mockReturnValue('/epics');
+
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+    });
+
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: vi.fn().mockReturnValue(null),
+      toString: vi.fn().mockReturnValue(''),
+    } as unknown as ReturnType<typeof useSearchParams>);
   });
 
   it('renders card and passes expected props', () => {
@@ -67,31 +86,32 @@ describe('EpicItem', () => {
     await user.click(within(card).getByText(epic.title));
 
     // Then
-    const dialog = screen.getByRole('dialog');
-    expect(within(dialog).getByText(epic.description)).toBeInTheDocument();
-    expect(
-      within(dialog).queryByText(epic.short_description)
-    ).not.toBeInTheDocument();
-
-    expect(within(card).getByText(epic.title)).toBeInTheDocument();
+    expect(mockPush).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith('/epics?epicId=epic-1', {
+      scroll: false,
+    });
   });
 
   it('closes detail dialog when dialog emits close event', async () => {
     // Given
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: vi.fn().mockReturnValue('epic-1'),
+      toString: vi.fn().mockReturnValue('epicId=epic-1'),
+    } as unknown as ReturnType<typeof useSearchParams>);
+
     const environment = createMockEnvironment();
-    const { user, queryByText } = testRender(<EpicItem {...defaultProps} />, {
+    const { user } = testRender(<EpicItem {...defaultProps} />, {
       relayConfig: environment,
     });
 
-    const card = screen.getByRole('listitem');
-    await user.click(within(card).getByText(epic.title));
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(epic.description)).toBeInTheDocument();
 
     // When
     await user.click(screen.getByRole('button', { name: 'Close' }));
 
     // Then
-    expect(queryByText(epic.title)).toBeInTheDocument();
-    expect(queryByText(epic.short_description)).toBeInTheDocument();
-    expect(queryByText(epic.description)).not.toBeInTheDocument();
+    expect(mockPush).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith('/epics?', { scroll: false });
   });
 });

--- a/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
@@ -3,7 +3,7 @@ import { EpicItemCard } from '@/components/epic/epic-item/EpicItemCard';
 import { EpicItemDetailed } from '@/components/epic/epic-item/EpicItemDetailed';
 import { Dialog, DialogContent } from '@filigran/ui';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
-import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 interface EpicItemProps {
   epic: epic_fragment$data;
@@ -18,20 +18,31 @@ export const EpicItem = ({
   userCanUpdate,
   userCanDelete,
 }: EpicItemProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const isOpen = searchParams.get('epicId') === epic.id;
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('epicId');
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    }
+  };
 
   return (
     <li className="group overflow-hidden border-light flex flex-col relative rounded border hover:cursor-pointer bg-page-background h-[183px]">
       <EpicItemCard
         epic={epic}
         serviceInstanceId={serviceInstanceId}
-        setIsOpen={setIsOpen}
         userCanDelete={userCanDelete}
         userCanUpdate={userCanUpdate}
       />
       <Dialog
         open={isOpen}
-        onOpenChange={setIsOpen}>
+        onOpenChange={handleClose}>
         <DialogContent className="p-0 w-full max-w-5xl h-[80vh] max-h-[90vh] flex flex-col overflow-hidden">
           <EpicItemDetailed
             epic={epic}

--- a/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
@@ -4,6 +4,7 @@ import { EpicItemDetailed } from '@/components/epic/epic-item/EpicItemDetailed';
 import { Dialog, DialogContent } from '@filigran/ui';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
 
 interface EpicItemProps {
   epic: epic_fragment$data;
@@ -24,13 +25,20 @@ export const EpicItem = ({
 
   const isOpen = searchParams.get('epicId') === epic.id;
 
-  const handleClose = (open: boolean) => {
-    if (!open) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete('epicId');
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
-    }
-  };
+  const handleClose = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.delete('epicId');
+
+        const queryString = params.toString();
+        const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
+
+        router.replace(targetUrl, { scroll: false });
+      }
+    },
+    [router, pathname, searchParams]
+  );
 
   return (
     <li className="group overflow-hidden border-light flex flex-col relative rounded border hover:cursor-pointer bg-page-background h-[183px]">

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
@@ -26,7 +26,7 @@ describe('EpicItemCard', () => {
     description: 'long description',
   } as epic_fragment$data;
 
-  const mockPush = vi.fn();
+  const mockReplace = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,11 +38,11 @@ describe('EpicItemCard', () => {
     vi.mocked(usePathname).mockReturnValue('/epics');
 
     vi.mocked(useRouter).mockReturnValue({
-      push: mockPush,
+      push: vi.fn(),
       back: vi.fn(),
       forward: vi.fn(),
       refresh: vi.fn(),
-      replace: vi.fn(),
+      replace: mockReplace,
       prefetch: vi.fn(),
     });
 
@@ -92,8 +92,8 @@ describe('EpicItemCard', () => {
     await user.click(screen.getByText(epic.title));
 
     // Then
-    expect(mockPush).toHaveBeenCalledOnce();
-    expect(mockPush).toHaveBeenCalledWith('/epics?epicId=epic-1', {
+    expect(mockReplace).toHaveBeenCalledOnce();
+    expect(mockReplace).toHaveBeenCalledWith('/epics?epicId=epic-1', {
       scroll: false,
     });
   });
@@ -116,6 +116,6 @@ describe('EpicItemCard', () => {
     await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
 
     // Then
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.test.tsx
@@ -5,8 +5,10 @@ import { EditionTypeEnum } from '@generated/models/EditionType.enum';
 import { EpicTypeEnum } from '@generated/models/EpicType.enum';
 import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { screen } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { createMockEnvironment } from 'relay-test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 const useEpicListContextMock = vi.fn();
 
 vi.mock('@/hooks/use-epic-list-context', () => ({
@@ -24,12 +26,30 @@ describe('EpicItemCard', () => {
     description: 'long description',
   } as epic_fragment$data;
 
+  const mockPush = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
     useEpicListContextMock.mockReturnValue({
       connectionID: 'connection-id-1',
       filterByProduct: vi.fn(),
     });
+
+    vi.mocked(usePathname).mockReturnValue('/epics');
+
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+    });
+
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: vi.fn().mockReturnValue(null),
+      toString: vi.fn().mockReturnValue(''),
+    } as unknown as ReturnType<typeof useSearchParams>);
   });
 
   it('renders card content and child components', () => {
@@ -41,7 +61,6 @@ describe('EpicItemCard', () => {
       <EpicItemCard
         epic={epic}
         serviceInstanceId={'service-instance-1'}
-        setIsOpen={vi.fn()}
         userCanDelete={false}
         userCanUpdate={false}
       />,
@@ -55,16 +74,14 @@ describe('EpicItemCard', () => {
     expect(screen.getByText(epic.short_description)).toBeInTheDocument();
   });
 
-  it('opens details when clicking outside admin menu area', async () => {
+  it('opens details by updating URL when clicking outside admin menu area', async () => {
     // Given
     const environment = createMockEnvironment();
-    const setIsOpen = vi.fn();
 
     const { user } = testRender(
       <EpicItemCard
         epic={epic}
         serviceInstanceId={'service-instance-1'}
-        setIsOpen={setIsOpen}
         userCanDelete={false}
         userCanUpdate={false}
       />,
@@ -75,20 +92,20 @@ describe('EpicItemCard', () => {
     await user.click(screen.getByText(epic.title));
 
     // Then
-    expect(setIsOpen).toHaveBeenCalledOnce();
-    expect(setIsOpen).toHaveBeenCalledWith(true);
+    expect(mockPush).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith('/epics?epicId=epic-1', {
+      scroll: false,
+    });
   });
 
-  it('does not open details when clicking in admin menu area', async () => {
+  it('does not update URL when clicking in admin menu area', async () => {
     // Given
     const environment = createMockEnvironment();
-    const setIsOpen = vi.fn();
 
     const { user } = testRender(
       <EpicItemCard
         epic={epic}
         serviceInstanceId={'service-instance-1'}
-        setIsOpen={setIsOpen}
         userCanDelete={true}
         userCanUpdate={true}
       />,
@@ -99,6 +116,6 @@ describe('EpicItemCard', () => {
     await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
 
     // Then
-    expect(setIsOpen).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
@@ -3,7 +3,7 @@ import { EpicItemFooter } from '@/components/epic/epic-item/EpicItemFooter';
 import { Separator } from '@filigran/ui/clients';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { MouseEvent } from 'react';
+import { MouseEvent, useCallback } from 'react';
 
 interface EpicItemCardProps {
   epic: epic_fragment$data;
@@ -21,24 +21,27 @@ export const EpicItemCard = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  // Do not open details if it's a click in admin menu
-  const handleOpenDetail = (event: MouseEvent<HTMLDivElement>) => {
-    const { currentTarget, target } = event;
-    if (!(target instanceof Node) || !currentTarget.contains(target)) {
-      return;
-    }
 
-    if (
-      target instanceof HTMLElement &&
-      target.closest(' [data-no-open-detail]')
-    ) {
-      return;
-    }
+  const handleOpenDetail = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      const { currentTarget, target } = event;
+      if (!(target instanceof Node) || !currentTarget.contains(target)) {
+        return;
+      }
 
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('epicId', epic.id);
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
+      if (
+        target instanceof HTMLElement &&
+        target.closest('[data-no-open-detail]')
+      ) {
+        return;
+      }
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('epicId', epic.id);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams, epic.id]
+  );
 
   return (
     <>

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
@@ -2,12 +2,12 @@ import { EpicAdminMenu } from '@/components/epic/epic-item/EpicAdminMenu';
 import { EpicItemFooter } from '@/components/epic/epic-item/EpicItemFooter';
 import { Separator } from '@filigran/ui/clients';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { MouseEvent } from 'react';
 
 interface EpicItemCardProps {
   epic: epic_fragment$data;
   serviceInstanceId: string;
-  setIsOpen: (open: boolean) => void;
   userCanDelete: boolean;
   userCanUpdate: boolean;
 }
@@ -15,10 +15,12 @@ interface EpicItemCardProps {
 export const EpicItemCard = ({
   epic,
   serviceInstanceId,
-  setIsOpen,
   userCanDelete,
   userCanUpdate,
 }: EpicItemCardProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   // Do not open details if it's a click in admin menu
   const handleOpenDetail = (event: MouseEvent<HTMLDivElement>) => {
     const { currentTarget, target } = event;
@@ -33,14 +35,16 @@ export const EpicItemCard = ({
       return;
     }
 
-    setIsOpen(true);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('epicId', epic.id);
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (
     <>
       <div
         onClick={handleOpenDetail}
-        className="h-full flex flex-col flex-1 bg-page-background text-ellipsis overflow-hidden p-m group-hover:bg-hover h-full w-full">
+        className="flex flex-col flex-1 bg-page-background text-ellipsis overflow-hidden p-m group-hover:bg-hover h-full w-full">
         <h2 className="text-base font-semibold pr-xxl line-clamp-2">
           {epic.title}
         </h2>


### PR DESCRIPTION
# Context
Add Share Button in roadmap Epics
Decided not to refactor the whole structure with slug usage for Epics but instead just use searchParams

## How to test
- Click on the Share Button
- Paste in another tab
- It should open the roadmap tab with the Epic popup open

## Related issues

- Related to #2418

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.