### PR TITLE
feat(roadmap): redirect when customer has old roadmap URL (#2515)

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -66,11 +66,15 @@ const nextConfig = {
       // -------------------------
 
       {
+        source: '/cybersecurity-solutions/public-roadmap',
+        destination: '/cybersecurity-solutions/xtm-platform-roadmap',
+        permanent: true,
+      },
+      {
         source: '/cybersecurity-solutions/free-trial',
         destination: '/cybersecurity-solutions/opencti-free-trial',
         permanent: true,
       },
-
       {
         source:
           '/cybersecurity-solutions/(open-bas-scenarios|obas-scenarios|open-aev-scenarios)/:path*',


### PR DESCRIPTION
# Context
> For users that have to old public roadmap URL, we redirect to the current one 

## How to test
- Go to .io/cybersecurity-solutions/public-roadmap 
- You should be redirected to the URL xtm-platform-roadmap and no see a 404 error

## Related issues

- Related to #2515

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
