### PR TITLE
chore(ci): switch to CalVer versioning MAJOR.YYMMDD.SEQ (#2482)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,15 +3,11 @@ name: Create Deployment
 on:
   workflow_dispatch:
     inputs:
-      version_type:
-        description: "Deployment version type"
-        required: true
-        default: "patch"
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+      bump_major:
+        description: "Bump the MAJOR version number"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   deploy:
@@ -70,16 +66,38 @@ jobs:
         run: |
           yarn install
 
-      - name: Bump deployment version in backend
-        working-directory: ./apps/backend
+      - name: Compute new version (MAJOR.YYMMDD.SEQ)
         run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "NEW_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+          CURRENT_VERSION=$(node -p "require('./apps/backend/package.json').version")
+          CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
 
-      - name: Sync deployment version in frontend
+          if [ "${{ github.event.inputs.bump_major }}" == "true" ]; then
+            MAJOR=$((CURRENT_MAJOR + 1))
+          else
+            MAJOR=$CURRENT_MAJOR
+          fi
+
+          YYMMDD=$(date -u +%y%m%d)
+
+          SEQ=0
+          for tag in $(git tag -l "v${MAJOR}.${YYMMDD}.*"); do
+            TAG_SEQ=$(echo "$tag" | cut -d. -f3)
+            if [ "$TAG_SEQ" -ge "$SEQ" ]; then
+              SEQ=$((TAG_SEQ + 1))
+            fi
+          done
+
+          NEW_VERSION="${MAJOR}.${YYMMDD}.${SEQ}"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "✅ Computed version: $NEW_VERSION"
+
+      - name: Set version in backend
+        working-directory: ./apps/backend
+        run: yarn version "${{ env.NEW_VERSION }}"
+
+      - name: Set version in frontend
         working-directory: ./apps/frontend
-        run: |
-          yarn version ${{ env.NEW_VERSION }}
+        run: yarn version "${{ env.NEW_VERSION }}"
 
       - name: Commit and tag changes
         run: |
@@ -130,7 +148,8 @@ jobs:
         run: |
           echo "## Deployment Summary 🚀" >> $GITHUB_STEP_SUMMARY
           echo "- **New Version:** v${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version Type:** ${{ github.event.inputs.version_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Major Bumped:** ${{ github.event.inputs.bump_major }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Format:** MAJOR.YYMMDD.SEQ" >> $GITHUB_STEP_SUMMARY
           echo "- **Components Updated:** apps/backend, apps/frontend" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag Created:** v${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Deployment Workflow:** Triggered automatically" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Context

As part of engineering harmonization across Filigran products, switch the deployment versioning scheme from semver (`patch`/`minor`/`major`) to calendar-based versioning: **`MAJOR.YYMMDD.SEQ`**.

- **MAJOR** — preserved from current version (currently `1`), with an optional "Bump major" checkbox in the workflow dispatch
- **YYMMDD** — UTC release date (e.g. `260605` for June 5, 2026)
- **SEQ** — auto-incremented from `0` when multiple releases happen on the same day

Example versions: `1.260605.0`, `1.260605.1`, `2.260701.0`

### Changes

- `deployment.yml`: replaced `version_type` (patch/minor/major choice) input with `bump_major` boolean
- New "Compute new version" step that reads the current MAJOR, computes YYMMDD, and scans existing tags for SEQ
- Updated summary step to reflect the new format
- `dockerbuild-ci.yml`: **no changes needed** — `docker/metadata-action` semver patterns handle the 3-segment format natively

## How to test

1. Review the workflow YAML for correctness
2. After merge, trigger the "Create Deployment" workflow manually via GitHub Actions
3. Verify the generated version follows the `MAJOR.YYMMDD.SEQ` format
4. Verify the tag is created and Docker build is triggered

## Related issues

- Closes #2482

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information

This is a CI-only change (`deployment.yml`). No application code is modified. The `dockerbuild-ci.yml` semver tag patterns (`{{version}}`, `{{major}}.{{minor}}`) remain compatible since the new format still has 3 numeric segments.