### PR TITLE
feat(roadmap): send monthly PM reminder on the 25th with a roadmap link (#2554)

### DIFF
--- a/apps/backend/config/production.json
+++ b/apps/backend/config/production.json
@@ -8,7 +8,8 @@
     }
   ],
   "enabled_emails": {
-    "pending_user_digest": true
+    "pending_user_digest": true,
+    "public_roadmap_monthly_reminder": true
   },
   "base_url_front": "https://hub.filigran.io"
 }

--- a/apps/backend/src/crons.ts
+++ b/apps/backend/src/crons.ts
@@ -65,7 +65,9 @@ export const initCronJobs = () => {
   scheduledTasks.push(cron.schedule('0 2 * * *', expireTrials));
   scheduledTasks.push(cron.schedule('0 9 * * 1', sendPendingUserDigest));
   scheduledTasks.push(
-    cron.schedule('0 8 1 * *', sendPublicRoadmapMonthlyReminder)
+    cron.schedule('0 8 * * 1-5', sendPublicRoadmapMonthlyReminder, {
+      timezone: 'Europe/Paris',
+    })
   );
   scheduledTasks.push(cron.schedule('0 3 * * *', cleanExpiredTrialGroups));
   scheduledTasks.push(cron.schedule('0 4 * * *', cleanExpiredNewsFeedItems));

--- a/apps/backend/src/modules/xtm-platform-roadmap/epic.app.reminder.test.ts
+++ b/apps/backend/src/modules/xtm-platform-roadmap/epic.app.reminder.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import portalConfig from '../../config';
+
+const mailServiceMock = vi.hoisted(() => ({
+  sendMail: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Keep buildServiceLink real (we want to verify the resolved URL),
+// only stub the actual send.
+vi.mock('../../server/mail-service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../server/mail-service')
+  >('../../server/mail-service');
+  return { ...actual, sendMail: mailServiceMock.sendMail };
+});
+
+// Bypass the "is it the 25th?" guard — covered by roadmap-reminder.util.test.ts.
+vi.mock('../../utils/roadmap-reminder.util', () => ({
+  isRoadmapReminderDay: vi.fn(() => true),
+}));
+
+import { EpicApp } from './epic.app';
+
+describe('epicApp.sendPublicRoadmapMonthlyReminder', () => {
+  let originalFlag: boolean;
+
+  beforeEach(() => {
+    originalFlag = portalConfig.enabled_emails.public_roadmap_monthly_reminder;
+    portalConfig.enabled_emails.public_roadmap_monthly_reminder = true;
+    mailServiceMock.sendMail.mockClear();
+  });
+
+  afterEach(() => {
+    portalConfig.enabled_emails.public_roadmap_monthly_reminder = originalFlag;
+  });
+
+  it('sends the reminder to the PMs with a link resolved from the roadmap instance', async () => {
+    await EpicApp.sendPublicRoadmapMonthlyReminder();
+
+    expect(mailServiceMock.sendMail).toHaveBeenCalledTimes(1);
+
+    const [payload] = mailServiceMock.sendMail.mock.calls[0] as [
+      { to: string; template: string; params: { roadmapLink: string } },
+    ];
+    expect(payload.to).toBe('product.managers@filigran.io');
+    expect(payload.template).toBe('public_roadmap_monthly_reminder');
+    // buildServiceLink ran for real against the seeded roadmap instance.
+    expect(payload.params.roadmapLink).toMatch(
+      /\/app\/service\/xtm_platform_roadmap\/.+/
+    );
+  });
+
+  it('does not send when the feature flag is disabled', async () => {
+    portalConfig.enabled_emails.public_roadmap_monthly_reminder = false;
+
+    await EpicApp.sendPublicRoadmapMonthlyReminder();
+
+    expect(mailServiceMock.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/modules/xtm-platform-roadmap/epic.app.ts
+++ b/apps/backend/src/modules/xtm-platform-roadmap/epic.app.ts
@@ -13,13 +13,14 @@ import { requestContext } from '../../context/request.context';
 import Epic, { EpicId } from '../../model/kanel/public/Epic';
 import User from '../../model/kanel/public/User';
 import { assertUserHasCapaOnService } from '../../security/guard';
-import { sendMail } from '../../server/mail-service';
+import { buildServiceLink, sendMail } from '../../server/mail-service';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 import {
   NotFoundErrorCode,
   UnknownErrorCode,
 } from '../../utils/error/error.code';
+import { isRoadmapReminderDay } from '../../utils/roadmap-reminder.util';
 import { stripNulls } from '../../utils/typescript';
 import {
   DocumentUploadsHelper,
@@ -182,10 +183,27 @@ export const EpicApp = {
       );
       return;
     }
+    if (!isRoadmapReminderDay(new Date())) {
+      return;
+    }
+    const serviceInstance = await ServiceInstanceDomain.loadServiceInstanceBy({
+      slug: PLATFORM_ROADMAP_SLUG,
+    });
+    if (!serviceInstance) {
+      logApp.error(
+        'Public roadmap service instance not found, skipping monthly reminder'
+      );
+      return;
+    }
+    const roadmapLink = buildServiceLink({
+      serviceDefinitionIdentifier:
+        ServiceDefinitionIdentifier.XtmPlatformRoadmap,
+      serviceInstanceId: serviceInstance.id,
+    });
     await sendMail({
       to: 'product.managers@filigran.io',
       template: 'public_roadmap_monthly_reminder',
-      params: {},
+      params: { roadmapLink },
     });
   },
 };

--- a/apps/backend/src/server/mail-template/mail.ts
+++ b/apps/backend/src/server/mail-template/mail.ts
@@ -174,5 +174,5 @@ export const templateSubjects: {
     return `New ${params.platformIdentifier} SaaS ${params.deploymentType} Has Been Launched on XTM Hub by ${params.organizationName}`;
   },
   public_roadmap_monthly_reminder: () =>
-    'XTM Hub - Public Roadmap monthly reminder',
+    'Monthly check-in — Update your XTM Hub Roadmap Epics',
 };

--- a/apps/backend/src/server/mail-template/public_roadmap_monthly_reminder.html
+++ b/apps/backend/src/server/mail-template/public_roadmap_monthly_reminder.html
@@ -171,7 +171,7 @@
                         <td
                           style="border-radius: 4px; background-color: #00020c">
                           <a
-                            href="{{{ roadmapLink }}}"
+                            href="{{ roadmapLink }}"
                             style="
                               display: inline-block;
                               padding: 12px 28px;

--- a/apps/backend/src/server/mail-template/public_roadmap_monthly_reminder.html
+++ b/apps/backend/src/server/mail-template/public_roadmap_monthly_reminder.html
@@ -147,23 +147,49 @@
                       box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
                     ">
                     <p style="margin: 0; line-height: 24px">
-                      Hi Team,<br />
-                      This is a friendly reminder to please upload your product
-                      roadmap to the XTM Hub for this month. <br />
+                      Hello PMs and PMMs,<br />
+                      Friendly monthly reminder: please make sure your epics are
+                      created and kept up to date in the roadmap. <br />
 
-                      Keeping the XTM Hub updated ensures alignment across teams
-                      and helps our community of users, partners & customers
-                      stay informed on priorities and timelines. <br />
+                      Maintaining an accurate roadmap helps us keep a clear and
+                      reliable view of Filigran’s priorities internally, while
+                      also providing the community with visibility into what’s
+                      coming next. <br />
 
                       <br />
                       If you’ve already submitted your roadmap, thank you!
                       <br />
                       <br />
                     </p>
-
+                    <table
+                      align="center"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="none"
+                      style="margin: 8px auto 16px">
+                      <tr>
+                        <td
+                          style="border-radius: 4px; background-color: #00020c">
+                          <a
+                            href="{{{ roadmapLink }}}"
+                            style="
+                              display: inline-block;
+                              padding: 12px 28px;
+                              font-size: 14px;
+                              font-weight: 600;
+                              line-height: 20px;
+                              color: #ffffff;
+                              text-decoration: none;
+                              border-radius: 4px;
+                            ">
+                            Open the roadmap
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
                     <p style="margin: 0; padding-top: 16px">
-                      Best regards, <br />
-                      <strong>The Filigran Team</strong>
+                      Kind regards, <br />
+                      <strong>The XTM Hub team</strong>
                     </p>
                   </td>
                 </tr>

--- a/apps/backend/src/utils/roadmap-reminder.util.test.ts
+++ b/apps/backend/src/utils/roadmap-reminder.util.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isRoadmapReminderDay } from './roadmap-reminder.util';
+
+describe('isRoadmapReminderDay', () => {
+  // June 2026: the 25th is a Thursday (a regular business day).
+  it('returns true on the 25th when it is a weekday', () => {
+    expect(isRoadmapReminderDay(new Date(2026, 5, 25))).toBe(true);
+  });
+
+  it('returns false on a weekday that is not the reminder day', () => {
+    expect(isRoadmapReminderDay(new Date(2026, 5, 24))).toBe(false);
+    expect(isRoadmapReminderDay(new Date(2026, 5, 26))).toBe(false);
+  });
+
+  // October 2026: the 25th is a Sunday -> reminder shifts to Friday the 23rd.
+  it('shifts to the previous Friday when the 25th is a Sunday', () => {
+    expect(isRoadmapReminderDay(new Date(2026, 9, 23))).toBe(true);
+    expect(isRoadmapReminderDay(new Date(2026, 9, 25))).toBe(false);
+  });
+
+  // April 2026: the 25th is a Saturday -> reminder shifts to Friday the 24th.
+  it('shifts to the previous Friday when the 25th is a Saturday', () => {
+    expect(isRoadmapReminderDay(new Date(2026, 3, 24))).toBe(true);
+    expect(isRoadmapReminderDay(new Date(2026, 3, 25))).toBe(false);
+  });
+});

--- a/apps/backend/src/utils/roadmap-reminder.util.test.ts
+++ b/apps/backend/src/utils/roadmap-reminder.util.test.ts
@@ -2,25 +2,30 @@ import { describe, expect, it } from 'vitest';
 import { isRoadmapReminderDay } from './roadmap-reminder.util';
 
 describe('isRoadmapReminderDay', () => {
-  // June 2026: the 25th is a Thursday (a regular business day).
+  // 25 June 2026 is a Thursday (a regular business day).
   it('returns true on the 25th when it is a weekday', () => {
-    expect(isRoadmapReminderDay(new Date(2026, 5, 25))).toBe(true);
+    expect(isRoadmapReminderDay(new Date('2026-06-25T12:00:00Z'))).toBe(true);
   });
 
   it('returns false on a weekday that is not the reminder day', () => {
-    expect(isRoadmapReminderDay(new Date(2026, 5, 24))).toBe(false);
-    expect(isRoadmapReminderDay(new Date(2026, 5, 26))).toBe(false);
+    expect(isRoadmapReminderDay(new Date('2026-06-24T12:00:00Z'))).toBe(false);
+    expect(isRoadmapReminderDay(new Date('2026-06-26T12:00:00Z'))).toBe(false);
   });
 
-  // October 2026: the 25th is a Sunday -> reminder shifts to Friday the 23rd.
+  // 25 October 2026 is a Sunday -> reminder shifts to Friday the 23rd.
   it('shifts to the previous Friday when the 25th is a Sunday', () => {
-    expect(isRoadmapReminderDay(new Date(2026, 9, 23))).toBe(true);
-    expect(isRoadmapReminderDay(new Date(2026, 9, 25))).toBe(false);
+    expect(isRoadmapReminderDay(new Date('2026-10-23T12:00:00Z'))).toBe(true);
+    expect(isRoadmapReminderDay(new Date('2026-10-25T12:00:00Z'))).toBe(false);
   });
 
-  // April 2026: the 25th is a Saturday -> reminder shifts to Friday the 24th.
+  // 25 April 2026 is a Saturday -> reminder shifts to Friday the 24th.
   it('shifts to the previous Friday when the 25th is a Saturday', () => {
-    expect(isRoadmapReminderDay(new Date(2026, 3, 24))).toBe(true);
-    expect(isRoadmapReminderDay(new Date(2026, 3, 25))).toBe(false);
+    expect(isRoadmapReminderDay(new Date('2026-04-24T12:00:00Z'))).toBe(true);
+    expect(isRoadmapReminderDay(new Date('2026-04-25T12:00:00Z'))).toBe(false);
+  });
+
+  it('is independent of the server timezone (computed in Europe/Paris)', () => {
+    // 08:00 UTC on the 25th = 10:00 in Paris, still the 25th.
+    expect(isRoadmapReminderDay(new Date('2026-06-25T08:00:00Z'))).toBe(true);
   });
 });

--- a/apps/backend/src/utils/roadmap-reminder.util.ts
+++ b/apps/backend/src/utils/roadmap-reminder.util.ts
@@ -1,0 +1,23 @@
+/**
+ * Determines whether the monthly public roadmap reminder should be sent today.
+ *
+ * The reminder is due on the 25th of the month, or on the preceding Friday when
+ * the 25th falls on a weekend. Only weekends are taken into account here, not
+ * public holidays (deliberate simplification for an internal reminder).
+ *
+ * The cron is scheduled to run every weekday morning; this guard ensures the
+ * email is only sent on the correct day.
+ */
+export const isRoadmapReminderDay = (now: Date): boolean => {
+  const twentyFifth = new Date(now.getFullYear(), now.getMonth(), 25);
+  const dayOfWeek = twentyFifth.getDay(); // 0 = Sunday, 6 = Saturday
+
+  let reminderDayOfMonth = 25;
+  if (dayOfWeek === 6) {
+    reminderDayOfMonth = 24; // Saturday -> previous Friday
+  } else if (dayOfWeek === 0) {
+    reminderDayOfMonth = 23; // Sunday -> previous Friday
+  }
+
+  return now.getDate() === reminderDayOfMonth;
+};

--- a/apps/backend/src/utils/roadmap-reminder.util.ts
+++ b/apps/backend/src/utils/roadmap-reminder.util.ts
@@ -1,16 +1,33 @@
+const REMINDER_TIME_ZONE = 'Europe/Paris';
+
 /**
- * Determines whether the monthly public roadmap reminder should be sent today.
+ * Whether the monthly public roadmap reminder is due today: the 25th of the
+ * month, or the preceding Friday when the 25th falls on a weekend (weekends
+ * only, not public holidays).
  *
- * The reminder is due on the 25th of the month, or on the preceding Friday when
- * the 25th falls on a weekend. Only weekends are taken into account here, not
- * public holidays (deliberate simplification for an internal reminder).
- *
- * The cron is scheduled to run every weekday morning; this guard ensures the
- * email is only sent on the correct day.
+ * The date is read in REMINDER_TIME_ZONE so the result does not depend on the
+ * server/container timezone (the cron is scheduled in the same zone).
  */
-export const isRoadmapReminderDay = (now: Date): boolean => {
-  const twentyFifth = new Date(now.getFullYear(), now.getMonth(), 25);
-  const dayOfWeek = twentyFifth.getDay(); // 0 = Sunday, 6 = Saturday
+export const isRoadmapReminderDay = (
+  now: Date,
+  timeZone: string = REMINDER_TIME_ZONE
+): boolean => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now);
+
+  const partValue = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((part) => part.type === type)?.value);
+
+  const year = partValue('year');
+  const month = partValue('month');
+  const day = partValue('day');
+
+  // A calendar date's weekday is timezone-independent, so compute it in UTC.
+  const dayOfWeek = new Date(Date.UTC(year, month - 1, 25)).getUTCDay(); // 0=Sun, 6=Sat
 
   let reminderDayOfMonth = 25;
   if (dayOfWeek === 6) {
@@ -19,5 +36,5 @@ export const isRoadmapReminderDay = (now: Date): boolean => {
     reminderDayOfMonth = 23; // Sunday -> previous Friday
   }
 
-  return now.getDate() === reminderDayOfMonth;
+  return day === reminderDayOfMonth;
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

<img width="1414" height="944" alt="image" src="https://github.com/user-attachments/assets/da8c592c-e59e-4f5b-8382-41415a87c9a1" />


Completes the monthly public-roadmap reminder for Product & Product Marketing managers (#2554). The plumbing was scaffolded in #1795 but shipped disabled, sent on the 1st of the month, and had no link to the roadmap.

This PR brings it in line with #2554:
- Sends on the **25th of the month, or the previous Friday** when the 25th falls on a weekend (cron runs weekdays at 08:00 Europe/Paris; a guard decides the actual day).
- Adds an **"Open the roadmap" CTA button**, with the link resolved from the roadmap service instance per environment (no hardcoded URL).
- Aligns the subject and body with the issue copy.
- Enables the email in production.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #2554

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.