### PR TITLE
fix(nextjs-cache): fix nextjs cache server (#2534)

### DIFF
--- a/apps/frontend/src/relay/environment/client.ts
+++ b/apps/frontend/src/relay/environment/client.ts
@@ -76,7 +76,11 @@ export function createClientSideRelayEnvironment() {
       ).catch(handleUnauthenticated);
     }
     // If we don't have hydration responses, execute the request as usual.
-    return networkFetch({ request, variables }).catch(handleUnauthenticated);
+    return networkFetch({
+      request,
+      variables,
+      cache: 'no-store',
+    }).catch(handleUnauthenticated);
   };
 
   // Create a new helper or reuse the existing one, if one has already been created.

--- a/apps/frontend/src/relay/environment/fetch-fn.ts
+++ b/apps/frontend/src/relay/environment/fetch-fn.ts
@@ -42,7 +42,7 @@ export async function networkFetch({
   request,
   variables,
   cookieList,
-  cache = cookieList?.length ? 'no-store' : undefined,
+  cache,
   options = {},
 }: {
   apiUri?: string;
@@ -52,8 +52,9 @@ export async function networkFetch({
   cache?: RequestCache;
   options?: RequestInit;
 }): Promise<GraphQLResponse> {
+  const cacheConfig = Boolean(options.cache) ? options.cache : cache;
   if (isDevelopment()) {
-    logGraphQLOperation(request, variables, apiUri, options.cache);
+    logGraphQLOperation(request, variables, apiUri, cacheConfig);
   }
 
   const headers: { [k: string]: string } = {
@@ -66,11 +67,7 @@ export async function networkFetch({
     headers.cookie = cookieHeader;
   }
 
-  const activeCacheConfig = isDevelopment()
-    ? 'no-store'
-    : Boolean(options.cache)
-      ? options.cache
-      : cache;
+  const activeCacheConfig = isDevelopment() ? 'no-store' : cacheConfig;
 
   if (activeCacheConfig === 'no-store' && options.next?.revalidate) {
     delete options.next.revalidate;

--- a/apps/frontend/src/relay/server-portal-api-fetch.ts
+++ b/apps/frontend/src/relay/server-portal-api-fetch.ts
@@ -30,6 +30,7 @@ export default async function serverPortalApiFetch<
     request: request.params,
     variables,
     cookieList,
+    cache: 'force-cache', //force cache on server-side, can be override by adding options
     options,
   }).catch((e: unknown) => {
     if (e instanceof UnauthenticatedError) {
@@ -59,7 +60,7 @@ export async function serverFetchGraphQL<TQuery extends OperationType>(
 export async function serverMutateGraphQL<TMutation extends OperationType>(
   request: ConcreteRequest,
   variables: VariablesOf<TMutation>,
-  options: RequestInit = {}
+  options: RequestInit = { cache: 'default' }
 ): Promise<{ data: TMutation['response'] }> {
   const rawResponse = await serverPortalApiFetch<typeof request, TMutation>(
     request,


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

The public path was no longer caching calls due to recent changes. Server-side calls now cache by default, with the option to override via an options parameter.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Check the time to render page.

## Related issues

- Related to #2534 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.