### PR TITLE
feat(subscribed-services): organization subscribed services page (#2123)

### DIFF
--- a/apps/backend/src/__generated__/resolvers-types.ts
+++ b/apps/backend/src/__generated__/resolvers-types.ts
@@ -2185,6 +2185,7 @@ export type SubscriptionFilter = {
 };
 
 export enum SubscriptionFilterKey {
+  OrganizationId = 'organization_id',
   OrganizationName = 'organization_name',
   ServiceInstanceId = 'service_instance_id'
 }

--- a/apps/backend/src/modules/subscription/subscription.app.test.ts
+++ b/apps/backend/src/modules/subscription/subscription.app.test.ts
@@ -9,6 +9,7 @@ import {
   SubscriptionFilterKey,
   SubscriptionOrdering,
 } from '../../__generated__/resolvers-types';
+import { OrganizationId } from '../../model/kanel/public/Organization';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
 import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { SubscriptionId } from '../../model/kanel/public/Subscription';
@@ -251,6 +252,33 @@ describe('subscription app', () => {
   });
 
   describe(`${subscriptionApp.loadSubscriptions.name}`, () => {
+    const serviceInstanceFilters = (ids: ServiceInstanceId[]) => [
+      {
+        key: SubscriptionFilterKey.ServiceInstanceId,
+        value: ids.map((id) => toGlobalId('ServiceInstance', id)),
+      },
+    ];
+
+    const createSubscription = async ({
+      id = uuidv4() as SubscriptionId,
+      organizationId,
+      serviceInstanceId,
+      startDate,
+    }: {
+      id?: SubscriptionId;
+      organizationId: OrganizationId;
+      serviceInstanceId: ServiceInstanceId;
+      startDate: Date;
+    }) => {
+      return SubscriptionDomain.createSubscription({
+        id,
+        organization_id: organizationId,
+        service_instance_id: serviceInstanceId,
+        start_date: startDate,
+        end_date: null,
+      });
+    };
+
     it('should sort subscriptions by related service name', async () => {
       const serviceAId = uuidv4() as ServiceInstanceId;
       const serviceBId = uuidv4() as ServiceInstanceId;
@@ -264,48 +292,28 @@ describe('subscription app', () => {
         name: 'bbb-service',
       });
 
-      await SubscriptionDomain.createSubscription({
-        id: uuidv4() as SubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        service_instance_id: serviceAId,
-        start_date: new Date('2026-01-01'),
-        end_date: null,
+      await createSubscription({
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        serviceInstanceId: serviceAId,
+        startDate: new Date('2026-01-01'),
       });
-      await SubscriptionDomain.createSubscription({
-        id: uuidv4() as SubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        service_instance_id: serviceBId,
-        start_date: new Date('2026-01-01'),
-        end_date: null,
+      await createSubscription({
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        serviceInstanceId: serviceBId,
+        startDate: new Date('2026-01-01'),
       });
 
       const ascResult = await subscriptionApp.loadSubscriptions({
         first: 10,
         orderBy: SubscriptionOrdering.ServiceName,
         orderMode: OrderingMode.Asc,
-        filters: [
-          {
-            key: SubscriptionFilterKey.ServiceInstanceId,
-            value: [
-              toGlobalId('ServiceInstance', serviceAId),
-              toGlobalId('ServiceInstance', serviceBId),
-            ],
-          },
-        ],
+        filters: serviceInstanceFilters([serviceAId, serviceBId]),
       });
       const descResult = await subscriptionApp.loadSubscriptions({
         first: 10,
         orderBy: SubscriptionOrdering.ServiceName,
         orderMode: OrderingMode.Desc,
-        filters: [
-          {
-            key: SubscriptionFilterKey.ServiceInstanceId,
-            value: [
-              toGlobalId('ServiceInstance', serviceAId),
-              toGlobalId('ServiceInstance', serviceBId),
-            ],
-          },
-        ],
+        filters: serviceInstanceFilters([serviceAId, serviceBId]),
       });
 
       expect(
@@ -326,19 +334,17 @@ describe('subscription app', () => {
       const firstSubscriptionId = uuidv4() as SubscriptionId;
       const secondSubscriptionId = uuidv4() as SubscriptionId;
 
-      await SubscriptionDomain.createSubscription({
+      await createSubscription({
         id: firstSubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        service_instance_id: serviceId,
-        start_date: new Date('2026-02-01'),
-        end_date: null,
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        serviceInstanceId: serviceId,
+        startDate: new Date('2026-02-01'),
       });
-      await SubscriptionDomain.createSubscription({
+      await createSubscription({
         id: secondSubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
-        service_instance_id: serviceId,
-        start_date: new Date('2026-02-01'),
-        end_date: null,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        serviceInstanceId: serviceId,
+        startDate: new Date('2026-02-01'),
       });
 
       const result = await subscriptionApp.loadSubscriptions({
@@ -346,12 +352,7 @@ describe('subscription app', () => {
         orderBy: SubscriptionOrdering.StartDate,
         orderMode: OrderingMode.Asc,
         searchTerm: 'second orga',
-        filters: [
-          {
-            key: SubscriptionFilterKey.ServiceInstanceId,
-            value: [toGlobalId('ServiceInstance', serviceId)],
-          },
-        ],
+        filters: serviceInstanceFilters([serviceId]),
       });
 
       expect(Number(result.totalCount)).toBe(1);
@@ -376,19 +377,16 @@ describe('subscription app', () => {
       });
 
       const openCtiSubscriptionId = uuidv4() as SubscriptionId;
-      await SubscriptionDomain.createSubscription({
+      await createSubscription({
         id: openCtiSubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        service_instance_id: openCtiServiceId,
-        start_date: new Date('2026-03-01'),
-        end_date: null,
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        serviceInstanceId: openCtiServiceId,
+        startDate: new Date('2026-03-01'),
       });
-      await SubscriptionDomain.createSubscription({
-        id: uuidv4() as SubscriptionId,
-        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
-        service_instance_id: othersServiceId,
-        start_date: new Date('2026-03-01'),
-        end_date: null,
+      await createSubscription({
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        serviceInstanceId: othersServiceId,
+        startDate: new Date('2026-03-01'),
       });
 
       const result = await subscriptionApp.loadSubscriptions({
@@ -396,15 +394,7 @@ describe('subscription app', () => {
         orderBy: SubscriptionOrdering.StartDate,
         orderMode: OrderingMode.Asc,
         searchTerm: 'trial',
-        filters: [
-          {
-            key: SubscriptionFilterKey.ServiceInstanceId,
-            value: [
-              toGlobalId('ServiceInstance', openCtiServiceId),
-              toGlobalId('ServiceInstance', othersServiceId),
-            ],
-          },
-        ],
+        filters: serviceInstanceFilters([openCtiServiceId, othersServiceId]),
       });
 
       expect(Number(result.totalCount)).toBe(1);

--- a/apps/backend/src/modules/subscription/subscription.app.test.ts
+++ b/apps/backend/src/modules/subscription/subscription.app.test.ts
@@ -1,7 +1,14 @@
+import { toGlobalId } from 'graphql-relay/node/node.js';
 import { v4 as uuidv4 } from 'uuid';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { TestHelper } from '../../../tests/helper/test.helper';
 import { SERVICES, TEST_ORGANIZATIONS } from '../../../tests/tests.const';
+import {
+  OrderingMode,
+  ServiceInstanceTag,
+  SubscriptionFilterKey,
+  SubscriptionOrdering,
+} from '../../__generated__/resolvers-types';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
 import { ServiceInstanceId } from '../../model/kanel/public/ServiceInstance';
 import { SubscriptionId } from '../../model/kanel/public/Subscription';
@@ -240,6 +247,169 @@ describe('subscription app', () => {
       expect(loadedSubscription.organization_id).toBe(
         TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID
       );
+    });
+  });
+
+  describe(`${subscriptionApp.loadSubscriptions.name}`, () => {
+    it('should sort subscriptions by related service name', async () => {
+      const serviceAId = uuidv4() as ServiceInstanceId;
+      const serviceBId = uuidv4() as ServiceInstanceId;
+
+      await TestHelper.serviceInstance.create({
+        id: serviceAId,
+        name: 'aaa-service',
+      });
+      await TestHelper.serviceInstance.create({
+        id: serviceBId,
+        name: 'bbb-service',
+      });
+
+      await SubscriptionDomain.createSubscription({
+        id: uuidv4() as SubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: serviceAId,
+        start_date: new Date('2026-01-01'),
+        end_date: null,
+      });
+      await SubscriptionDomain.createSubscription({
+        id: uuidv4() as SubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: serviceBId,
+        start_date: new Date('2026-01-01'),
+        end_date: null,
+      });
+
+      const ascResult = await subscriptionApp.loadSubscriptions({
+        first: 10,
+        orderBy: SubscriptionOrdering.ServiceName,
+        orderMode: OrderingMode.Asc,
+        filters: [
+          {
+            key: SubscriptionFilterKey.ServiceInstanceId,
+            value: [
+              toGlobalId('ServiceInstance', serviceAId),
+              toGlobalId('ServiceInstance', serviceBId),
+            ],
+          },
+        ],
+      });
+      const descResult = await subscriptionApp.loadSubscriptions({
+        first: 10,
+        orderBy: SubscriptionOrdering.ServiceName,
+        orderMode: OrderingMode.Desc,
+        filters: [
+          {
+            key: SubscriptionFilterKey.ServiceInstanceId,
+            value: [
+              toGlobalId('ServiceInstance', serviceAId),
+              toGlobalId('ServiceInstance', serviceBId),
+            ],
+          },
+        ],
+      });
+
+      expect(
+        ascResult.edges.map(({ node }) => node.service_instance_id)
+      ).toEqual([serviceAId, serviceBId]);
+      expect(
+        descResult.edges.map(({ node }) => node.service_instance_id)
+      ).toEqual([serviceBId, serviceAId]);
+    });
+
+    it('should search subscriptions by related organization name', async () => {
+      const serviceId = uuidv4() as ServiceInstanceId;
+      await TestHelper.serviceInstance.create({
+        id: serviceId,
+        name: 'search-by-org-service',
+      });
+
+      const firstSubscriptionId = uuidv4() as SubscriptionId;
+      const secondSubscriptionId = uuidv4() as SubscriptionId;
+
+      await SubscriptionDomain.createSubscription({
+        id: firstSubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: serviceId,
+        start_date: new Date('2026-02-01'),
+        end_date: null,
+      });
+      await SubscriptionDomain.createSubscription({
+        id: secondSubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: serviceId,
+        start_date: new Date('2026-02-01'),
+        end_date: null,
+      });
+
+      const result = await subscriptionApp.loadSubscriptions({
+        first: 10,
+        orderBy: SubscriptionOrdering.StartDate,
+        orderMode: OrderingMode.Asc,
+        searchTerm: 'second orga',
+        filters: [
+          {
+            key: SubscriptionFilterKey.ServiceInstanceId,
+            value: [toGlobalId('ServiceInstance', serviceId)],
+          },
+        ],
+      });
+
+      expect(Number(result.totalCount)).toBe(1);
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].node.id).toBe(secondSubscriptionId);
+      expect(result.edges[0].node.id).not.toBe(firstSubscriptionId);
+    });
+
+    it('should search subscriptions by service tags', async () => {
+      const openCtiServiceId = uuidv4() as ServiceInstanceId;
+      const othersServiceId = uuidv4() as ServiceInstanceId;
+
+      await TestHelper.serviceInstance.create({
+        id: openCtiServiceId,
+        name: 'service-a',
+        tags: [ServiceInstanceTag.Trial],
+      });
+      await TestHelper.serviceInstance.create({
+        id: othersServiceId,
+        name: 'service-b',
+        tags: [ServiceInstanceTag.Others],
+      });
+
+      const openCtiSubscriptionId = uuidv4() as SubscriptionId;
+      await SubscriptionDomain.createSubscription({
+        id: openCtiSubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: openCtiServiceId,
+        start_date: new Date('2026-03-01'),
+        end_date: null,
+      });
+      await SubscriptionDomain.createSubscription({
+        id: uuidv4() as SubscriptionId,
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: othersServiceId,
+        start_date: new Date('2026-03-01'),
+        end_date: null,
+      });
+
+      const result = await subscriptionApp.loadSubscriptions({
+        first: 10,
+        orderBy: SubscriptionOrdering.StartDate,
+        orderMode: OrderingMode.Asc,
+        searchTerm: 'trial',
+        filters: [
+          {
+            key: SubscriptionFilterKey.ServiceInstanceId,
+            value: [
+              toGlobalId('ServiceInstance', openCtiServiceId),
+              toGlobalId('ServiceInstance', othersServiceId),
+            ],
+          },
+        ],
+      });
+
+      expect(Number(result.totalCount)).toBe(1);
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].node.id).toBe(openCtiSubscriptionId);
     });
   });
 

--- a/apps/backend/src/modules/subscription/subscription.app.ts
+++ b/apps/backend/src/modules/subscription/subscription.app.ts
@@ -1,10 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
-import { db, paginate, QueryOpts } from '../../../knexfile';
-import {
-  SubscriptionConnection,
-  SubscriptionModel,
-  SubscriptionOrdering,
-} from '../../__generated__/resolvers-types';
+import { QueryOpts } from '../../../knexfile';
+import { SubscriptionModel } from '../../__generated__/resolvers-types';
 import { withTransaction } from '../../context/database.context';
 import { OrganizationId } from '../../model/kanel/public/Organization';
 import { ServiceCapabilityId } from '../../model/kanel/public/ServiceCapability';
@@ -123,104 +119,8 @@ export const subscriptionApp = {
   },
 
   loadSubscriptions: async (opts: QueryOpts) => {
-    const { filters, searchTerm, orderBy } = opts;
-    const subscriptionOrderBy = getSubscriptionOrdering(orderBy);
-    const queryContext = db<Subscription>('Subscription');
-    const normalizedSearchTerm = searchTerm?.trim();
-    const shouldJoinOrganization =
-      normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0
-        ? true
-        : subscriptionOrderBy === SubscriptionOrdering.OrganizationName;
-    const shouldJoinServiceInstanceAndDefinition =
-      normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0
-        ? true
-        : subscriptionOrderBy === SubscriptionOrdering.ServiceName ||
-          subscriptionOrderBy === SubscriptionOrdering.ServiceDescription ||
-          subscriptionOrderBy === SubscriptionOrdering.ServiceProvider ||
-          subscriptionOrderBy === SubscriptionOrdering.ServiceType;
-
-    if (shouldJoinOrganization) {
-      queryContext.leftJoin(
-        'Organization',
-        'Organization.id',
-        'Subscription.organization_id'
-      );
-    }
-    if (shouldJoinServiceInstanceAndDefinition) {
-      queryContext
-        .leftJoin(
-          'ServiceInstance',
-          'ServiceInstance.id',
-          'Subscription.service_instance_id'
-        )
-        .leftJoin(
-          'ServiceDefinition',
-          'ServiceDefinition.id',
-          'ServiceInstance.service_definition_id'
-        );
-    }
-
-    if (normalizedSearchTerm) {
-      queryContext.andWhere((qb) => {
-        qb.whereILike('Organization.name', `%${normalizedSearchTerm}%`)
-          .orWhereILike('ServiceInstance.name', `%${normalizedSearchTerm}%`)
-          .orWhereILike(
-            'ServiceDefinition.identifier',
-            `%${normalizedSearchTerm}%`
-          )
-          .orWhereILike(
-            'ServiceInstance.creation_status',
-            `%${normalizedSearchTerm}%`
-          )
-          .orWhereRaw(
-            `EXISTS (
-              SELECT 1
-              FROM unnest("ServiceInstance"."tags"::text[]) AS tag
-              WHERE LOWER(tag) = LOWER(?)
-            )`,
-            [normalizedSearchTerm]
-          );
-      });
-    }
-
-    return paginate<Subscription, SubscriptionConnection>(
-      'Subscription',
-      {
-        ...opts,
-        orderBy: mapSubscriptionOrderingToColumn(subscriptionOrderBy),
-        filters,
-        searchTerm: undefined,
-      },
-      {},
-      queryContext
-    );
+    return SubscriptionDomain.loadSubscriptions(opts);
   },
-};
-
-const subscriptionOrderings = new Set(Object.values(SubscriptionOrdering));
-const getSubscriptionOrdering = (
-  orderBy: string | null | undefined
-): SubscriptionOrdering => {
-  if (orderBy && subscriptionOrderings.has(orderBy as SubscriptionOrdering)) {
-    return orderBy as SubscriptionOrdering;
-  }
-  return SubscriptionOrdering.StartDate;
-};
-
-const SUBSCRIPTION_ORDERING_TO_COLUMN: Record<SubscriptionOrdering, string> = {
-  [SubscriptionOrdering.OrganizationName]: 'Organization.name',
-  [SubscriptionOrdering.StartDate]: 'Subscription.start_date',
-  [SubscriptionOrdering.EndDate]: 'Subscription.end_date',
-  [SubscriptionOrdering.ServiceName]: 'ServiceInstance.name',
-  [SubscriptionOrdering.ServiceDescription]: 'ServiceDefinition.description',
-  [SubscriptionOrdering.ServiceType]: 'ServiceDefinition.identifier',
-  [SubscriptionOrdering.ServiceProvider]: 'ServiceDefinition.name',
-};
-
-const mapSubscriptionOrderingToColumn = (
-  orderBy: SubscriptionOrdering
-): string => {
-  return SUBSCRIPTION_ORDERING_TO_COLUMN[orderBy] ?? 'Subscription.start_date';
 };
 
 const assertOrganizationIsNotAlreadySubscribed = async ({

--- a/apps/backend/src/modules/subscription/subscription.app.ts
+++ b/apps/backend/src/modules/subscription/subscription.app.ts
@@ -1,8 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
-import { paginate, QueryOpts } from '../../../knexfile';
+import { db, paginate, QueryOpts } from '../../../knexfile';
 import {
   SubscriptionConnection,
   SubscriptionModel,
+  SubscriptionOrdering,
 } from '../../__generated__/resolvers-types';
 import { withTransaction } from '../../context/database.context';
 import { OrganizationId } from '../../model/kanel/public/Organization';
@@ -123,13 +124,108 @@ export const subscriptionApp = {
 
   loadSubscriptions: async (opts: QueryOpts) => {
     const { filters, searchTerm, orderBy } = opts;
-    return paginate<Subscription, SubscriptionConnection>('Subscription', {
-      ...opts,
-      orderBy: `Subscription.${orderBy}`,
-      filters,
-      searchTerm,
-    });
+    const subscriptionOrderBy = getSubscriptionOrdering(orderBy);
+    const queryContext = db<Subscription>('Subscription');
+    const normalizedSearchTerm = searchTerm?.trim();
+    const shouldJoinOrganization =
+      normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0
+        ? true
+        : subscriptionOrderBy === SubscriptionOrdering.OrganizationName;
+    const shouldJoinServiceInstanceAndDefinition =
+      normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0
+        ? true
+        : subscriptionOrderBy === SubscriptionOrdering.ServiceName ||
+          subscriptionOrderBy === SubscriptionOrdering.ServiceDescription ||
+          subscriptionOrderBy === SubscriptionOrdering.ServiceProvider ||
+          subscriptionOrderBy === SubscriptionOrdering.ServiceType;
+
+    if (shouldJoinOrganization) {
+      queryContext.leftJoin(
+        'Organization',
+        'Organization.id',
+        'Subscription.organization_id'
+      );
+    }
+    if (shouldJoinServiceInstanceAndDefinition) {
+      queryContext
+        .leftJoin(
+          'ServiceInstance',
+          'ServiceInstance.id',
+          'Subscription.service_instance_id'
+        )
+        .leftJoin(
+          'ServiceDefinition',
+          'ServiceDefinition.id',
+          'ServiceInstance.service_definition_id'
+        );
+    }
+
+    if (normalizedSearchTerm) {
+      queryContext.andWhere((qb) => {
+        qb.whereILike('Organization.name', `%${normalizedSearchTerm}%`)
+          .orWhereILike('ServiceInstance.name', `%${normalizedSearchTerm}%`)
+          .orWhereILike(
+            'ServiceDefinition.identifier',
+            `%${normalizedSearchTerm}%`
+          )
+          .orWhereILike(
+            'ServiceInstance.creation_status',
+            `%${normalizedSearchTerm}%`
+          )
+          .orWhereRaw(
+            `EXISTS (
+              SELECT 1
+              FROM unnest("ServiceInstance"."tags"::text[]) AS tag
+              WHERE LOWER(tag) = LOWER(?)
+            )`,
+            [normalizedSearchTerm]
+          );
+      });
+    }
+
+    return paginate<Subscription, SubscriptionConnection>(
+      'Subscription',
+      {
+        ...opts,
+        orderBy: mapSubscriptionOrderingToColumn(subscriptionOrderBy),
+        filters,
+        searchTerm: undefined,
+      },
+      {},
+      queryContext
+    );
   },
+};
+
+const subscriptionOrderings = new Set(Object.values(SubscriptionOrdering));
+const getSubscriptionOrdering = (
+  orderBy: string | null | undefined
+): SubscriptionOrdering => {
+  if (orderBy && subscriptionOrderings.has(orderBy as SubscriptionOrdering)) {
+    return orderBy as SubscriptionOrdering;
+  }
+  return SubscriptionOrdering.StartDate;
+};
+
+const mapSubscriptionOrderingToColumn = (orderBy: SubscriptionOrdering) => {
+  switch (orderBy) {
+    case SubscriptionOrdering.OrganizationName:
+      return 'Organization.name';
+    case SubscriptionOrdering.StartDate:
+      return 'Subscription.start_date';
+    case SubscriptionOrdering.EndDate:
+      return 'Subscription.end_date';
+    case SubscriptionOrdering.ServiceName:
+      return 'ServiceInstance.name';
+    case SubscriptionOrdering.ServiceDescription:
+      return 'ServiceDefinition.description';
+    case SubscriptionOrdering.ServiceType:
+      return 'ServiceDefinition.identifier';
+    case SubscriptionOrdering.ServiceProvider:
+      return 'ServiceDefinition.name';
+    default:
+      return 'Subscription.start_date';
+  }
 };
 
 const assertOrganizationIsNotAlreadySubscribed = async ({

--- a/apps/backend/src/modules/subscription/subscription.app.ts
+++ b/apps/backend/src/modules/subscription/subscription.app.ts
@@ -207,25 +207,20 @@ const getSubscriptionOrdering = (
   return SubscriptionOrdering.StartDate;
 };
 
-const mapSubscriptionOrderingToColumn = (orderBy: SubscriptionOrdering) => {
-  switch (orderBy) {
-    case SubscriptionOrdering.OrganizationName:
-      return 'Organization.name';
-    case SubscriptionOrdering.StartDate:
-      return 'Subscription.start_date';
-    case SubscriptionOrdering.EndDate:
-      return 'Subscription.end_date';
-    case SubscriptionOrdering.ServiceName:
-      return 'ServiceInstance.name';
-    case SubscriptionOrdering.ServiceDescription:
-      return 'ServiceDefinition.description';
-    case SubscriptionOrdering.ServiceType:
-      return 'ServiceDefinition.identifier';
-    case SubscriptionOrdering.ServiceProvider:
-      return 'ServiceDefinition.name';
-    default:
-      return 'Subscription.start_date';
-  }
+const SUBSCRIPTION_ORDERING_TO_COLUMN: Record<SubscriptionOrdering, string> = {
+  [SubscriptionOrdering.OrganizationName]: 'Organization.name',
+  [SubscriptionOrdering.StartDate]: 'Subscription.start_date',
+  [SubscriptionOrdering.EndDate]: 'Subscription.end_date',
+  [SubscriptionOrdering.ServiceName]: 'ServiceInstance.name',
+  [SubscriptionOrdering.ServiceDescription]: 'ServiceDefinition.description',
+  [SubscriptionOrdering.ServiceType]: 'ServiceDefinition.identifier',
+  [SubscriptionOrdering.ServiceProvider]: 'ServiceDefinition.name',
+};
+
+const mapSubscriptionOrderingToColumn = (
+  orderBy: SubscriptionOrdering
+): string => {
+  return SUBSCRIPTION_ORDERING_TO_COLUMN[orderBy] ?? 'Subscription.start_date';
 };
 
 const assertOrganizationIsNotAlreadySubscribed = async ({

--- a/apps/backend/src/modules/subscription/subscription.domain.ts
+++ b/apps/backend/src/modules/subscription/subscription.domain.ts
@@ -23,15 +23,20 @@ export const SubscriptionDomain = {
     const { filters, searchTerm, orderBy } = opts;
     const subscriptionOrderBy = getSubscriptionOrdering(orderBy);
     const normalizedSearchTerm = searchTerm?.trim();
+    const orderingsRequiringServiceInstanceJoin = [
+      SubscriptionOrdering.ServiceName,
+      SubscriptionOrdering.ServiceDescription,
+      SubscriptionOrdering.ServiceProvider,
+      SubscriptionOrdering.ServiceType,
+    ];
+    const hasSearchTerm =
+      normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0;
     const shouldJoinOrganization =
-      (normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0) ||
+      hasSearchTerm ||
       subscriptionOrderBy === SubscriptionOrdering.OrganizationName;
     const shouldJoinServiceInstanceAndDefinition =
-      (normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0) ||
-      subscriptionOrderBy === SubscriptionOrdering.ServiceName ||
-      subscriptionOrderBy === SubscriptionOrdering.ServiceDescription ||
-      subscriptionOrderBy === SubscriptionOrdering.ServiceProvider ||
-      subscriptionOrderBy === SubscriptionOrdering.ServiceType;
+      hasSearchTerm ||
+      orderingsRequiringServiceInstanceJoin.includes(subscriptionOrderBy);
 
     const queryContext = buildLoadSubscriptionsQuery({
       normalizedSearchTerm,

--- a/apps/backend/src/modules/subscription/subscription.domain.ts
+++ b/apps/backend/src/modules/subscription/subscription.domain.ts
@@ -1,4 +1,8 @@
-import { db, dbRaw } from '../../../knexfile';
+import { db, dbRaw, paginate, QueryOpts } from '../../../knexfile';
+import {
+  SubscriptionConnection,
+  SubscriptionOrdering,
+} from '../../__generated__/resolvers-types';
 import { OrganizationId } from '../../model/kanel/public/Organization';
 import ServiceCapability from '../../model/kanel/public/ServiceCapability';
 import Subscription, {
@@ -15,6 +19,39 @@ import { UnknownErrorCode } from '../../utils/error/error.code';
 import { formatRawObject } from '../../utils/query-raw.util';
 
 export const SubscriptionDomain = {
+  loadSubscriptions: async (opts: QueryOpts) => {
+    const { filters, searchTerm, orderBy } = opts;
+    const subscriptionOrderBy = getSubscriptionOrdering(orderBy);
+    const normalizedSearchTerm = searchTerm?.trim();
+    const shouldJoinOrganization =
+      (normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0) ||
+      subscriptionOrderBy === SubscriptionOrdering.OrganizationName;
+    const shouldJoinServiceInstanceAndDefinition =
+      (normalizedSearchTerm !== undefined && normalizedSearchTerm.length > 0) ||
+      subscriptionOrderBy === SubscriptionOrdering.ServiceName ||
+      subscriptionOrderBy === SubscriptionOrdering.ServiceDescription ||
+      subscriptionOrderBy === SubscriptionOrdering.ServiceProvider ||
+      subscriptionOrderBy === SubscriptionOrdering.ServiceType;
+
+    const queryContext = buildLoadSubscriptionsQuery({
+      normalizedSearchTerm,
+      shouldJoinOrganization,
+      shouldJoinServiceInstanceAndDefinition,
+    });
+
+    return paginate<Subscription, SubscriptionConnection>(
+      'Subscription',
+      {
+        ...opts,
+        orderBy: mapSubscriptionOrderingToColumn(subscriptionOrderBy),
+        filters,
+        searchTerm: undefined,
+      },
+      {},
+      queryContext
+    );
+  },
+
   deleteSubscriptions: async (
     ids: SubscriptionId[]
   ): Promise<Subscription[]> => {
@@ -193,4 +230,89 @@ export const SubscriptionDomain = {
         'Service_Capability.id',
       ]);
   },
+};
+
+const buildLoadSubscriptionsQuery = ({
+  normalizedSearchTerm,
+  shouldJoinOrganization,
+  shouldJoinServiceInstanceAndDefinition,
+}: {
+  normalizedSearchTerm: string | undefined;
+  shouldJoinOrganization: boolean;
+  shouldJoinServiceInstanceAndDefinition: boolean;
+}) => {
+  const queryContext = db<Subscription>('Subscription');
+
+  if (shouldJoinOrganization) {
+    queryContext.leftJoin(
+      'Organization',
+      'Organization.id',
+      'Subscription.organization_id'
+    );
+  }
+
+  if (shouldJoinServiceInstanceAndDefinition) {
+    queryContext
+      .leftJoin(
+        'ServiceInstance',
+        'ServiceInstance.id',
+        'Subscription.service_instance_id'
+      )
+      .leftJoin(
+        'ServiceDefinition',
+        'ServiceDefinition.id',
+        'ServiceInstance.service_definition_id'
+      );
+  }
+
+  if (normalizedSearchTerm) {
+    queryContext.andWhere((qb) => {
+      qb.whereILike('Organization.name', `%${normalizedSearchTerm}%`)
+        .orWhereILike('ServiceInstance.name', `%${normalizedSearchTerm}%`)
+        .orWhereILike(
+          'ServiceDefinition.identifier',
+          `%${normalizedSearchTerm}%`
+        )
+        .orWhereILike(
+          'ServiceInstance.creation_status',
+          `%${normalizedSearchTerm}%`
+        )
+        .orWhereRaw(
+          `EXISTS (
+            SELECT 1
+            FROM unnest("ServiceInstance"."tags"::text[]) AS tag
+            WHERE LOWER(tag) = LOWER(?)
+          )`,
+          [normalizedSearchTerm]
+        );
+    });
+  }
+
+  return queryContext;
+};
+
+const subscriptionOrderings = new Set(Object.values(SubscriptionOrdering));
+const getSubscriptionOrdering = (
+  orderBy: string | null | undefined
+): SubscriptionOrdering => {
+  if (orderBy && subscriptionOrderings.has(orderBy as SubscriptionOrdering)) {
+    return orderBy as SubscriptionOrdering;
+  }
+  return SubscriptionOrdering.StartDate;
+};
+
+const SUBSCRIPTION_ORDERING_TO_COLUMN: Record<SubscriptionOrdering, string> = {
+  [SubscriptionOrdering.OrganizationName]: 'Organization.name',
+  [SubscriptionOrdering.StartDate]: 'Subscription.start_date',
+  [SubscriptionOrdering.EndDate]: 'Subscription.end_date',
+  [SubscriptionOrdering.ServiceName]: 'ServiceInstance.name',
+  [SubscriptionOrdering.ServiceDescription]: 'ServiceDefinition.description',
+  [SubscriptionOrdering.ServiceType]: 'ServiceDefinition.identifier',
+  [SubscriptionOrdering.ServiceProvider]: 'ServiceDefinition.name',
+};
+
+const mapSubscriptionOrderingToColumn = (
+  orderBy: SubscriptionOrdering
+): string => {
+  return SUBSCRIPTION_ORDERING_TO_COLUMN[orderBy] ?? 'Subscription.start_date';
 };

--- a/apps/backend/src/modules/subscription/subscription.graphql
+++ b/apps/backend/src/modules/subscription/subscription.graphql
@@ -66,6 +66,7 @@ type SubscriptionConnection {
 }
 enum SubscriptionFilterKey {
   organization_name
+  organization_id
   service_instance_id
 }
 input SubscriptionFilter {

--- a/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page-loader.tsx
+++ b/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page-loader.tsx
@@ -4,8 +4,7 @@ import OrganizationSubscribedServicesSlug from '@/components/organization/[slug]
 import { BreadcrumbNav } from '@/components/ui/BreadcrumbNav';
 import { portalGraphqlClient } from '@/lib/graphql-client';
 import { APP_PATH } from '@/utils/path/constant';
-import { useQuery } from '@tanstack/react-query';
-import { gql } from 'graphql-request';
+import { useOrganizationSubscribedServicesBreadcrumbQuery } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
@@ -24,33 +23,13 @@ interface PreloaderProps {
   id: string;
 }
 
-interface OrganizationBreadcrumbQueryData {
-  organization: {
-    id: string;
-    name: string;
-  } | null;
-}
-
-const organizationBreadcrumbQuery = gql`
-  query OrganizationBreadcrumbQuery($id: ID!) {
-    organization(id: $id) {
-      id
-      name
-    }
-  }
-`;
-
 // Component
 const PageLoader = ({ id }: PreloaderProps) => {
   const t = useTranslations();
-  const { data: organizationData } = useQuery({
-    queryKey: ['organization-breadcrumb', id],
-    queryFn: () =>
-      portalGraphqlClient.request<OrganizationBreadcrumbQueryData>(
-        organizationBreadcrumbQuery,
-        { id }
-      ),
-  });
+  const { data: organizationData } =
+    useOrganizationSubscribedServicesBreadcrumbQuery(portalGraphqlClient, {
+      id,
+    });
   const organizationLabel = organizationData?.organization?.name ?? id;
 
   const breadcrumbValue = useMemo(() => {

--- a/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page-loader.tsx
+++ b/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page-loader.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import OrganizationSubscribedServicesSlug from '@/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices';
+import { BreadcrumbNav } from '@/components/ui/BreadcrumbNav';
+import { portalGraphqlClient } from '@/lib/graphql-client';
+import { APP_PATH } from '@/utils/path/constant';
+import { useQuery } from '@tanstack/react-query';
+import { gql } from 'graphql-request';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+
+const baseBreadcrumbValue = [
+  {
+    label: 'MenuLinks.Settings',
+  },
+  {
+    label: 'MenuLinks.Organization',
+    href: `/${APP_PATH}/admin/organizations`,
+  },
+];
+
+// Component interface
+interface PreloaderProps {
+  id: string;
+}
+
+interface OrganizationBreadcrumbQueryData {
+  organization: {
+    id: string;
+    name: string;
+  } | null;
+}
+
+const organizationBreadcrumbQuery = gql`
+  query OrganizationBreadcrumbQuery($id: ID!) {
+    organization(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+// Component
+const PageLoader = ({ id }: PreloaderProps) => {
+  const t = useTranslations();
+  const { data: organizationData } = useQuery({
+    queryKey: ['organization-breadcrumb', id],
+    queryFn: () =>
+      portalGraphqlClient.request<OrganizationBreadcrumbQueryData>(
+        organizationBreadcrumbQuery,
+        { id }
+      ),
+  });
+  const organizationLabel = organizationData?.organization?.name ?? id;
+
+  const breadcrumbValue = useMemo(() => {
+    return [
+      ...baseBreadcrumbValue,
+      { label: organizationLabel, original: true },
+      { label: 'Service.SubscribedServices' },
+    ];
+  }, [organizationLabel]);
+
+  return (
+    <>
+      <BreadcrumbNav value={breadcrumbValue} />
+      <h1 className="sr-only">{t('Service.SubscribedServices')}</h1>
+      <OrganizationSubscribedServicesSlug organizationId={id} />
+    </>
+  );
+};
+
+// Component export
+export default PageLoader;

--- a/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page.tsx
+++ b/apps/frontend/app/(application)/app/(admin)/admin/organizations/[slug]/subscribed-services/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation';
+import PageLoader from './page-loader';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { slug } = await params;
+  const encodedOrganizationId = slug;
+  let id = encodedOrganizationId;
+  try {
+    id = decodeURIComponent(encodedOrganizationId);
+  } catch {
+    notFound();
+  }
+  return <PageLoader id={id} />;
+};
+
+export default Page;

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -2562,6 +2562,13 @@ export type UsersWithCapabilitiesInOrganizationInput = {
   organizationId: Scalars['OrganizationId']['input'];
 };
 
+export type OrganizationSubscribedServicesBreadcrumbQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type OrganizationSubscribedServicesBreadcrumbQuery = { __typename?: 'Query', organization: { __typename?: 'Organization', id: string, name: string } | null };
+
 export type OrganizationSubscribedServiceRowFragment = { __typename?: 'SubscriptionModel', id: string, start_date: any | null, service_instance: { __typename?: 'ServiceInstance', id: string, name: string, creation_status: ServiceInstanceCreationStatus | null, tags: Array<ServiceInstanceTag> | null, service_definition: { __typename?: 'ServiceDefinition', id: string, name: string, identifier: ServiceDefinitionIdentifier } | null } };
 
 export type OrganizationSubscribedServicesListQueryVariables = Exact<{
@@ -2635,6 +2642,60 @@ export const UseCaseRowFragmentDoc = `
   color
 }
     `;
+export const OrganizationSubscribedServicesBreadcrumbDocument = `
+    query OrganizationSubscribedServicesBreadcrumb($id: ID!) {
+  organization(id: $id) {
+    id
+    name
+  }
+}
+    `;
+
+export const useOrganizationSubscribedServicesBreadcrumbQuery = <
+      TData = OrganizationSubscribedServicesBreadcrumbQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: OrganizationSubscribedServicesBreadcrumbQueryVariables,
+      options?: Omit<UseQueryOptions<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useQuery<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>(
+      {
+    queryKey: ['OrganizationSubscribedServicesBreadcrumb', variables],
+    queryFn: fetcher<OrganizationSubscribedServicesBreadcrumbQuery, OrganizationSubscribedServicesBreadcrumbQueryVariables>(client, OrganizationSubscribedServicesBreadcrumbDocument, variables, headers),
+    ...options
+  }
+    )};
+
+useOrganizationSubscribedServicesBreadcrumbQuery.getKey = (variables: OrganizationSubscribedServicesBreadcrumbQueryVariables) => ['OrganizationSubscribedServicesBreadcrumb', variables];
+useOrganizationSubscribedServicesBreadcrumbQuery.getRootKey = () => ['OrganizationSubscribedServicesBreadcrumb'] as const;
+export const useInfiniteOrganizationSubscribedServicesBreadcrumbQuery = <
+      TData = InfiniteData<OrganizationSubscribedServicesBreadcrumbQuery>,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: OrganizationSubscribedServicesBreadcrumbQueryVariables,
+      options: Omit<UseInfiniteQueryOptions<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>, 'queryKey'> & { queryKey?: UseInfiniteQueryOptions<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useInfiniteQuery<OrganizationSubscribedServicesBreadcrumbQuery, TError, TData>(
+      (() => {
+    const { queryKey: optionsQueryKey, ...restOptions } = options;
+    return {
+      queryKey: optionsQueryKey ?? ['OrganizationSubscribedServicesBreadcrumb.infinite', variables],
+      queryFn: (metaData) => fetcher<OrganizationSubscribedServicesBreadcrumbQuery, OrganizationSubscribedServicesBreadcrumbQueryVariables>(client, OrganizationSubscribedServicesBreadcrumbDocument, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
+      ...restOptions
+    }
+  })()
+    )};
+
+useInfiniteOrganizationSubscribedServicesBreadcrumbQuery.getKey = (variables: OrganizationSubscribedServicesBreadcrumbQueryVariables) => ['OrganizationSubscribedServicesBreadcrumb.infinite', variables];
+useInfiniteOrganizationSubscribedServicesBreadcrumbQuery.getRootKey = () => ['OrganizationSubscribedServicesBreadcrumb.infinite'] as const;
+useOrganizationSubscribedServicesBreadcrumbQuery.fetcher = (client: GraphQLClient, variables: OrganizationSubscribedServicesBreadcrumbQueryVariables, headers?: RequestInit['headers']) => fetcher<OrganizationSubscribedServicesBreadcrumbQuery, OrganizationSubscribedServicesBreadcrumbQueryVariables>(client, OrganizationSubscribedServicesBreadcrumbDocument, variables, headers);
+
 export const OrganizationSubscribedServicesListDocument = `
     query OrganizationSubscribedServicesList($count: Int!, $after: ID, $orderBy: SubscriptionOrdering!, $orderMode: OrderingMode!, $searchTerm: String, $filters: [SubscriptionFilter!]) {
   subscriptions(

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -1,6 +1,6 @@
 import type { GraphQLClient, RequestOptions } from "graphql-request";
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
-import { useMutation, useQuery, useInfiniteQuery, UseMutationOptions, UseQueryOptions, UseInfiniteQueryOptions, InfiniteData } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, InfiniteData, UseMutationOptions } from '@tanstack/react-query';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -2193,6 +2193,7 @@ export type SubscriptionFilter = {
 };
 
 export enum SubscriptionFilterKey {
+  OrganizationId = 'organization_id',
   OrganizationName = 'organization_name',
   ServiceInstanceId = 'service_instance_id'
 }
@@ -2561,6 +2562,20 @@ export type UsersWithCapabilitiesInOrganizationInput = {
   organizationId: Scalars['OrganizationId']['input'];
 };
 
+export type OrganizationSubscribedServiceRowFragment = { __typename?: 'SubscriptionModel', id: string, start_date: any | null, service_instance: { __typename?: 'ServiceInstance', id: string, name: string, creation_status: ServiceInstanceCreationStatus | null, tags: Array<ServiceInstanceTag> | null, service_definition: { __typename?: 'ServiceDefinition', id: string, name: string, identifier: ServiceDefinitionIdentifier } | null } };
+
+export type OrganizationSubscribedServicesListQueryVariables = Exact<{
+  count: Scalars['Int']['input'];
+  after: InputMaybe<Scalars['ID']['input']>;
+  orderBy: SubscriptionOrdering;
+  orderMode: OrderingMode;
+  searchTerm: InputMaybe<Scalars['String']['input']>;
+  filters: InputMaybe<Array<SubscriptionFilter> | SubscriptionFilter>;
+}>;
+
+
+export type OrganizationSubscribedServicesListQuery = { __typename?: 'Query', subscriptions: { __typename?: 'SubscriptionConnection', totalCount: number, edges: Array<{ __typename?: 'SubscriptionEdge', node: { __typename?: 'SubscriptionModel', id: string, start_date: any | null, service_instance: { __typename?: 'ServiceInstance', id: string, name: string, creation_status: ServiceInstanceCreationStatus | null, tags: Array<ServiceInstanceTag> | null, service_definition: { __typename?: 'ServiceDefinition', id: string, name: string, identifier: ServiceDefinitionIdentifier } | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null } } };
+
 export type UseCaseAddMutationVariables = Exact<{
   input: AddUseCaseInput;
 }>;
@@ -2596,6 +2611,23 @@ export type UseCasesListQueryVariables = Exact<{
 export type UseCasesListQuery = { __typename?: 'Query', useCases: { __typename?: 'UseCaseConnection', totalCount: number, edges: Array<{ __typename?: 'UseCaseEdge', node: { __typename?: 'UseCase', id: string, name: string, color: string } }> } | null };
 
 
+export const OrganizationSubscribedServiceRowFragmentDoc = `
+    fragment OrganizationSubscribedServiceRow on SubscriptionModel {
+  id
+  start_date
+  service_instance {
+    id
+    name
+    creation_status
+    tags
+    service_definition {
+      id
+      name
+      identifier
+    }
+  }
+}
+    `;
 export const UseCaseRowFragmentDoc = `
     fragment UseCaseRow on UseCase {
   id
@@ -2603,6 +2635,77 @@ export const UseCaseRowFragmentDoc = `
   color
 }
     `;
+export const OrganizationSubscribedServicesListDocument = `
+    query OrganizationSubscribedServicesList($count: Int!, $after: ID, $orderBy: SubscriptionOrdering!, $orderMode: OrderingMode!, $searchTerm: String, $filters: [SubscriptionFilter!]) {
+  subscriptions(
+    first: $count
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+    searchTerm: $searchTerm
+    filters: $filters
+  ) {
+    totalCount
+    edges {
+      node {
+        ...OrganizationSubscribedServiceRow
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+}
+    ${OrganizationSubscribedServiceRowFragmentDoc}`;
+
+export const useOrganizationSubscribedServicesListQuery = <
+      TData = OrganizationSubscribedServicesListQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: OrganizationSubscribedServicesListQueryVariables,
+      options?: Omit<UseQueryOptions<OrganizationSubscribedServicesListQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<OrganizationSubscribedServicesListQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useQuery<OrganizationSubscribedServicesListQuery, TError, TData>(
+      {
+    queryKey: ['OrganizationSubscribedServicesList', variables],
+    queryFn: fetcher<OrganizationSubscribedServicesListQuery, OrganizationSubscribedServicesListQueryVariables>(client, OrganizationSubscribedServicesListDocument, variables, headers),
+    ...options
+  }
+    )};
+
+useOrganizationSubscribedServicesListQuery.getKey = (variables: OrganizationSubscribedServicesListQueryVariables) => ['OrganizationSubscribedServicesList', variables];
+useOrganizationSubscribedServicesListQuery.getRootKey = () => ['OrganizationSubscribedServicesList'] as const;
+export const useInfiniteOrganizationSubscribedServicesListQuery = <
+      TData = InfiniteData<OrganizationSubscribedServicesListQuery>,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: OrganizationSubscribedServicesListQueryVariables,
+      options: Omit<UseInfiniteQueryOptions<OrganizationSubscribedServicesListQuery, TError, TData>, 'queryKey'> & { queryKey?: UseInfiniteQueryOptions<OrganizationSubscribedServicesListQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useInfiniteQuery<OrganizationSubscribedServicesListQuery, TError, TData>(
+      (() => {
+    const { queryKey: optionsQueryKey, ...restOptions } = options;
+    return {
+      queryKey: optionsQueryKey ?? ['OrganizationSubscribedServicesList.infinite', variables],
+      queryFn: (metaData) => fetcher<OrganizationSubscribedServicesListQuery, OrganizationSubscribedServicesListQueryVariables>(client, OrganizationSubscribedServicesListDocument, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
+      ...restOptions
+    }
+  })()
+    )};
+
+useInfiniteOrganizationSubscribedServicesListQuery.getKey = (variables: OrganizationSubscribedServicesListQueryVariables) => ['OrganizationSubscribedServicesList.infinite', variables];
+useInfiniteOrganizationSubscribedServicesListQuery.getRootKey = () => ['OrganizationSubscribedServicesList.infinite'] as const;
+useOrganizationSubscribedServicesListQuery.fetcher = (client: GraphQLClient, variables: OrganizationSubscribedServicesListQueryVariables, headers?: RequestInit['headers']) => fetcher<OrganizationSubscribedServicesListQuery, OrganizationSubscribedServicesListQueryVariables>(client, OrganizationSubscribedServicesListDocument, variables, headers);
+
 export const UseCaseAddDocument = `
     mutation UseCaseAdd($input: AddUseCaseInput!) {
   addUseCase(input: $input) {

--- a/apps/frontend/graphql/mocks.ts
+++ b/apps/frontend/graphql/mocks.ts
@@ -1603,7 +1603,7 @@ export const mockSubscriptionFilter = (overrides?: Partial<SubscriptionFilter>, 
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('SubscriptionFilter');
     return {
-        key: overrides && overrides.hasOwnProperty('key') ? overrides.key! : SubscriptionFilterKey.OrganizationName,
+        key: overrides && overrides.hasOwnProperty('key') ? overrides.key! : SubscriptionFilterKey.OrganizationId,
         value: overrides && overrides.hasOwnProperty('value') ? overrides.value! : ['admiratio'],
     };
 };

--- a/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services-breadcrumb.query.graphql
+++ b/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services-breadcrumb.query.graphql
@@ -1,0 +1,6 @@
+query OrganizationSubscribedServicesBreadcrumb($id: ID!) {
+  organization(id: $id) {
+    id
+    name
+  }
+}

--- a/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services.keys.ts
+++ b/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services.keys.ts
@@ -1,0 +1,10 @@
+import {
+  type OrganizationSubscribedServicesListQueryVariables,
+  useOrganizationSubscribedServicesListQuery,
+} from '@graphql/generated';
+
+export const organizationSubscribedServicesKeys = {
+  all: useOrganizationSubscribedServicesListQuery.getRootKey,
+  list: (variables: OrganizationSubscribedServicesListQueryVariables) =>
+    useOrganizationSubscribedServicesListQuery.getKey(variables),
+};

--- a/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services.query.graphql
+++ b/apps/frontend/graphql/organization-subscribed-services/organization-subscribed-services.query.graphql
@@ -1,0 +1,46 @@
+fragment OrganizationSubscribedServiceRow on SubscriptionModel {
+  id
+  start_date
+  service_instance {
+    id
+    name
+    creation_status
+    tags
+    service_definition {
+      id
+      name
+      identifier
+    }
+  }
+}
+
+query OrganizationSubscribedServicesList(
+  $count: Int!
+  $after: ID
+  $orderBy: SubscriptionOrdering!
+  $orderMode: OrderingMode!
+  $searchTerm: String
+  $filters: [SubscriptionFilter!]
+) {
+  subscriptions(
+    first: $count
+    after: $after
+    orderBy: $orderBy
+    orderMode: $orderMode
+    searchTerm: $searchTerm
+    filters: $filters
+  ) {
+    totalCount
+    edges {
+      node {
+        ...OrganizationSubscribedServiceRow
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -1078,6 +1078,15 @@
     "Name": "Name",
     "NoOwnedService": "You don't have any services yet.",
     "NoService": "There is no service... Yet!",
+    "SubscribedServices": "Subscribed services",
+    "SubscribedServicesList": {
+      "ServiceName": "Service name",
+      "ServiceType": "Service type",
+      "Status": "Status",
+      "StartDate": "Start date",
+      "Tags": "Tags",
+      "NoSubscribedServices": "No subscribed services found for this organization."
+    },
     "Organizations": "Organizations",
     "RegisteredPlatforms": {
       "PlatformDetails": "Platform details",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -1078,6 +1078,15 @@
     "Name": "Nom",
     "NoOwnedService": "Vous n'avez pas encore de service.",
     "NoService": "Il n'y a pas encore de service...",
+    "SubscribedServices": "Services souscrits",
+    "SubscribedServicesList": {
+      "ServiceName": "Nom du service",
+      "ServiceType": "Type de service",
+      "Status": "Statut",
+      "StartDate": "Date de début",
+      "Tags": "Tags",
+      "NoSubscribedServices": "Aucun service souscrit trouvé pour cette organisation."
+    },
     "Organizations": "Organisations",
     "RegisteredPlatforms": {
       "PlatformDetails": "Détails de la plateforme",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -1078,6 +1078,15 @@
     "Name": "氏名",
     "NoOwnedService": "まだサービスをご利用になっていません。",
     "NoService": "サービスはありません...まだ",
+    "SubscribedServices": "契約済みサービス",
+    "SubscribedServicesList": {
+      "ServiceName": "サービス名",
+      "ServiceType": "サービスタイプ",
+      "Status": "ステータス",
+      "StartDate": "開始日",
+      "Tags": "タグ",
+      "NoSubscribedServices": "この組織に契約済みサービスはありません。"
+    },
     "Organizations": "組織",
     "RegisteredPlatforms": {
       "PlatformDetails": "プラットフォームの詳細",

--- a/apps/frontend/schema.graphql
+++ b/apps/frontend/schema.graphql
@@ -1641,6 +1641,7 @@ type SubscriptionConnection {
 
 enum SubscriptionFilterKey {
   organization_name
+  organization_id
   service_instance_id
 }
 

--- a/apps/frontend/src/components/organization/OrganizationList.tsx
+++ b/apps/frontend/src/components/organization/OrganizationList.tsx
@@ -21,71 +21,86 @@ import { OrganizationOrderingEnum } from '@generated/models/OrganizationOrdering
 import { organizationItem_fragment$data } from '@generated/organizationItem_fragment.graphql';
 import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
-import { Suspense, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { Suspense, useMemo, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 const OrganizationList = () => {
   const t = useTranslations();
+  const router = useRouter();
+  const pathname = usePathname();
   const [editOrganization, setEditOrganization] = useState<
     organizationItem_fragment$data | undefined
   >(undefined);
   const [deleteOrganization, setDeleteOrganization] = useState<
     organizationItem_fragment$data | undefined
   >(undefined);
-  const columns: ColumnDef<organizationItem_fragment$data>[] = [
-    {
-      accessorKey: 'name',
-      id: 'name',
-      header: t('OrganizationForm.Name'),
-      cell: ({ row }) => {
-        return <>{row.original.name}</>;
+  const columns = useMemo<ColumnDef<organizationItem_fragment$data>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        id: 'name',
+        header: t('OrganizationForm.Name'),
+        cell: ({ row }) => {
+          return <>{row.original.name}</>;
+        },
       },
-    },
-    {
-      accessorKey: 'domains',
-      id: 'domains',
-      header: t('OrganizationForm.Domains'),
-      enableSorting: false,
-      cell: ({ row }) => {
-        return (
-          <div className="flex space-x-s">
-            {row.original.domains?.map((domain) => (
-              <Badge
-                className="truncate"
-                key={domain}>
-                {domain}
-              </Badge>
-            ))}
+      {
+        accessorKey: 'domains',
+        id: 'domains',
+        header: t('OrganizationForm.Domains'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          return (
+            <div className="flex space-x-s">
+              {row.original.domains?.map((domain) => (
+                <Badge
+                  className="truncate"
+                  key={domain}>
+                  {domain}
+                </Badge>
+              ))}
+            </div>
+          );
+        },
+      },
+      {
+        id: 'actions',
+        size: 100,
+        enableHiding: false,
+        enableSorting: false,
+        enableResizing: false,
+        cell: ({ row }) => (
+          <div className="flex items-center justify-end">
+            <IconActions
+              icon={
+                <>
+                  <MoreVertIcon className="h-4 w-4 text-primary" />
+                  <span className="sr-only">{t('Utils.OpenMenu')}</span>
+                </>
+              }>
+              <IconActionsItem
+                onClick={() => {
+                  router.push(
+                    `${pathname}/${encodeURIComponent(row.original.id)}/subscribed-services`
+                  );
+                }}>
+                {t('Service.SubscribedServices')}
+              </IconActionsItem>
+              <IconActionsItem
+                onClick={() => setEditOrganization(row.original)}>
+                {t('Utils.Update')}
+              </IconActionsItem>
+              <IconActionsItem
+                onClick={() => setDeleteOrganization(row.original)}>
+                {t('Utils.Delete')}
+              </IconActionsItem>
+            </IconActions>
           </div>
-        );
+        ),
       },
-    },
-    {
-      id: 'actions',
-      size: 100,
-      enableHiding: false,
-      enableSorting: false,
-      enableResizing: false,
-      cell: ({ row }) => (
-        <div className="flex items-center justify-end">
-          <IconActions
-            icon={
-              <>
-                <MoreVertIcon className="h-4 w-4 text-primary" />
-                <span className="sr-only">{t('Utils.OpenMenu')}</span>
-              </>
-            }>
-            <IconActionsItem onClick={() => setEditOrganization(row.original)}>
-              {t('Utils.Update')}
-            </IconActionsItem>
-            <IconActionsItem
-              onClick={() => setDeleteOrganization(row.original)}>
-              {t('Utils.Delete')}
-            </IconActionsItem>
-          </IconActions>
-        </div>
-      ),
-    },
-  ];
+    ],
+    [pathname, router, t]
+  );
   const {
     pageSize,
     setPageSize,

--- a/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.test.tsx
+++ b/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.test.tsx
@@ -1,0 +1,239 @@
+import OrganizationSubscribedServices from '@/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices';
+import testRender from '@/utils/test/test-render';
+import {
+  OrderingMode,
+  OrganizationSubscribedServicesListQuery,
+  ServiceDefinitionIdentifier,
+  ServiceInstanceCreationStatus,
+  ServiceInstanceTag,
+  SubscriptionOrdering,
+} from '@graphql/generated';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const graphqlMocks = vi.hoisted(() => ({
+  useOrganizationSubscribedServicesListQuery: Object.assign(vi.fn(), {
+    getKey: vi.fn((_variables: unknown) => [
+      'OrganizationSubscribedServicesList',
+    ]),
+    getRootKey: vi.fn(() => ['OrganizationSubscribedServicesList']),
+  }),
+}));
+
+vi.mock('@graphql/generated', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@graphql/generated')>();
+  return {
+    ...actual,
+    useOrganizationSubscribedServicesListQuery:
+      graphqlMocks.useOrganizationSubscribedServicesListQuery,
+  };
+});
+
+vi.mock('usehooks-ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('usehooks-ts')>();
+  return {
+    ...actual,
+    useDebounceCallback: (callback: (event: unknown) => void) => callback,
+  };
+});
+
+vi.mock('@filigran/ui', () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  DataTableHeadBarOptions: () => <div>DataTableHeadBarOptions</div>,
+  DataTable: ({
+    data,
+    isLoading,
+    toolbar,
+  }: {
+    data: Array<{ id: string; service_instance: { name: string } }>;
+    isLoading?: boolean;
+    toolbar?: ReactNode;
+  }) => (
+    <div>
+      {isLoading ? <div>loading</div> : null}
+      {data.map((row) => (
+        <div key={row.id}>{row.service_instance.name}</div>
+      ))}
+      {toolbar}
+    </div>
+  ),
+}));
+
+vi.mock(
+  '@/components/organization/[slug]/subscribed-services/organization-subscribed-services-localstorage',
+  () => ({
+    useOrganizationSubscribedServicesLocalstorage: () => ({
+      pageSize: 50,
+      setPageSize: vi.fn(),
+      orderMode: OrderingMode.Asc,
+      setOrderMode: vi.fn(),
+      orderBy: SubscriptionOrdering.StartDate,
+      setOrderBy: vi.fn(),
+      removeOrder: vi.fn(),
+      columnOrder: [],
+      setColumnOrder: vi.fn(),
+      columnVisibility: {},
+      setColumnVisibility: vi.fn(),
+      resetAll: vi.fn(),
+    }),
+    normalizeSubscribedServicesPageSize: (value: number) => value,
+  })
+);
+
+const baseQueryResponse: OrganizationSubscribedServicesListQuery = {
+  __typename: 'Query',
+  subscriptions: {
+    __typename: 'SubscriptionConnection',
+    totalCount: 1,
+    edges: [
+      {
+        __typename: 'SubscriptionEdge',
+        node: {
+          __typename: 'SubscriptionModel',
+          id: 'subscription-1',
+          start_date: '2026-01-01',
+          service_instance: {
+            __typename: 'ServiceInstance',
+            id: 'service-1',
+            name: 'OpenCTI',
+            creation_status: ServiceInstanceCreationStatus.Ready,
+            tags: [ServiceInstanceTag.OpenCti],
+            service_definition: {
+              __typename: 'ServiceDefinition',
+              id: 'definition-1',
+              name: 'OpenCTI',
+              identifier: ServiceDefinitionIdentifier.OpenctiRegistration,
+            },
+          },
+        },
+      },
+    ],
+    pageInfo: {
+      __typename: 'PageInfo',
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  },
+};
+
+describe('OrganizationSubscribedServices', () => {
+  it('renders subscribed services from query data', async () => {
+    graphqlMocks.useOrganizationSubscribedServicesListQuery.mockReturnValue({
+      data: baseQueryResponse,
+      isError: false,
+      isLoading: false,
+    });
+
+    testRender(
+      <OrganizationSubscribedServices organizationId="organization-1" />
+    );
+
+    expect(await screen.findByText('OpenCTI')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Service.SubscribedServicesList.NoSubscribedServices')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows error message when query fails', async () => {
+    graphqlMocks.useOrganizationSubscribedServicesListQuery.mockReturnValue({
+      data: undefined,
+      isError: true,
+      isLoading: false,
+    });
+
+    testRender(
+      <OrganizationSubscribedServices organizationId="organization-1" />
+    );
+
+    expect(await screen.findByText('Utils.Error')).toBeInTheDocument();
+  });
+
+  it('shows empty state only after loading finishes', async () => {
+    graphqlMocks.useOrganizationSubscribedServicesListQuery.mockReturnValue({
+      data: {
+        __typename: 'Query',
+        subscriptions: {
+          __typename: 'SubscriptionConnection',
+          totalCount: 0,
+          edges: [],
+          pageInfo: {
+            __typename: 'PageInfo',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        },
+      },
+      isError: false,
+      isLoading: true,
+    });
+
+    const { rerender } = testRender(
+      <OrganizationSubscribedServices organizationId="organization-1" />
+    );
+
+    expect(
+      screen.queryByText('Service.SubscribedServicesList.NoSubscribedServices')
+    ).not.toBeInTheDocument();
+
+    graphqlMocks.useOrganizationSubscribedServicesListQuery.mockReturnValue({
+      data: {
+        __typename: 'Query',
+        subscriptions: {
+          __typename: 'SubscriptionConnection',
+          totalCount: 0,
+          edges: [],
+          pageInfo: {
+            __typename: 'PageInfo',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        },
+      },
+      isError: false,
+      isLoading: false,
+    });
+
+    rerender(
+      <OrganizationSubscribedServices organizationId="organization-1" />
+    );
+
+    expect(
+      await screen.findByText(
+        'Service.SubscribedServicesList.NoSubscribedServices'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('sends search term to backend query variables', async () => {
+    graphqlMocks.useOrganizationSubscribedServicesListQuery.mockReturnValue({
+      data: baseQueryResponse,
+      isError: false,
+      isLoading: false,
+    });
+
+    testRender(
+      <OrganizationSubscribedServices organizationId="organization-1" />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Service.SearchServices'), {
+      target: { value: 'opencti' },
+    });
+
+    await waitFor(() => {
+      const lastCall =
+        graphqlMocks.useOrganizationSubscribedServicesListQuery.mock.calls.at(
+          -1
+        );
+      expect(lastCall?.[1]).toMatchObject({
+        searchTerm: 'opencti',
+      });
+    });
+  });
+});

--- a/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.tsx
+++ b/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { SearchInput } from '@/components/ui/SearchInput';
+import {
+  handleSortingChange,
+  mapToSortingTableValue,
+} from '@/components/ui/handle-sorting.utils';
+import { portalGraphqlClient } from '@/lib/graphql-client';
+import { DEBOUNCE_TIME } from '@/utils/constant';
+import { i18nKey } from '@/utils/datatable';
+import { Badge, DataTable, DataTableHeadBarOptions } from '@filigran/ui';
+import {
+  OrderingMode,
+  OrganizationSubscribedServiceRowFragment,
+  SubscriptionFilterKey,
+  useOrganizationSubscribedServicesListQuery,
+} from '@graphql/generated';
+import { organizationSubscribedServicesKeys } from '@graphql/organization-subscribed-services/organization-subscribed-services.keys';
+import { ColumnDef, PaginationState } from '@tanstack/react-table';
+import { useTranslations } from 'next-intl';
+import { ChangeEvent, useMemo, useState } from 'react';
+import { useDebounceCallback } from 'usehooks-ts';
+import {
+  normalizeSubscribedServicesPageSize,
+  useOrganizationSubscribedServicesLocalstorage,
+} from './organization-subscribed-services-localstorage';
+
+interface OrganizationSubscribedServicesProps {
+  organizationId: string;
+}
+
+const OrganizationSubscribedServicesSlug = ({
+  organizationId,
+}: OrganizationSubscribedServicesProps) => {
+  const t = useTranslations();
+  const [searchTerm, setSearchTerm] = useState('');
+  const columns = useMemo<
+    ColumnDef<OrganizationSubscribedServiceRowFragment>[]
+  >(
+    () => [
+      {
+        accessorFn: (row) => row.service_instance?.name,
+        id: 'service_name',
+        header: t('Service.SubscribedServicesList.ServiceName'),
+        cell: ({ row }) => {
+          return (
+            <span className="font-medium">
+              {row.original.service_instance?.name ?? '—'}
+            </span>
+          );
+        },
+      },
+      {
+        accessorFn: (row) =>
+          row.service_instance?.service_definition?.identifier,
+        id: 'service_type',
+        header: t('Service.SubscribedServicesList.ServiceType'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const identifier =
+            row.original.service_instance?.service_definition?.identifier;
+          return identifier ? (
+            <Badge variant="outline">
+              {t(`Service.ServiceDefinitionIdentifier.${identifier}`)}
+            </Badge>
+          ) : (
+            '—'
+          );
+        },
+      },
+      {
+        accessorFn: (row) => row.service_instance?.creation_status,
+        id: 'status',
+        header: t('Service.SubscribedServicesList.Status'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const status = row.original.service_instance?.creation_status;
+          return status ? <Badge>{status}</Badge> : '—';
+        },
+      },
+      {
+        accessorFn: (row) =>
+          row.start_date ? new Date(row.start_date).getTime() : undefined,
+        id: 'start_date',
+        header: t('Service.SubscribedServicesList.StartDate'),
+        cell: ({ row }) => {
+          return row.original.start_date
+            ? new Date(row.original.start_date).toLocaleDateString()
+            : '—';
+        },
+      },
+      {
+        accessorKey: 'service_instance.tags',
+        id: 'tags',
+        header: t('Service.SubscribedServicesList.Tags'),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const tags = row.original.service_instance?.tags;
+          return tags?.length ? (
+            <div className="flex gap-xs">
+              {tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            '—'
+          );
+        },
+      },
+    ],
+    [t]
+  );
+  const {
+    pageSize,
+    setPageSize,
+    orderMode,
+    setOrderMode,
+    orderBy,
+    setOrderBy,
+    removeOrder,
+    columnOrder,
+    setColumnOrder,
+    columnVisibility,
+    setColumnVisibility,
+    resetAll,
+  } = useOrganizationSubscribedServicesLocalstorage(columns);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize,
+  });
+
+  const variables = {
+    count: pagination.pageSize,
+    after: btoa(String(pagination.pageSize * pagination.pageIndex)),
+    orderBy,
+    orderMode,
+    searchTerm: searchTerm.trim() || null,
+    filters: [
+      {
+        key: SubscriptionFilterKey.OrganizationId,
+        value: [organizationId],
+      },
+    ],
+  };
+
+  const {
+    data: queryData,
+    isError,
+    isLoading,
+  } = useOrganizationSubscribedServicesListQuery(
+    portalGraphqlClient,
+    variables,
+    {
+      queryKey: organizationSubscribedServicesKeys.list(variables),
+    }
+  );
+
+  const subscribedServicesData = useMemo<
+    OrganizationSubscribedServiceRowFragment[]
+  >(() => {
+    const edges = queryData?.subscriptions?.edges ?? [];
+    return edges.map(({ node }) => node);
+  }, [queryData]);
+
+  const onSortingChange = (updater: unknown) => {
+    handleSortingChange({
+      updater,
+      orderBy,
+      orderMode,
+      setOrderMode: (nextOrderMode) =>
+        setOrderMode(
+          nextOrderMode === 'desc' ? OrderingMode.Desc : OrderingMode.Asc
+        ),
+      setOrderBy,
+      removeOrder,
+      handleRefetchData: () => undefined,
+    });
+  };
+
+  const onPaginationChange = (updater: unknown) => {
+    const newPaginationValue: PaginationState =
+      updater instanceof Function ? updater(pagination) : updater;
+    const normalizedPageSize = normalizeSubscribedServicesPageSize(
+      newPaginationValue.pageSize
+    );
+    setPagination({
+      ...newPaginationValue,
+      pageSize: normalizedPageSize,
+    });
+    if (normalizedPageSize !== pageSize) {
+      setPageSize(normalizedPageSize);
+    }
+  };
+
+  const onSearchChange = useDebounceCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setSearchTerm(event.target.value);
+      setPagination((prevPagination) => ({
+        ...prevPagination,
+        pageIndex: 0,
+      }));
+    },
+    DEBOUNCE_TIME
+  );
+
+  return (
+    <>
+      {isError && (
+        <div className="mb-s text-sm text-destructive">{t('Utils.Error')}</div>
+      )}
+      {!isError && !isLoading && subscribedServicesData.length === 0 && (
+        <div className="mb-s text-sm text-muted-foreground">
+          {t('Service.SubscribedServicesList.NoSubscribedServices')}
+        </div>
+      )}
+      <DataTable
+        columns={columns}
+        data={subscribedServicesData}
+        isLoading={isLoading}
+        i18nKey={i18nKey(t)}
+        onResetTable={resetAll}
+        tableState={{
+          sorting: mapToSortingTableValue(orderBy, orderMode),
+          pagination,
+          columnOrder,
+          columnVisibility,
+        }}
+        tableOptions={{
+          onSortingChange,
+          manualSorting: true,
+          onPaginationChange,
+          manualPagination: true,
+          onColumnOrderChange: setColumnOrder,
+          onColumnVisibilityChange: setColumnVisibility,
+          rowCount: queryData?.subscriptions.totalCount ?? 0,
+        }}
+        toolbar={
+          <div className="flex flex-col-reverse items-center justify-between gap-s sm:flex-row">
+            <label
+              htmlFor="subscribed-services-search"
+              className="sr-only">
+              {t('Service.SearchServices')}
+            </label>
+            <SearchInput
+              id="subscribed-services-search"
+              containerClass="w-full sm:w-1/3"
+              placeholder={t('Service.SearchServices')}
+              onChange={onSearchChange}
+            />
+            <div className="flex w-full items-center justify-between gap-s sm:w-auto">
+              <DataTableHeadBarOptions />
+            </div>
+          </div>
+        }
+      />
+    </>
+  );
+};
+
+export default OrganizationSubscribedServicesSlug;

--- a/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.tsx
+++ b/apps/frontend/src/components/organization/[slug]/subscribed-services/OrganizationSubscribedServices.tsx
@@ -8,6 +8,7 @@ import {
 import { portalGraphqlClient } from '@/lib/graphql-client';
 import { DEBOUNCE_TIME } from '@/utils/constant';
 import { i18nKey } from '@/utils/datatable';
+import { formatDate } from '@/utils/date';
 import { Badge, DataTable, DataTableHeadBarOptions } from '@filigran/ui';
 import {
   OrderingMode,
@@ -85,7 +86,7 @@ const OrganizationSubscribedServicesSlug = ({
         header: t('Service.SubscribedServicesList.StartDate'),
         cell: ({ row }) => {
           return row.original.start_date
-            ? new Date(row.original.start_date).toLocaleDateString()
+            ? (formatDate(row.original.start_date) ?? '—')
             : '—';
         },
       },

--- a/apps/frontend/src/components/organization/[slug]/subscribed-services/organization-subscribed-services-localstorage.ts
+++ b/apps/frontend/src/components/organization/[slug]/subscribed-services/organization-subscribed-services-localstorage.ts
@@ -1,0 +1,88 @@
+import { isValueInEnum } from '@/utils/is-value-in-enum';
+import { OrderingMode, SubscriptionOrdering } from '@graphql/generated';
+import { ColumnDef } from '@tanstack/react-table';
+import { useEffect } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
+
+const SUBSCRIBED_SERVICES_DEFAULT_PAGE_SIZE = 50;
+const SUBSCRIBED_SERVICES_PAGE_SIZES = [50, 100, 200, 300, 500];
+
+export const normalizeSubscribedServicesPageSize = (value: number) => {
+  return SUBSCRIBED_SERVICES_PAGE_SIZES.includes(value)
+    ? value
+    : SUBSCRIBED_SERVICES_DEFAULT_PAGE_SIZE;
+};
+
+export const useOrganizationSubscribedServicesLocalstorage = <U>(
+  columns: ColumnDef<U>[]
+) => {
+  const [orderMode, setOrderMode, removeOrderMode] =
+    useLocalStorage<OrderingMode>(
+      'orderModeOrganizationSubscribedServicesList',
+      OrderingMode.Asc
+    );
+  const [orderBy, setOrderBy, removeOrderBy] =
+    useLocalStorage<SubscriptionOrdering>(
+      'orderByOrganizationSubscribedServicesList',
+      SubscriptionOrdering.StartDate
+    );
+  const safeOrderBy = isValueInEnum(orderBy, SubscriptionOrdering)
+    ? orderBy
+    : SubscriptionOrdering.StartDate;
+  const safeOrderMode = isValueInEnum(orderMode, OrderingMode)
+    ? orderMode
+    : OrderingMode.Asc;
+  useEffect(() => {
+    if (!isValueInEnum(orderBy, SubscriptionOrdering)) {
+      setOrderBy(SubscriptionOrdering.StartDate);
+    }
+  }, [orderBy, setOrderBy]);
+  useEffect(() => {
+    if (!isValueInEnum(orderMode, OrderingMode)) {
+      setOrderMode(OrderingMode.Asc);
+    }
+  }, [orderMode, setOrderMode]);
+  const [pageSize, setPageSize, removePageSize] = useLocalStorage<number>(
+    'countOrganizationSubscribedServicesList',
+    SUBSCRIBED_SERVICES_DEFAULT_PAGE_SIZE
+  );
+  const safePageSize = normalizeSubscribedServicesPageSize(pageSize);
+  useEffect(() => {
+    if (pageSize !== safePageSize) {
+      setPageSize(safePageSize);
+    }
+  }, [pageSize, safePageSize, setPageSize]);
+  const [columnOrder, setColumnOrder, removeColumnOrder] = useLocalStorage(
+    'columnOrderingOrganizationSubscribedServicesList',
+    columns.flatMap((column) => (column.id ? [column.id] : []))
+  );
+  const [columnVisibility, setColumnVisibility, removeColumnVisibility] =
+    useLocalStorage('columnVisibilityOrganizationSubscribedServicesList', {});
+
+  const removeOrder = () => {
+    removeOrderBy();
+    removeOrderMode();
+  };
+
+  const resetAll = () => {
+    removeOrder();
+    removePageSize();
+    removeColumnOrder();
+    removeColumnVisibility();
+  };
+
+  return {
+    pageSize: safePageSize,
+    setPageSize,
+    orderMode: safeOrderMode,
+    setOrderMode,
+    orderBy: safeOrderBy,
+    setOrderBy,
+    removeOrder,
+    columnOrder,
+    setColumnOrder,
+    columnVisibility,
+    setColumnVisibility,
+    resetAll,
+  };
+};


### PR DESCRIPTION
# Context
This PR implement a new page to see Organization Subscribed Services in a table, and corresponding tests
Caching is done using React Query


## How to test
From the Organization List, you can access an Organization Subscribed Services by opening the Action Items and clicking on the `Subscribed services` button, it will redirect you to this specific Org Subscribed Services Table.
Filters is possible using the search bar, and data table configuration (pagination, column visibility/ordering) is available, they are persistent and stored in localStorage

https://github.com/user-attachments/assets/7e17b0f4-19d2-4722-810a-7f3a979a1724




## Related issues

- Related to #2123

# Checklist
## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.