### PR TITLE
chore(trials): update platform status inactive when trial status removed (#2549)

### DIFF
--- a/apps/backend/src/migrations/20260615121230_update_platform_status_removed_trials.js
+++ b/apps/backend/src/migrations/20260615121230_update_platform_status_removed_trials.js
@@ -1,0 +1,33 @@
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex('PlatformConfiguration as pc')
+    .update({ status: 'inactive' })
+    .where('pc.status', '=', 'active')
+    .whereExists(function () {
+      this.select(1)
+        .from('DeploymentRequest as dr')
+        .whereRaw('dr.service_instance_id = pc.service_instance_id')
+        .where('dr.type', '=', 'trial')
+        .where('dr.actual_state', '=', 'removed');
+    });
+}
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex('PlatformConfiguration as pc')
+    .update({ status: 'active' })
+    .where('pc.status', '=', 'inactive')
+    .whereExists(function () {
+      this.select(1)
+        .from('DeploymentRequest as dr')
+        .whereRaw('dr.service_instance_id = pc.service_instance_id')
+        .where('dr.type', '=', 'trial')
+        .where('dr.actual_state', '=', 'removed');
+    });
+}

--- a/apps/backend/src/modules/deployment/deployment.app.test.ts
+++ b/apps/backend/src/modules/deployment/deployment.app.test.ts
@@ -883,6 +883,33 @@ describe('deployment app', () => {
         );
       expect(userObserverGroup).toHaveLength(0);
     });
+
+    it('should set platform registration status to inactive when actual state is removed', async () => {
+      await TestHelper.platformConfiguration.create({
+        service_instance_id: initialDeployment.service_instance_id,
+        status: PlatformConfigurationStatus.Active,
+      });
+
+      await DeploymentApp.updateDeploymentRequest({
+        id: initialDeployment.id as DeploymentRequestId,
+        actual_state: DeploymentRequestPlatformState.Removed,
+      });
+
+      const platformConfiguration = await TestHelper.platformConfiguration.load(
+        {
+          service_instance_id: initialDeployment.service_instance_id,
+        }
+      );
+
+      expect(platformConfiguration?.status).toBe(
+        PlatformConfigurationStatus.Inactive
+      );
+
+      await TestHelper.platformConfiguration.delete({
+        service_instance_id: initialDeployment.service_instance_id,
+      });
+    });
+
     it('should throw if deployment request does not exist', async () => {
       const call = DeploymentApp.updateDeploymentRequest({
         id: uuidv4() as DeploymentRequestId,

--- a/apps/backend/src/modules/deployment/deployment.app.test.ts
+++ b/apps/backend/src/modules/deployment/deployment.app.test.ts
@@ -890,24 +890,25 @@ describe('deployment app', () => {
         status: PlatformConfigurationStatus.Active,
       });
 
-      await DeploymentApp.updateDeploymentRequest({
-        id: initialDeployment.id as DeploymentRequestId,
-        actual_state: DeploymentRequestPlatformState.Removed,
-      });
+      try {
+        await DeploymentApp.updateDeploymentRequest({
+          id: initialDeployment.id as DeploymentRequestId,
+          actual_state: DeploymentRequestPlatformState.Removed,
+        });
 
-      const platformConfiguration = await TestHelper.platformConfiguration.load(
-        {
+        const platformConfiguration =
+          await TestHelper.platformConfiguration.load({
+            service_instance_id: initialDeployment.service_instance_id,
+          });
+
+        expect(platformConfiguration?.status).toBe(
+          PlatformConfigurationStatus.Inactive
+        );
+      } finally {
+        await TestHelper.platformConfiguration.delete({
           service_instance_id: initialDeployment.service_instance_id,
-        }
-      );
-
-      expect(platformConfiguration?.status).toBe(
-        PlatformConfigurationStatus.Inactive
-      );
-
-      await TestHelper.platformConfiguration.delete({
-        service_instance_id: initialDeployment.service_instance_id,
-      });
+        });
+      }
     });
 
     it('should throw if deployment request does not exist', async () => {

--- a/apps/backend/src/modules/deployment/deployment.app.ts
+++ b/apps/backend/src/modules/deployment/deployment.app.ts
@@ -10,6 +10,7 @@ import {
   DeploymentRequestPlatformRegion,
   DeploymentRequestPlatformState,
   OrderingMode,
+  PlatformConfigurationStatus,
   PlatformDeploymentRequest,
   PlatformDeploymentRequestConnection,
   PlatformIdentifier,
@@ -819,6 +820,20 @@ const resolveNextHubStatus = (
   return computedStatus;
 };
 
+const syncPlatformRegistrationStatus = async (
+  deploymentRequest: DeploymentRequestModel,
+  actualState: UpdateDeploymentRequestInput['actual_state']
+) => {
+  if (actualState !== DeploymentRequestPlatformState.Removed) {
+    return;
+  }
+
+  await PlatformConfigurationDomain.updateConfiguration(
+    deploymentRequest.service_instance_id,
+    { status: PlatformConfigurationStatus.Inactive }
+  );
+};
+
 const applyDeploymentRequestUpdateInQuotaTransaction = async ({
   deploymentRequest,
   deploymentRequestId,
@@ -860,6 +875,10 @@ const applyDeploymentRequestUpdateInQuotaTransaction = async ({
       await DeploymentRequestDomain.updateDeploymentRequestById(
         deploymentRequestId,
         updateData
+      );
+      await syncPlatformRegistrationStatus(
+        deploymentRequest,
+        input.actual_state
       );
 
       if (newStatus === DeploymentRequestHubStatus.Active) {


### PR DESCRIPTION
# Context
On Trial removal, the platform status was not updated to be inactive
It now sets the Platform status to `inactive` if Trial status is updated with `removed`

## How to test
When removing a trial, check that the concerned PlatformConfiguration status is well updated to `inactive`

## Related issues

- Related to #2549 

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.