### PR TITLE
fix(integration-library): page filter ui tweak (#2566)

### DIFF
--- a/apps/frontend/src/components/ui/pagination/PaginationArrowButtons.tsx
+++ b/apps/frontend/src/components/ui/pagination/PaginationArrowButtons.tsx
@@ -18,6 +18,9 @@ export const PaginationArrowButtons = ({
 }: PaginationArrowButtonsProps) => {
   const t = useTranslations();
   const pageCount = Math.ceil(totalCount / pageSize);
+  const rangeStart = totalCount > 0 ? pageIndex * pageSize + 1 : 0;
+  const rangeEnd = Math.min((pageIndex + 1) * pageSize, totalCount);
+  const counterWidth = `${3 * String(totalCount).length + 6}ch`;
 
   const canGoToPreviousPage = (): boolean => {
     return pageIndex > 0;
@@ -54,13 +57,16 @@ export const PaginationArrowButtons = ({
         aria-label={t('GenericActions.Paginate.PreviousPage')}>
         <ArrowPreviousIcon className="size-3" />
       </Button>
-      <div className="px-s leading-none text-text-secondary txt-sub-content">
+      <div
+        className="leading-none text-text-secondary txt-sub-content whitespace-nowrap text-center"
+        style={{ width: counterWidth }}>
         <span className="text-foreground">
-          {totalCount > 0 ? pageIndex * pageSize + 1 : 0}
+          {rangeStart}
           {' - '}
-          {Math.min((pageIndex + 1) * pageSize, totalCount)}
+          {rangeEnd}
         </span>
-        / {totalCount}
+        {' / '}
+        {totalCount}
       </div>
       <Button
         variant="ghost"

--- a/apps/frontend/src/components/ui/pagination/PaginationArrowButtons.tsx
+++ b/apps/frontend/src/components/ui/pagination/PaginationArrowButtons.tsx
@@ -17,9 +17,10 @@ export const PaginationArrowButtons = ({
   pageSize,
 }: PaginationArrowButtonsProps) => {
   const t = useTranslations();
-  const pageCount = Math.ceil(totalCount / pageSize);
-  const rangeStart = totalCount > 0 ? pageIndex * pageSize + 1 : 0;
-  const rangeEnd = Math.min((pageIndex + 1) * pageSize, totalCount);
+  const safePageSize = pageSize > 0 ? pageSize : 1;
+  const pageCount = Math.ceil(totalCount / safePageSize);
+  const rangeStart = totalCount > 0 ? pageIndex * safePageSize + 1 : 0;
+  const rangeEnd = Math.min((pageIndex + 1) * safePageSize, totalCount);
   const counterWidth = `${3 * String(totalCount).length + 6}ch`;
 
   const canGoToPreviousPage = (): boolean => {
@@ -35,7 +36,7 @@ export const PaginationArrowButtons = ({
       return;
     }
 
-    onPaginationChange({ pageSize, pageIndex: pageIndex - 1 });
+    onPaginationChange({ pageSize: safePageSize, pageIndex: pageIndex - 1 });
   };
 
   const nextPage = (): void => {
@@ -43,7 +44,7 @@ export const PaginationArrowButtons = ({
       return;
     }
 
-    onPaginationChange({ pageSize, pageIndex: pageIndex + 1 });
+    onPaginationChange({ pageSize: safePageSize, pageIndex: pageIndex + 1 });
   };
 
   return (

--- a/apps/frontend/src/components/ui/pagination/PaginationControls.tsx
+++ b/apps/frontend/src/components/ui/pagination/PaginationControls.tsx
@@ -17,6 +17,11 @@ export const PaginationControls = ({
   pageIndex,
   onSetPageSize,
 }: PaginationControlsProps) => {
+  const handleSetPageSize = (nextPageSize: number) => {
+    onPaginationChange({ pageIndex: 0, pageSize: nextPageSize });
+    onSetPageSize(nextPageSize);
+  };
+
   return (
     <div className="flex-0 shrink-0 box-border flex h-9 items-center rounded border border-border-light">
       <PaginationArrowButtons
@@ -27,7 +32,7 @@ export const PaginationControls = ({
       />
       <PaginationManageDropdown
         pageSize={pageSize}
-        onSetPageSize={onSetPageSize}
+        onSetPageSize={handleSetPageSize}
       />
     </div>
   );

--- a/apps/frontend/src/components/ui/pagination/PaginationControls.tsx
+++ b/apps/frontend/src/components/ui/pagination/PaginationControls.tsx
@@ -17,10 +17,6 @@ export const PaginationControls = ({
   pageIndex,
   onSetPageSize,
 }: PaginationControlsProps) => {
-  if (totalCount <= pageSize) {
-    return null;
-  }
-
   return (
     <div className="flex-0 shrink-0 box-border flex h-9 items-center rounded border border-border-light">
       <PaginationArrowButtons


### PR DESCRIPTION
# Context
Page filter setting container behaved inappropriately :
- setting a rows per page > totalCount would hide the settings container, resulting in not being able to change it
- switching pages would move the container a little bit to the left

## How to test
Playing with the page settings should result in not having weird behavior anymore, it should be flawless

**Before** 

https://github.com/user-attachments/assets/03e83761-0df5-43df-96e3-c368a3ec2ac3


**After**

https://github.com/user-attachments/assets/b9f55b6c-625c-4e6a-85f7-55d80e8b3e64



## Related issues

- Related to #2566

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.