### PR TITLE
chore(renovate): emit Conventional Commits titles (#2494)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended"
   ],
   "labels": [
@@ -10,7 +11,6 @@
   "ignorePaths": [
     "chart/**"
   ],
-  "commitMessagePrefix": "[deps]",
   "prConcurrentLimit": 5,
   "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #2494