### PR TITLE
fix(trial): conditionally display connection status and last check (#2593)

### DIFF
--- a/apps/frontend/src/components/service/registration/RegistrationDetails.test.tsx
+++ b/apps/frontend/src/components/service/registration/RegistrationDetails.test.tsx
@@ -232,6 +232,38 @@ describe('RegistrationDetails', () => {
         screen.queryByText(/Register\.Details\.EndDate/i)
       ).not.toBeInTheDocument();
     });
+
+    it('should hide connection status and last check rows for trial when deployment is not ACTIVE', () => {
+      renderDetails({
+        ...trialPlatform,
+        last_connectivity_check: '2025-03-10T12:00:00.000Z',
+        deployment_request: {
+          ...trialPlatform.deployment_request!,
+          hub_status: DeploymentRequestHubStatusEnum.PENDING,
+        },
+      });
+
+      expect(
+        screen.queryByText(/Register\.Details\.ConnectionStatus\.Title/i)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Register\.Details\.LastConnectionCheck/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show connection status and last check rows for trial when deployment is ACTIVE', () => {
+      renderDetails({
+        ...trialPlatform,
+        last_connectivity_check: '2025-03-10T12:00:00.000Z',
+      });
+
+      expect(
+        screen.getByText(/Register\.Details\.ConnectionStatus\.Title/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Register\.Details\.LastConnectionCheck/i)
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Access row for trial', () => {

--- a/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
+++ b/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
@@ -92,6 +92,11 @@ export const RegistrationDetails = ({
     1
   );
 
+  const isLastConnectivityCheckDisplayed =
+    !isTrial ||
+    platform?.deployment_request?.hub_status ===
+      DeploymentRequestHubStatusEnum.ACTIVE;
+
   return (
     <section className="flex justify-between p-xl border border-solid border-blue rounded">
       <ul className="text-sm flex flex-col gap-l">
@@ -118,6 +123,7 @@ export const RegistrationDetails = ({
             {isCancellable && (
               <Button
                 variant="link-destructive"
+                className="cursor-pointer m-0 p-0 ml-4 h-full"
                 onClick={() => setOpenCancelSheet(true)}>
                 {t('Utils.Cancel')}
               </Button>
@@ -173,37 +179,41 @@ export const RegistrationDetails = ({
             ? t('Register.Details.Contracts.CE')
             : t('Register.Details.Contracts.EE')}
         </li>
-        <li>
-          <span className="text-gray/60">
-            {t('Register.Details.ConnectionStatus.Title')}:
-          </span>{' '}
-          <span
-            className={
-              isConnectionStatusOk ? 'text-green-500' : 'text-red-500'
-            }>
-            {isConnectionStatusOk ? (
-              t('Register.Details.ConnectionStatus.Connected')
-            ) : (
-              <span>
-                {t('Register.Details.ConnectionStatus.NotConnected')}
-                {'. '}
+        {isLastConnectivityCheckDisplayed && (
+          <>
+            <li>
+              <span className="text-gray/60">
+                {t('Register.Details.ConnectionStatus.Title')}:
+              </span>{' '}
+              <span
+                className={
+                  isConnectionStatusOk ? 'text-green-500' : 'text-red-500'
+                }>
+                {isConnectionStatusOk ? (
+                  t('Register.Details.ConnectionStatus.Connected')
+                ) : (
+                  <span>
+                    {t('Register.Details.ConnectionStatus.NotConnected')}
+                    {'. '}
+                  </span>
+                )}
               </span>
-            )}
-          </span>
-          {!isConnectionStatusOk && (
-            <span>
-              {t('Register.Details.ConnectionStatus.NotConnectedDetails')}
-            </span>
-          )}
-        </li>
-        <li>
-          <span className="text-gray/60">
-            {t('Register.Details.LastConnectionCheck')}:
-          </span>{' '}
-          {platform.last_connectivity_check
-            ? formatDate(platform.last_connectivity_check)
-            : '-'}
-        </li>
+              {!isConnectionStatusOk && (
+                <span>
+                  {t('Register.Details.ConnectionStatus.NotConnectedDetails')}
+                </span>
+              )}
+            </li>
+            <li>
+              <span className="text-gray/60">
+                {t('Register.Details.LastConnectionCheck')}:
+              </span>{' '}
+              {platform.last_connectivity_check
+                ? formatDate(platform.last_connectivity_check)
+                : '-'}
+            </li>
+          </>
+        )}
         {isTrialActive && (
           <li>
             <span>

--- a/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
+++ b/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
@@ -123,7 +123,7 @@ export const RegistrationDetails = ({
             {isCancellable && (
               <Button
                 variant="link-destructive"
-                className="cursor-pointer m-0 p-0 ml-4 h-full"
+                className="m-0 p-0 ml-4 h-full"
                 onClick={() => setOpenCancelSheet(true)}>
                 {t('Utils.Cancel')}
               </Button>

--- a/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
+++ b/apps/frontend/src/components/service/registration/RegistrationDetails.tsx
@@ -102,23 +102,23 @@ export const RegistrationDetails = ({
       <ul className="text-sm flex flex-col gap-l">
         {platform.title && (
           <li>
-            <span className="text-gray/60">
+            <span className="text-gray/60 mr-1">
               {t('Register.Details.PlatformName')}:
-            </span>{' '}
+            </span>
             {platform.title}
           </li>
         )}
         <li>
-          <span className="text-gray/60">
+          <span className="text-gray/60 mr-1">
             {t('Register.Details.PlatformURL')}:
-          </span>{' '}
+          </span>
           <span>{platform.url ? platform.url : '-'}</span>
         </li>
         {platform.deployment_request?.hub_status && (
           <li>
-            <span className="text-gray/60">
+            <span className="text-gray/60 mr-1">
               {t('Register.Details.Status')}:
-            </span>{' '}
+            </span>
             {formatTitleCase(platform.deployment_request?.hub_status)}
             {isCancellable && (
               <Button
@@ -133,19 +133,18 @@ export const RegistrationDetails = ({
         {isTrial ? (
           <>
             <li>
-              <span className="text-gray/60">
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.StartDate')}:
-              </span>{' '}
+              </span>
               {platform.subscription?.start_date &&
               platform.subscription.end_date
                 ? formatDate(platform.subscription.start_date)
                 : '-'}
             </li>
             <li>
-              <span className="text-gray/60">
-                {' '}
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.EndDate')}:
-              </span>{' '}
+              </span>
               {platform.subscription?.end_date
                 ? formatDate(platform.subscription?.end_date)
                 : '-'}
@@ -154,9 +153,9 @@ export const RegistrationDetails = ({
         ) : (
           <>
             <li>
-              <span className="text-gray/60">
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.RegisteredOn')}:
-              </span>{' '}
+              </span>
               {platform.subscription?.start_date
                 ? formatDate(platform.subscription.start_date)
                 : '-'}
@@ -166,15 +165,16 @@ export const RegistrationDetails = ({
 
         {platform.deployment_request?.region && (
           <li>
-            <span className="text-gray/60">
-              {' '}
+            <span className="text-gray/60 mr-1">
               {t('Register.Details.Region')}:
-            </span>{' '}
+            </span>
             {t(`Region.${platform.deployment_request.region.toUpperCase()}`)}
           </li>
         )}
         <li>
-          <span className="text-gray/60">{t('Register.Details.License')}:</span>{' '}
+          <span className="text-gray/60 mr-1">
+            {t('Register.Details.License')}:
+          </span>
           {platform.contract === 'CE'
             ? t('Register.Details.Contracts.CE')
             : t('Register.Details.Contracts.EE')}
@@ -182,9 +182,9 @@ export const RegistrationDetails = ({
         {isLastConnectivityCheckDisplayed && (
           <>
             <li>
-              <span className="text-gray/60">
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.ConnectionStatus.Title')}:
-              </span>{' '}
+              </span>
               <span
                 className={
                   isConnectionStatusOk ? 'text-green-500' : 'text-red-500'
@@ -205,9 +205,9 @@ export const RegistrationDetails = ({
               )}
             </li>
             <li>
-              <span className="text-gray/60">
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.LastConnectionCheck')}:
-              </span>{' '}
+              </span>
               {platform.last_connectivity_check
                 ? formatDate(platform.last_connectivity_check)
                 : '-'}
@@ -217,9 +217,9 @@ export const RegistrationDetails = ({
         {isTrialActive && (
           <li>
             <span>
-              <span className="text-gray/60">
+              <span className="text-gray/60 mr-1">
                 {t('Register.Details.Access')}:
-              </span>{' '}
+              </span>
               {userHasTrialAccess ? (
                 <span>
                   {(platform.myGroups ?? [])
@@ -229,9 +229,9 @@ export const RegistrationDetails = ({
                 </span>
               ) : (
                 <span>
-                  <span className="text-red-500">
+                  <span className="text-red-500 mr-1">
                     {t('RegistrationDetails.NoAccess')}
-                  </span>{' '}
+                  </span>
                   {t('RegistrationDetails.NoAccessContact', {
                     email: platform.deployment_request?.requester_email ?? '',
                   })}


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


This PR fixes the trial registration details UI so that connectivity information (connection status + last connectivity check) is only shown when a trial’s deployment is **ACTIVE**, preventing confusing “connection lost” messaging while the trial is still pending.

**Changes:**
- Conditionally render the “Connection status” and “Last connection check” rows based on trial deployment status (ACTIVE-only for trials; unchanged for non-trials).
- Adjust the cancel button styling in the status row to better fit the inline layout.
- Add unit tests covering the new conditional display behavior for trials.


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- start a trial
- check that connection status is not displayed
- make the trial active
- check that connectivity status is displayed

## Related issues

- Related to #2593 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.

## Inactive trial

<img width="3024" height="1606" alt="image" src="https://github.com/user-attachments/assets/a097457f-7c0a-4cd9-86d4-a73e5434f436" />

## Active trial

<img width="3022" height="1608" alt="image" src="https://github.com/user-attachments/assets/8008229b-93c7-490a-99ae-cf27d9e65bab" />
