### PR TITLE
chore: align issue templates across repositories (#2496)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,38 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve XTM Hub
 title: 'fix: '
-labels: bug, needs triage
+labels: needs triage, bug
 assignees: ''
-type: Bug
+type: bug
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Description
 
-**Screenshots and screen records**
-Add here screenshots & record to help a better understanding of the bug.
+<!-- Please provide a clear and concise description of the bug. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## Environment
 
-**Actual behavior**
-A clear and concise description of what happened.
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
-**Expected behavior**
-A clear and complete description of what you expected to happen.
+## Reproducible steps
 
-**Additional context**
-Add any other context about the problem here : screenshots, browser, desktop or mobile...
+Steps to create the smallest reproducible scenario:
+1. { e.g. Run ... }
+2. { e.g. Click ... }
+3. { e.g. Error ... }
+
+## Expected output
+
+<!-- Please describe what you expected to happen. -->
+
+## Actual output
+
+<!-- Please describe what actually happened. -->
+
+## Additional information
+
+<!-- Any additional information, including logs or screenshots if you have any. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/FiligranHQ/xtm-hub/security/policy
+    about: Please review our security policy and report vulnerabilities privately and responsibly.
+  - name: Filigran community Slack
+    url: https://community.filigran.io
+    about: Ask questions and chat with the Filigran community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,16 +1,29 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest a new feature or capability for XTM Hub
 title: 'feat: '
-labels: Feature, needs triage
-type: Feature
+labels: needs triage, feature
+assignees: ''
+type: feature
+
 ---
 
-**Overall Description**
-A clear and concise description of what the feature is about. The scope should be clearly defined.
+## Use case
 
-**Use case**
-Describe the use case for which you need a solution
+<!-- Please describe the use case for which you need a solution. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Current workaround
+
+<!-- Please describe how you currently solve or work around this problem. -->
+
+## Proposed solution
+
+<!-- Please describe the solution you would like to be provided. -->
+
+## Additional information
+
+<!-- Any additional information, including logs or screenshots if you have any. -->
+
+## If the feature request is approved, would you be willing to submit a PR?
+
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about the project
+about: Ask a question about XTM Hub
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -16,6 +16,12 @@ assignees: ''
 ## Description
 
 <!-- Please provide a clear and concise description of your question. -->
+
+## Environment
+
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #2496