### PR TITLE
fix(user-picture): cache avatars and widen rate limit to avoid 429 on resource list (#2579)

### DIFF
--- a/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
+++ b/apps/backend/src/modules/organization-management/user/user-domain/user.domain.ts
@@ -123,6 +123,13 @@ export const UserDomain = {
     return db<User>('User').where(field).first();
   },
 
+  loadUserPictureMinio: async (userId: string): Promise<string | null> => {
+    const [user] = await db<User>('User')
+      .where('id', userId)
+      .select('picture_minio');
+    return user?.picture_minio ?? null;
+  },
+
   loadUserBy: async (
     field: addPrefixToObject<UserMutator, 'User.'> | UserMutator
   ): Promise<UserLoadUserBy | undefined> => {

--- a/apps/backend/src/server/endpoints/user-picture-endpoint.test.ts
+++ b/apps/backend/src/server/endpoints/user-picture-endpoint.test.ts
@@ -1,0 +1,96 @@
+import type { Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, downloadFileMock } = vi.hoisted(() => ({
+  dbMock: vi.fn(),
+  downloadFileMock: vi.fn(),
+}));
+
+vi.mock('../../../knexfile', () => ({ db: dbMock }));
+vi.mock('../../thirdparty/minio/client', () => ({
+  MinIOClient: { downloadFile: downloadFileMock },
+}));
+vi.mock('../../utils/app-logger.util', () => ({
+  logApp: { error: vi.fn() },
+}));
+
+import { getUserPicture } from './user-picture-endpoint';
+
+const CACHE_CONTROL = 'public, max-age=2592000, immutable';
+
+const mockDbResult = (rows: { picture_minio: string | null }[]) => {
+  const builder = {
+    where: vi.fn(() => builder),
+    select: vi.fn(() => Promise.resolve(rows)),
+  };
+  dbMock.mockReturnValue(builder);
+};
+
+const buildResponse = () => ({
+  headersSent: false,
+  setHeader: vi.fn(),
+  removeHeader: vi.fn(),
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+});
+
+const buildRequest = (userId: string) =>
+  ({ params: { userId } }) as unknown as Request;
+
+describe('getUserPicture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets an immutable Cache-Control header on a successful response', async () => {
+    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    downloadFileMock.mockResolvedValue({ on: vi.fn(), pipe: vi.fn() });
+
+    const res = buildResponse();
+    await getUserPicture(buildRequest('user-1'), res as unknown as Response);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', CACHE_CONTROL);
+  });
+
+  it('returns 404 and no cache header when the user has no picture', async () => {
+    mockDbResult([]);
+
+    const res = buildResponse();
+    await getUserPicture(buildRequest('user-1'), res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 and no cache header when the MinIO download fails', async () => {
+    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    downloadFileMock.mockResolvedValue(null);
+
+    const res = buildResponse();
+    await getUserPicture(buildRequest('user-1'), res as unknown as Response);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  it('removes the cache header before a 404 when the stream errors early', async () => {
+    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    let onError: (error: Error) => void = () => undefined;
+    downloadFileMock.mockResolvedValue({
+      on: vi.fn((event: string, cb: (error: Error) => void) => {
+        if (event === 'error') {
+          onError = cb;
+        }
+      }),
+      pipe: vi.fn(),
+    });
+
+    const res = buildResponse();
+    await getUserPicture(buildRequest('user-1'), res as unknown as Response);
+    onError(new Error('minio unreachable'));
+
+    expect(res.removeHeader).toHaveBeenCalledWith('Cache-Control');
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/apps/backend/src/server/endpoints/user-picture-endpoint.test.ts
+++ b/apps/backend/src/server/endpoints/user-picture-endpoint.test.ts
@@ -1,30 +1,27 @@
 import type { Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbMock, downloadFileMock } = vi.hoisted(() => ({
-  dbMock: vi.fn(),
+const { loadUserPictureMinioMock, downloadFileMock } = vi.hoisted(() => ({
+  loadUserPictureMinioMock: vi.fn(),
   downloadFileMock: vi.fn(),
 }));
 
-vi.mock('../../../knexfile', () => ({ db: dbMock }));
+vi.mock(
+  '../../modules/organization-management/user/user-domain/user.domain',
+  () => ({
+    UserDomain: { loadUserPictureMinio: loadUserPictureMinioMock },
+  })
+);
 vi.mock('../../thirdparty/minio/client', () => ({
   MinIOClient: { downloadFile: downloadFileMock },
 }));
 vi.mock('../../utils/app-logger.util', () => ({
-  logApp: { error: vi.fn() },
+  logApp: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
 import { getUserPicture } from './user-picture-endpoint';
 
 const CACHE_CONTROL = 'public, max-age=2592000, immutable';
-
-const mockDbResult = (rows: { picture_minio: string | null }[]) => {
-  const builder = {
-    where: vi.fn(() => builder),
-    select: vi.fn(() => Promise.resolve(rows)),
-  };
-  dbMock.mockReturnValue(builder);
-};
 
 const buildResponse = () => ({
   headersSent: false,
@@ -44,7 +41,7 @@ describe('getUserPicture', () => {
   });
 
   it('sets an immutable Cache-Control header on a successful response', async () => {
-    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    loadUserPictureMinioMock.mockResolvedValue('picture/abc');
     downloadFileMock.mockResolvedValue({ on: vi.fn(), pipe: vi.fn() });
 
     const res = buildResponse();
@@ -54,7 +51,7 @@ describe('getUserPicture', () => {
   });
 
   it('returns 404 and no cache header when the user has no picture', async () => {
-    mockDbResult([]);
+    loadUserPictureMinioMock.mockResolvedValue(null);
 
     const res = buildResponse();
     await getUserPicture(buildRequest('user-1'), res as unknown as Response);
@@ -64,7 +61,7 @@ describe('getUserPicture', () => {
   });
 
   it('returns 404 and no cache header when the MinIO download fails', async () => {
-    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    loadUserPictureMinioMock.mockResolvedValue('picture/abc');
     downloadFileMock.mockResolvedValue(null);
 
     const res = buildResponse();
@@ -75,7 +72,7 @@ describe('getUserPicture', () => {
   });
 
   it('removes the cache header before a 404 when the stream errors early', async () => {
-    mockDbResult([{ picture_minio: 'picture/abc' }]);
+    loadUserPictureMinioMock.mockResolvedValue('picture/abc');
     let onError: (error: Error) => void = () => undefined;
     downloadFileMock.mockResolvedValue({
       on: vi.fn((event: string, cb: (error: Error) => void) => {

--- a/apps/backend/src/server/endpoints/user-picture-endpoint.ts
+++ b/apps/backend/src/server/endpoints/user-picture-endpoint.ts
@@ -1,5 +1,5 @@
 import cors from 'cors';
-import { Express } from 'express';
+import { Express, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import { Readable } from 'stream';
 import { db } from '../../../knexfile';
@@ -7,37 +7,72 @@ import User from '../../model/kanel/public/User';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 
+const USER_PICTURE_RATE_WINDOW_MS = 60 * 1000;
+const USER_PICTURE_RATE_MAX = 300;
+const USER_PICTURE_CACHE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
 const userPictureRateLimiter = rateLimit({
-  windowMs: 180 * 1000, // 3 minutes
-  max: 10, // max 10 request per minute per IP
+  windowMs: USER_PICTURE_RATE_WINDOW_MS,
+  max: USER_PICTURE_RATE_MAX,
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+export const getUserPicture = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const [user] = await db<User>('User')
+      .where('id', req.params.userId)
+      .select('picture_minio');
+
+    if (!user?.picture_minio) {
+      res.status(404).json({ message: 'No picture found' });
+      return;
+    }
+
+    const body = await MinIOClient.downloadFile(user.picture_minio);
+
+    if (!body) {
+      res.status(404).json({ message: 'Picture not found' });
+      return;
+    }
+
+    const stream = body as Readable;
+
+    res.setHeader(
+      'Cache-Control',
+      `public, max-age=${USER_PICTURE_CACHE_MAX_AGE_SECONDS}, immutable`
+    );
+
+    stream.on('error', (error) => {
+      logApp.error('Error while streaming user picture', { error });
+      if (res.headersSent) {
+        res.destroy(error);
+      } else {
+        res.removeHeader('Cache-Control');
+        res.status(404).json({ message: 'Picture not found' });
+      }
+    });
+
+    stream.pipe(res);
+  } catch (error) {
+    logApp.error('Error while retrieving user picture', { error });
+    if (res.headersSent) {
+      res.destroy(error as Error);
+      return;
+    }
+    res.removeHeader('Cache-Control');
+    res.status(404).json({ message: 'Picture not found' });
+  }
+};
 
 export const userPictureEndpoint = (app: Express) => {
   app.get(
     '/user/picture/:userId',
     userPictureRateLimiter,
     cors(),
-    async (req, res) => {
-      try {
-        const [user] = await db<User>('User')
-          .where('id', req.params.userId)
-          .select('picture_minio');
-
-        if (!user?.picture_minio) {
-          return res.status(404).json({ message: 'No picture found' });
-        }
-
-        const stream = (await MinIOClient.downloadFile(
-          user.picture_minio
-        )) as Readable;
-
-        stream.pipe(res);
-      } catch (error) {
-        logApp.error('Error while retrieving user picture', { error });
-        res.status(404).json({ message: 'Picture not found' });
-      }
-    }
+    getUserPicture
   );
 };

--- a/apps/backend/src/server/endpoints/user-picture-endpoint.ts
+++ b/apps/backend/src/server/endpoints/user-picture-endpoint.ts
@@ -2,8 +2,7 @@ import cors from 'cors';
 import { Express, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import { Readable } from 'stream';
-import { db } from '../../../knexfile';
-import User from '../../model/kanel/public/User';
+import { UserDomain } from '../../modules/organization-management/user/user-domain/user.domain';
 import { MinIOClient } from '../../thirdparty/minio/client';
 import { logApp } from '../../utils/app-logger.util';
 
@@ -23,16 +22,16 @@ export const getUserPicture = async (
   res: Response
 ): Promise<void> => {
   try {
-    const [user] = await db<User>('User')
-      .where('id', req.params.userId)
-      .select('picture_minio');
+    const pictureMinio = await UserDomain.loadUserPictureMinio(
+      req.params.userId as string
+    );
 
-    if (!user?.picture_minio) {
+    if (!pictureMinio) {
       res.status(404).json({ message: 'No picture found' });
       return;
     }
 
-    const body = await MinIOClient.downloadFile(user.picture_minio);
+    const body = await MinIOClient.downloadFile(pictureMinio);
 
     if (!body) {
       res.status(404).json({ message: 'Picture not found' });


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

User profile pictures on the public integrations library returned `429 Too Many
Requests`, falling back to the default avatar.

Two root causes:
- The `/user/picture/:userId` endpoint set no `Cache-Control`, so the browser
  re-fetched every avatar on each page load even though the URL is already
  content-versioned (`?t=<uploadTime>`, persisted at upload time).
- The rate limiter was set to 10 requests / 3 minutes, far below what a normal
  list page needs.

## Changes

- Add `Cache-Control: public, max-age=2592000, immutable` on successful picture
  responses. Safe because the URL changes whenever the picture is re-uploaded.
- Widen the limiter to 300 requests / minute; magic numbers extracted into named
  constants (the previous inline comment also misstated the window).
- Add a stream error handler that removes `Cache-Control` before a 404, so error
  responses are never cached.
- Extract the route handler into an exported `getUserPicture` (single
  responsibility + unit-testable).

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. Open the public OpenCTI integrations library, Network tab open.
2. On a `/user/picture/...` request, confirm `Cache-Control: public,
   max-age=2592000, immutable` is present.
3. Reload -> avatars served "(from memory cache)", no network request, no 429.
4. Change your profile picture, reload -> avatar updates (new `?t=`), no stale cache.

Rate limit (curl): loop 30 GETs on `/user/picture/<id>?t=$i` -> all 200, no 429.

<img width="1769" height="680" alt="image" src="https://github.com/user-attachments/assets/1757d3b7-3443-493a-83a0-2df40134ef92" />


## Related issues

- Related to #2579

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.