### PR TITLE
chore: audit & align issue templates (#2498)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/FiligranHQ/xtm-hub/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
Closes #2498

Audit and align the GitHub issue templates with the canonical Filigran templates.

- Standardize `bug_report.md`, `feature_request.md`, `question.md` on the canonical format.
- Set `config.yml` to the public form (`blank_issues_enabled: true` only).
- Drop the duplicate security contact link (native private vulnerability reporting is enabled).
- Remove the Filigran community Slack contact link.