### PR TITLE
fix(perf): batch field resolvers with DataLoader (#2567)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -66,6 +66,7 @@
     "body-parser": "2.3.0",
     "config": "4.4.1",
     "cors": "2.8.6",
+    "dataloader": "2.2.3",
     "eslint-plugin-jest": "29.15.2",
     "express": "5.2.1",
     "express-prom-bundle": "8.0.0",

--- a/apps/backend/src/context/request.context.ts
+++ b/apps/backend/src/context/request.context.ts
@@ -1,9 +1,11 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { UserLoadUserBy } from '../model/user';
+import type { DocumentDataLoaders } from '../modules/document/document.dataloader';
 import { UnknownErrorCode } from '../utils/error/error.code';
 export interface RequestContext {
   user?: UserLoadUserBy;
   correlationId?: string;
+  dataLoaders?: DocumentDataLoaders;
 }
 
 // Create typed AsyncLocalStorage

--- a/apps/backend/src/context/request.context.ts
+++ b/apps/backend/src/context/request.context.ts
@@ -1,11 +1,9 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { UserLoadUserBy } from '../model/user';
-import type { DocumentDataLoaders } from '../modules/document/document.dataloader';
 import { UnknownErrorCode } from '../utils/error/error.code';
 export interface RequestContext {
   user?: UserLoadUserBy;
   correlationId?: string;
-  dataLoaders?: DocumentDataLoaders;
 }
 
 // Create typed AsyncLocalStorage

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -24,7 +24,7 @@ import { initCronJobs, stopCronJobs } from './crons';
 import { PortalContext } from './model/portal-context';
 import { UserLoadUserBy } from './model/user';
 import { documentDownloadEndpoint } from './modules/document/document-download-endpoint';
-import { createDocumentDataLoaders } from './modules/document/document.dataloader';
+import { DocumentDataLoader } from './modules/document/document.dataloader';
 import { documentVisualizeEndpoint } from './modules/document/visualize-document-endpoint';
 import { initAuthPlatform } from './modules/security-management/authentication/auth-platform';
 import { errorLoggingPlugin } from './server/apollo-plugins/log';
@@ -230,7 +230,6 @@ app.use(function (req, res, next) {
     {
       user: req.session.user,
       correlationId: uuidv4(),
-      dataLoaders: createDocumentDataLoaders(),
     },
     () => {
       next();
@@ -311,8 +310,7 @@ const middlewareExpress = expressMiddleware(server, {
       user: user as UserLoadUserBy,
       req,
       res,
-      dataLoaders:
-        requestContext.get()?.dataLoaders ?? createDocumentDataLoaders(),
+      dataLoaders: DocumentDataLoader.create(),
     };
 
     return portalContext;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -24,6 +24,7 @@ import { initCronJobs, stopCronJobs } from './crons';
 import { PortalContext } from './model/portal-context';
 import { UserLoadUserBy } from './model/user';
 import { documentDownloadEndpoint } from './modules/document/document-download-endpoint';
+import { createDocumentDataLoaders } from './modules/document/document.dataloader';
 import { documentVisualizeEndpoint } from './modules/document/visualize-document-endpoint';
 import { initAuthPlatform } from './modules/security-management/authentication/auth-platform';
 import { errorLoggingPlugin } from './server/apollo-plugins/log';
@@ -226,7 +227,11 @@ if (
 
 app.use(function (req, res, next) {
   requestContext.run(
-    { user: req.session.user, correlationId: uuidv4() },
+    {
+      user: req.session.user,
+      correlationId: uuidv4(),
+      dataLoaders: createDocumentDataLoaders(),
+    },
     () => {
       next();
     }
@@ -306,6 +311,8 @@ const middlewareExpress = expressMiddleware(server, {
       user: user as UserLoadUserBy,
       req,
       res,
+      dataLoaders:
+        requestContext.get()?.dataLoaders ?? createDocumentDataLoaders(),
     };
 
     return portalContext;

--- a/apps/backend/src/model/portal-context.ts
+++ b/apps/backend/src/model/portal-context.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 
+import type { DocumentDataLoaders } from '../modules/document/document.dataloader';
 import { UserLoadUserBy } from './user';
 
 export interface PortalContext {
@@ -7,4 +8,5 @@ export interface PortalContext {
   referer?: string;
   req: express.Request;
   res: express.Response;
+  dataLoaders: DocumentDataLoaders;
 }

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -27,23 +27,23 @@ export const DocumentDataLoader = {
   batchLoadUploaders: async (
     ids: readonly string[]
   ): Promise<(User | null)[]> => {
-    const rows = await db<User>('User')
+    type Row = User & { _document_id: string };
+    const rows = await db<Row>('User')
       .leftJoin('Document', 'Document.uploader_id', 'User.id')
       .whereIn('Document.id', ids)
       .select('User.*', 'Document.id as _document_id');
 
-    const map = new Map<string, User>();
-    for (const row of rows) {
-      const docId = (row as User & { _document_id: string })._document_id;
-      map.set(docId, row);
-    }
+    const map = new Map<string, User>(
+      rows.map((row: Row) => [row._document_id, row])
+    );
     return ids.map((id) => map.get(id) ?? null);
   },
 
   batchLoadUploaderOrganizations: async (
     ids: readonly string[]
   ): Promise<(Organization | null)[]> => {
-    const rows = await db<Organization>('Organization')
+    type Row = Organization & { _document_id: string };
+    const rows = await db<Row>('Organization')
       .leftJoin(
         'Document',
         'Document.uploader_organization_id',
@@ -52,20 +52,18 @@ export const DocumentDataLoader = {
       .whereIn('Document.id', ids)
       .select('Organization.*', 'Document.id as _document_id');
 
-    const map = new Map<string, Organization>();
-    for (const row of rows) {
-      const docId = (row as Organization & { _document_id: string })
-        ._document_id;
-      map.set(docId, row);
-    }
+    const map = new Map<string, Organization>(
+      rows.map((row: Row) => [row._document_id, row])
+    );
     return ids.map((id) => map.get(id) ?? null);
   },
 
   batchLoadChildrenDocuments: async (
     ids: readonly string[]
   ): Promise<Document[][]> => {
+    type Row = Document & { _parent_id: string };
     const context = requestContext.get();
-    const query = db<Document>('Document_Children')
+    const query = db<Row>('Document_Children')
       .leftJoin(
         'Document',
         'Document.id',
@@ -89,14 +87,13 @@ export const DocumentDataLoader = {
       DOCUMENT_IMAGE_METADATA_KEYS
     );
 
-    const rows: (Document & { _parent_id: string })[] = await query;
+    const rows: Row[] = await query;
 
     const map = new Map<string, Document[]>();
     for (const row of rows) {
-      const parentId = row._parent_id;
-      const existing = map.get(parentId) ?? [];
+      const existing = map.get(row._parent_id) ?? [];
       existing.push(row);
-      map.set(parentId, existing);
+      map.set(row._parent_id, existing);
     }
     return ids.map((id) => map.get(id) ?? []);
   },
@@ -104,7 +101,8 @@ export const DocumentDataLoader = {
   batchLoadImagesByDocumentId: async (
     ids: readonly string[]
   ): Promise<Document[][]> => {
-    const query = db<Document>('Document')
+    type Row = Document & { _parent_id: string };
+    const query = db<Row>('Document')
       .select(
         'Document.*',
         'Document_Children.parent_document_id as _parent_id'
@@ -124,18 +122,17 @@ export const DocumentDataLoader = {
       DOCUMENT_IMAGE_METADATA_KEYS
     );
 
-    const rows: (Document & { _parent_id: string })[] = await query;
+    const rows: Row[] = await query;
 
     const map = new Map<string, Document[]>();
     for (const row of rows) {
-      const parentId = row._parent_id;
       const image = {
         ...row,
         id: toGlobalId('Document', row.id) as typeof row.id,
       };
-      const existing = map.get(parentId) ?? [];
+      const existing = map.get(row._parent_id) ?? [];
       existing.push(image);
-      map.set(parentId, existing);
+      map.set(row._parent_id, existing);
     }
     return ids.map((id) => map.get(id) ?? []);
   },
@@ -143,19 +140,17 @@ export const DocumentDataLoader = {
   batchLoadUseCasesByDocumentId: async (
     ids: readonly string[]
   ): Promise<UseCase[][]> => {
-    const rows: (UseCase & { _document_id: string })[] = await db<UseCase>(
-      'UseCase'
-    )
+    type Row = UseCase & { _document_id: string };
+    const rows: Row[] = await db<Row>('UseCase')
       .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
       .whereIn('ouc.object_id', ids)
       .select('UseCase.*', 'ouc.object_id as _document_id');
 
     const map = new Map<string, UseCase[]>();
     for (const row of rows) {
-      const docId = row._document_id;
-      const existing = map.get(docId) ?? [];
+      const existing = map.get(row._document_id) ?? [];
       existing.push(row);
-      map.set(docId, existing);
+      map.set(row._document_id, existing);
     }
     return ids.map((id) => map.get(id) ?? []);
   },
@@ -163,17 +158,15 @@ export const DocumentDataLoader = {
   batchLoadIntegrationTypes: async (
     ids: readonly string[]
   ): Promise<(IntegrationType | null)[]> => {
-    const rows: { document_id: string; value: string }[] = await db(
-      'Document_Metadata'
-    )
+    type Row = { document_id: string; value: string };
+    const rows: Row[] = await db<Row>('Document_Metadata')
       .select('document_id', 'value')
       .whereIn('document_id', ids)
       .where('key', DocumentMetadataKeyCode.IntegrationType);
 
-    const map = new Map<string, IntegrationType>();
-    for (const row of rows) {
-      map.set(row.document_id, row.value as IntegrationType);
-    }
+    const map = new Map<string, IntegrationType>(
+      rows.map((row: Row) => [row.document_id, row.value as IntegrationType])
+    );
     return ids.map((id) => map.get(id) ?? null);
   },
 

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -27,7 +27,7 @@ export const DocumentDataLoader = {
     ids: readonly string[]
   ): Promise<(User | null)[]> => {
     const rows: WithDocumentId<User>[] =
-      await DocumentDomain.buildUploaderQuery([...ids]);
+      await DocumentDomain.buildUploaderQuery(ids);
 
     const map = new Map<string, User>(
       rows.map((row) => [row._document_id, row])
@@ -39,7 +39,7 @@ export const DocumentDataLoader = {
     ids: readonly string[]
   ): Promise<(Organization | null)[]> => {
     const rows: WithDocumentId<Organization>[] =
-      await DocumentDomain.buildUploaderOrganizationQuery([...ids]);
+      await DocumentDomain.buildUploaderOrganizationQuery(ids);
 
     const map = new Map<string, Organization>(
       rows.map((row) => [row._document_id, row])
@@ -53,7 +53,7 @@ export const DocumentDataLoader = {
     const rows: WithParentId<Document>[] =
       await DocumentChildrenDomain.buildChildrenDocumentsQuery<
         WithParentId<Document>
-      >([...ids], {
+      >(ids, {
         isDataLoader: true,
         includeMetadata: DOCUMENT_IMAGE_METADATA_KEYS,
       });
@@ -73,7 +73,7 @@ export const DocumentDataLoader = {
     const rows: WithParentId<Document>[] =
       await DocumentChildrenDomain.buildImagesByDocumentIdQuery<
         WithParentId<Document>
-      >([...ids], {
+      >(ids, {
         isDataLoader: true,
       });
 
@@ -94,7 +94,7 @@ export const DocumentDataLoader = {
     ids: readonly string[]
   ): Promise<UseCase[][]> => {
     const rows: WithDocumentId<UseCase>[] =
-      await useCaseDomain.buildUseCasesByDocumentIdQuery([...ids]);
+      await useCaseDomain.buildUseCasesByDocumentIdQuery(ids);
 
     const map = new Map<string, UseCase[]>();
     for (const row of rows) {
@@ -109,9 +109,8 @@ export const DocumentDataLoader = {
     ids: readonly string[]
   ): Promise<(IntegrationType | null)[]> => {
     type Row = { document_id: string; value: IntegrationType };
-    const rows: Row[] = await DocumentMetadataDomain.buildIntegrationTypeQuery([
-      ...ids,
-    ]);
+    const rows: Row[] =
+      await DocumentMetadataDomain.buildIntegrationTypeQuery(ids);
 
     const map = new Map<string, IntegrationType>(
       rows.map((row) => [row.document_id, row.value])

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -14,148 +14,6 @@ import { Document } from './document.helper';
 import { DOCUMENT_IMAGE_METADATA_KEYS } from './document.model';
 import { DocumentMetadataDomain } from './domain/document.metadata.domain';
 
-const batchLoadUploaders = async (
-  ids: readonly string[]
-): Promise<(User | null)[]> => {
-  const rows = await db<User>('User')
-    .leftJoin('Document', 'Document.uploader_id', 'User.id')
-    .whereIn('Document.id', ids as string[])
-    .select('User.*', 'Document.id as _document_id');
-
-  const map = new Map<string, User>();
-  for (const row of rows) {
-    const docId = (row as User & { _document_id: string })._document_id;
-    map.set(docId, row);
-  }
-  return ids.map((id) => map.get(id) ?? null);
-};
-
-const batchLoadUploaderOrganizations = async (
-  ids: readonly string[]
-): Promise<(Organization | null)[]> => {
-  const rows = await db<Organization>('Organization')
-    .leftJoin(
-      'Document',
-      'Document.uploader_organization_id',
-      'Organization.id'
-    )
-    .whereIn('Document.id', ids as string[])
-    .select('Organization.*', 'Document.id as _document_id');
-
-  const map = new Map<string, Organization>();
-  for (const row of rows) {
-    const docId = (row as Organization & { _document_id: string })._document_id;
-    map.set(docId, row);
-  }
-  return ids.map((id) => map.get(id) ?? null);
-};
-
-const batchLoadChildrenDocuments = async (
-  ids: readonly string[]
-): Promise<Document[][]> => {
-  const context = requestContext.get();
-  const query = db<Document>('Document_Children')
-    .leftJoin('Document', 'Document.id', 'Document_Children.child_document_id')
-    .whereIn('Document_Children.parent_document_id', ids as string[])
-    .modify((qb) => {
-      if (context?.user) {
-        restrictDocumentToUserOrganization(qb);
-      }
-    })
-    .orderBy('created_at', 'asc')
-    .select('Document.*', 'Document_Children.parent_document_id as _parent_id')
-    .groupBy('Document.id', 'Document_Children.parent_document_id');
-
-  DocumentMetadataDomain.addIncludeMetadataQuery(
-    query,
-    DOCUMENT_IMAGE_METADATA_KEYS
-  );
-
-  const rows: (Document & { _parent_id: string })[] = await query;
-
-  const map = new Map<string, Document[]>();
-  for (const row of rows) {
-    const parentId = row._parent_id;
-    const existing = map.get(parentId) ?? [];
-    existing.push(row);
-    map.set(parentId, existing);
-  }
-  return ids.map((id) => map.get(id) ?? []);
-};
-
-const batchLoadImagesByDocumentId = async (
-  ids: readonly string[]
-): Promise<Document[][]> => {
-  const query = db<Document>('Document')
-    .select('Document.*', 'Document_Children.parent_document_id as _parent_id')
-    .join(
-      'Document_Children',
-      'Document.id',
-      '=',
-      'Document_Children.child_document_id'
-    )
-    .whereIn('Document_Children.parent_document_id', ids as string[])
-    .where('Document.mime_type', 'like', 'image/%')
-    .groupBy('Document.id', 'Document_Children.parent_document_id');
-
-  DocumentMetadataDomain.addIncludeMetadataQuery(
-    query,
-    DOCUMENT_IMAGE_METADATA_KEYS
-  );
-
-  const rows: (Document & { _parent_id: string })[] = await query;
-
-  const map = new Map<string, Document[]>();
-  for (const row of rows) {
-    const parentId = row._parent_id;
-    const image = {
-      ...row,
-      id: toGlobalId('Document', row.id) as typeof row.id,
-    };
-    const existing = map.get(parentId) ?? [];
-    existing.push(image);
-    map.set(parentId, existing);
-  }
-  return ids.map((id) => map.get(id) ?? []);
-};
-
-const batchLoadUseCasesByDocumentId = async (
-  ids: readonly string[]
-): Promise<UseCase[][]> => {
-  const rows: (UseCase & { _document_id: string })[] = await db<UseCase>(
-    'UseCase'
-  )
-    .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
-    .whereIn('ouc.object_id', ids as string[])
-    .select('UseCase.*', 'ouc.object_id as _document_id');
-
-  const map = new Map<string, UseCase[]>();
-  for (const row of rows) {
-    const docId = row._document_id;
-    const existing = map.get(docId) ?? [];
-    existing.push(row);
-    map.set(docId, existing);
-  }
-  return ids.map((id) => map.get(id) ?? []);
-};
-
-const batchLoadIntegrationTypes = async (
-  ids: readonly string[]
-): Promise<(IntegrationType | null)[]> => {
-  const rows: { document_id: string; value: string }[] = await db(
-    'Document_Metadata'
-  )
-    .select('document_id', 'value')
-    .whereIn('document_id', ids as string[])
-    .where('key', DocumentMetadataKeyCode.IntegrationType);
-
-  const map = new Map<string, IntegrationType>();
-  for (const row of rows) {
-    map.set(row.document_id, row.value as IntegrationType);
-  }
-  return ids.map((id) => map.get(id) ?? null);
-};
-
 export interface DocumentDataLoaders {
   uploaderLoader: DataLoader<string, User | null>;
   uploaderOrganizationLoader: DataLoader<string, Organization | null>;
@@ -165,11 +23,176 @@ export interface DocumentDataLoaders {
   integrationTypeLoader: DataLoader<string, IntegrationType | null>;
 }
 
-export const createDocumentDataLoaders = (): DocumentDataLoaders => ({
-  uploaderLoader: new DataLoader(batchLoadUploaders),
-  uploaderOrganizationLoader: new DataLoader(batchLoadUploaderOrganizations),
-  childrenDocumentsLoader: new DataLoader(batchLoadChildrenDocuments),
-  imagesByDocumentIdLoader: new DataLoader(batchLoadImagesByDocumentId),
-  useCasesByDocumentIdLoader: new DataLoader(batchLoadUseCasesByDocumentId),
-  integrationTypeLoader: new DataLoader(batchLoadIntegrationTypes),
-});
+export const DocumentDataLoader = {
+  batchLoadUploaders: async (
+    ids: readonly string[]
+  ): Promise<(User | null)[]> => {
+    const rows = await db<User>('User')
+      .leftJoin('Document', 'Document.uploader_id', 'User.id')
+      .whereIn('Document.id', ids)
+      .select('User.*', 'Document.id as _document_id');
+
+    const map = new Map<string, User>();
+    for (const row of rows) {
+      const docId = (row as User & { _document_id: string })._document_id;
+      map.set(docId, row);
+    }
+    return ids.map((id) => map.get(id) ?? null);
+  },
+
+  batchLoadUploaderOrganizations: async (
+    ids: readonly string[]
+  ): Promise<(Organization | null)[]> => {
+    const rows = await db<Organization>('Organization')
+      .leftJoin(
+        'Document',
+        'Document.uploader_organization_id',
+        'Organization.id'
+      )
+      .whereIn('Document.id', ids)
+      .select('Organization.*', 'Document.id as _document_id');
+
+    const map = new Map<string, Organization>();
+    for (const row of rows) {
+      const docId = (row as Organization & { _document_id: string })
+        ._document_id;
+      map.set(docId, row);
+    }
+    return ids.map((id) => map.get(id) ?? null);
+  },
+
+  batchLoadChildrenDocuments: async (
+    ids: readonly string[]
+  ): Promise<Document[][]> => {
+    const context = requestContext.get();
+    const query = db<Document>('Document_Children')
+      .leftJoin(
+        'Document',
+        'Document.id',
+        'Document_Children.child_document_id'
+      )
+      .whereIn('Document_Children.parent_document_id', ids)
+      .modify((qb) => {
+        if (context?.user) {
+          restrictDocumentToUserOrganization(qb);
+        }
+      })
+      .orderBy('created_at', 'asc')
+      .select(
+        'Document.*',
+        'Document_Children.parent_document_id as _parent_id'
+      )
+      .groupBy('Document.id', 'Document_Children.parent_document_id');
+
+    DocumentMetadataDomain.addIncludeMetadataQuery(
+      query,
+      DOCUMENT_IMAGE_METADATA_KEYS
+    );
+
+    const rows: (Document & { _parent_id: string })[] = await query;
+
+    const map = new Map<string, Document[]>();
+    for (const row of rows) {
+      const parentId = row._parent_id;
+      const existing = map.get(parentId) ?? [];
+      existing.push(row);
+      map.set(parentId, existing);
+    }
+    return ids.map((id) => map.get(id) ?? []);
+  },
+
+  batchLoadImagesByDocumentId: async (
+    ids: readonly string[]
+  ): Promise<Document[][]> => {
+    const query = db<Document>('Document')
+      .select(
+        'Document.*',
+        'Document_Children.parent_document_id as _parent_id'
+      )
+      .join(
+        'Document_Children',
+        'Document.id',
+        '=',
+        'Document_Children.child_document_id'
+      )
+      .whereIn('Document_Children.parent_document_id', ids)
+      .where('Document.mime_type', 'like', 'image/%')
+      .groupBy('Document.id', 'Document_Children.parent_document_id');
+
+    DocumentMetadataDomain.addIncludeMetadataQuery(
+      query,
+      DOCUMENT_IMAGE_METADATA_KEYS
+    );
+
+    const rows: (Document & { _parent_id: string })[] = await query;
+
+    const map = new Map<string, Document[]>();
+    for (const row of rows) {
+      const parentId = row._parent_id;
+      const image = {
+        ...row,
+        id: toGlobalId('Document', row.id) as typeof row.id,
+      };
+      const existing = map.get(parentId) ?? [];
+      existing.push(image);
+      map.set(parentId, existing);
+    }
+    return ids.map((id) => map.get(id) ?? []);
+  },
+
+  batchLoadUseCasesByDocumentId: async (
+    ids: readonly string[]
+  ): Promise<UseCase[][]> => {
+    const rows: (UseCase & { _document_id: string })[] = await db<UseCase>(
+      'UseCase'
+    )
+      .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
+      .whereIn('ouc.object_id', ids)
+      .select('UseCase.*', 'ouc.object_id as _document_id');
+
+    const map = new Map<string, UseCase[]>();
+    for (const row of rows) {
+      const docId = row._document_id;
+      const existing = map.get(docId) ?? [];
+      existing.push(row);
+      map.set(docId, existing);
+    }
+    return ids.map((id) => map.get(id) ?? []);
+  },
+
+  batchLoadIntegrationTypes: async (
+    ids: readonly string[]
+  ): Promise<(IntegrationType | null)[]> => {
+    const rows: { document_id: string; value: string }[] = await db(
+      'Document_Metadata'
+    )
+      .select('document_id', 'value')
+      .whereIn('document_id', ids)
+      .where('key', DocumentMetadataKeyCode.IntegrationType);
+
+    const map = new Map<string, IntegrationType>();
+    for (const row of rows) {
+      map.set(row.document_id, row.value as IntegrationType);
+    }
+    return ids.map((id) => map.get(id) ?? null);
+  },
+
+  create: (): DocumentDataLoaders => ({
+    uploaderLoader: new DataLoader(DocumentDataLoader.batchLoadUploaders),
+    uploaderOrganizationLoader: new DataLoader(
+      DocumentDataLoader.batchLoadUploaderOrganizations
+    ),
+    childrenDocumentsLoader: new DataLoader(
+      DocumentDataLoader.batchLoadChildrenDocuments
+    ),
+    imagesByDocumentIdLoader: new DataLoader(
+      DocumentDataLoader.batchLoadImagesByDocumentId
+    ),
+    useCasesByDocumentIdLoader: new DataLoader(
+      DocumentDataLoader.batchLoadUseCasesByDocumentId
+    ),
+    integrationTypeLoader: new DataLoader(
+      DocumentDataLoader.batchLoadIntegrationTypes
+    ),
+  }),
+};

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -1,0 +1,175 @@
+import DataLoader from 'dataloader';
+import { toGlobalId } from 'graphql-relay/node/node.js';
+import { db } from '../../../knexfile';
+import {
+  DocumentMetadataKeyCode,
+  IntegrationType,
+  Organization,
+} from '../../__generated__/resolvers-types';
+import { requestContext } from '../../context/request.context';
+import UseCase from '../../model/kanel/public/UseCase';
+import User from '../../model/kanel/public/User';
+import { restrictDocumentToUserOrganization } from '../../security/restriction/document';
+import { Document } from './document.helper';
+import { DOCUMENT_IMAGE_METADATA_KEYS } from './document.model';
+import { DocumentMetadataDomain } from './domain/document.metadata.domain';
+
+const batchLoadUploaders = async (
+  ids: readonly string[]
+): Promise<(User | null)[]> => {
+  const rows = await db<User>('User')
+    .leftJoin('Document', 'Document.uploader_id', 'User.id')
+    .whereIn('Document.id', ids as string[])
+    .select('User.*', 'Document.id as _document_id');
+
+  const map = new Map<string, User>();
+  for (const row of rows) {
+    const docId = (row as User & { _document_id: string })._document_id;
+    map.set(docId, row);
+  }
+  return ids.map((id) => map.get(id) ?? null);
+};
+
+const batchLoadUploaderOrganizations = async (
+  ids: readonly string[]
+): Promise<(Organization | null)[]> => {
+  const rows = await db<Organization>('Organization')
+    .leftJoin(
+      'Document',
+      'Document.uploader_organization_id',
+      'Organization.id'
+    )
+    .whereIn('Document.id', ids as string[])
+    .select('Organization.*', 'Document.id as _document_id');
+
+  const map = new Map<string, Organization>();
+  for (const row of rows) {
+    const docId = (row as Organization & { _document_id: string })._document_id;
+    map.set(docId, row);
+  }
+  return ids.map((id) => map.get(id) ?? null);
+};
+
+const batchLoadChildrenDocuments = async (
+  ids: readonly string[]
+): Promise<Document[][]> => {
+  const context = requestContext.get();
+  const query = db<Document>('Document_Children')
+    .leftJoin('Document', 'Document.id', 'Document_Children.child_document_id')
+    .whereIn('Document_Children.parent_document_id', ids as string[])
+    .modify((qb) => {
+      if (context?.user) {
+        restrictDocumentToUserOrganization(qb);
+      }
+    })
+    .orderBy('created_at', 'asc')
+    .select('Document.*', 'Document_Children.parent_document_id as _parent_id')
+    .groupBy('Document.id', 'Document_Children.parent_document_id');
+
+  DocumentMetadataDomain.addIncludeMetadataQuery(
+    query,
+    DOCUMENT_IMAGE_METADATA_KEYS
+  );
+
+  const rows: (Document & { _parent_id: string })[] = await query;
+
+  const map = new Map<string, Document[]>();
+  for (const row of rows) {
+    const parentId = row._parent_id;
+    const existing = map.get(parentId) ?? [];
+    existing.push(row);
+    map.set(parentId, existing);
+  }
+  return ids.map((id) => map.get(id) ?? []);
+};
+
+const batchLoadImagesByDocumentId = async (
+  ids: readonly string[]
+): Promise<Document[][]> => {
+  const query = db<Document>('Document')
+    .select('Document.*', 'Document_Children.parent_document_id as _parent_id')
+    .join(
+      'Document_Children',
+      'Document.id',
+      '=',
+      'Document_Children.child_document_id'
+    )
+    .whereIn('Document_Children.parent_document_id', ids as string[])
+    .where('Document.mime_type', 'like', 'image/%')
+    .groupBy('Document.id', 'Document_Children.parent_document_id');
+
+  DocumentMetadataDomain.addIncludeMetadataQuery(
+    query,
+    DOCUMENT_IMAGE_METADATA_KEYS
+  );
+
+  const rows: (Document & { _parent_id: string })[] = await query;
+
+  const map = new Map<string, Document[]>();
+  for (const row of rows) {
+    const parentId = row._parent_id;
+    const image = {
+      ...row,
+      id: toGlobalId('Document', row.id) as typeof row.id,
+    };
+    const existing = map.get(parentId) ?? [];
+    existing.push(image);
+    map.set(parentId, existing);
+  }
+  return ids.map((id) => map.get(id) ?? []);
+};
+
+const batchLoadUseCasesByDocumentId = async (
+  ids: readonly string[]
+): Promise<UseCase[][]> => {
+  const rows: (UseCase & { _document_id: string })[] = await db<UseCase>(
+    'UseCase'
+  )
+    .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
+    .whereIn('ouc.object_id', ids as string[])
+    .select('UseCase.*', 'ouc.object_id as _document_id');
+
+  const map = new Map<string, UseCase[]>();
+  for (const row of rows) {
+    const docId = row._document_id;
+    const existing = map.get(docId) ?? [];
+    existing.push(row);
+    map.set(docId, existing);
+  }
+  return ids.map((id) => map.get(id) ?? []);
+};
+
+const batchLoadIntegrationTypes = async (
+  ids: readonly string[]
+): Promise<(IntegrationType | null)[]> => {
+  const rows: { document_id: string; value: string }[] = await db(
+    'Document_Metadata'
+  )
+    .select('document_id', 'value')
+    .whereIn('document_id', ids as string[])
+    .where('key', DocumentMetadataKeyCode.IntegrationType);
+
+  const map = new Map<string, IntegrationType>();
+  for (const row of rows) {
+    map.set(row.document_id, row.value as IntegrationType);
+  }
+  return ids.map((id) => map.get(id) ?? null);
+};
+
+export interface DocumentDataLoaders {
+  uploaderLoader: DataLoader<string, User | null>;
+  uploaderOrganizationLoader: DataLoader<string, Organization | null>;
+  childrenDocumentsLoader: DataLoader<string, Document[]>;
+  imagesByDocumentIdLoader: DataLoader<string, Document[]>;
+  useCasesByDocumentIdLoader: DataLoader<string, UseCase[]>;
+  integrationTypeLoader: DataLoader<string, IntegrationType | null>;
+}
+
+export const createDocumentDataLoaders = (): DocumentDataLoaders => ({
+  uploaderLoader: new DataLoader(batchLoadUploaders),
+  uploaderOrganizationLoader: new DataLoader(batchLoadUploaderOrganizations),
+  childrenDocumentsLoader: new DataLoader(batchLoadChildrenDocuments),
+  imagesByDocumentIdLoader: new DataLoader(batchLoadImagesByDocumentId),
+  useCasesByDocumentIdLoader: new DataLoader(batchLoadUseCasesByDocumentId),
+  integrationTypeLoader: new DataLoader(batchLoadIntegrationTypes),
+});

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -1,17 +1,16 @@
 import DataLoader from 'dataloader';
 import { toGlobalId } from 'graphql-relay/node/node.js';
-import { db } from '../../../knexfile';
 import {
-  DocumentMetadataKeyCode,
   IntegrationType,
   Organization,
 } from '../../__generated__/resolvers-types';
-import { requestContext } from '../../context/request.context';
 import UseCase from '../../model/kanel/public/UseCase';
 import User from '../../model/kanel/public/User';
-import { restrictDocumentToUserOrganization } from '../../security/restriction/document';
-import { Document } from './document.helper';
+import { useCaseDomain } from '../use-case/use-case.domain';
+import { Document, WithDocumentId, WithParentId } from './document.helper';
 import { DOCUMENT_IMAGE_METADATA_KEYS } from './document.model';
+import { DocumentChildrenDomain } from './domain/document.children.domain';
+import { DocumentDomain } from './domain/document.domain';
 import { DocumentMetadataDomain } from './domain/document.metadata.domain';
 
 export interface DocumentDataLoaders {
@@ -27,14 +26,11 @@ export const DocumentDataLoader = {
   batchLoadUploaders: async (
     ids: readonly string[]
   ): Promise<(User | null)[]> => {
-    type Row = User & { _document_id: string };
-    const rows = await db<Row>('User')
-      .leftJoin('Document', 'Document.uploader_id', 'User.id')
-      .whereIn('Document.id', ids)
-      .select('User.*', 'Document.id as _document_id');
+    const rows: WithDocumentId<User>[] =
+      await DocumentDomain.buildUploaderQuery([...ids]);
 
     const map = new Map<string, User>(
-      rows.map((row: Row) => [row._document_id, row])
+      rows.map((row) => [row._document_id, row])
     );
     return ids.map((id) => map.get(id) ?? null);
   },
@@ -42,18 +38,11 @@ export const DocumentDataLoader = {
   batchLoadUploaderOrganizations: async (
     ids: readonly string[]
   ): Promise<(Organization | null)[]> => {
-    type Row = Organization & { _document_id: string };
-    const rows = await db<Row>('Organization')
-      .leftJoin(
-        'Document',
-        'Document.uploader_organization_id',
-        'Organization.id'
-      )
-      .whereIn('Document.id', ids)
-      .select('Organization.*', 'Document.id as _document_id');
+    const rows: WithDocumentId<Organization>[] =
+      await DocumentDomain.buildUploaderOrganizationQuery([...ids]);
 
     const map = new Map<string, Organization>(
-      rows.map((row: Row) => [row._document_id, row])
+      rows.map((row) => [row._document_id, row])
     );
     return ids.map((id) => map.get(id) ?? null);
   },
@@ -61,33 +50,13 @@ export const DocumentDataLoader = {
   batchLoadChildrenDocuments: async (
     ids: readonly string[]
   ): Promise<Document[][]> => {
-    type Row = Document & { _parent_id: string };
-    const context = requestContext.get();
-    const query = db<Row>('Document_Children')
-      .leftJoin(
-        'Document',
-        'Document.id',
-        'Document_Children.child_document_id'
-      )
-      .whereIn('Document_Children.parent_document_id', ids)
-      .modify((qb) => {
-        if (context?.user) {
-          restrictDocumentToUserOrganization(qb);
-        }
-      })
-      .orderBy('created_at', 'asc')
-      .select(
-        'Document.*',
-        'Document_Children.parent_document_id as _parent_id'
-      )
-      .groupBy('Document.id', 'Document_Children.parent_document_id');
-
-    DocumentMetadataDomain.addIncludeMetadataQuery(
-      query,
-      DOCUMENT_IMAGE_METADATA_KEYS
-    );
-
-    const rows: Row[] = await query;
+    const rows: WithParentId<Document>[] =
+      await DocumentChildrenDomain.buildChildrenDocumentsQuery<
+        WithParentId<Document>
+      >([...ids], {
+        isDataLoader: true,
+        includeMetadata: DOCUMENT_IMAGE_METADATA_KEYS,
+      });
 
     const map = new Map<string, Document[]>();
     for (const row of rows) {
@@ -101,28 +70,12 @@ export const DocumentDataLoader = {
   batchLoadImagesByDocumentId: async (
     ids: readonly string[]
   ): Promise<Document[][]> => {
-    type Row = Document & { _parent_id: string };
-    const query = db<Row>('Document')
-      .select(
-        'Document.*',
-        'Document_Children.parent_document_id as _parent_id'
-      )
-      .join(
-        'Document_Children',
-        'Document.id',
-        '=',
-        'Document_Children.child_document_id'
-      )
-      .whereIn('Document_Children.parent_document_id', ids)
-      .where('Document.mime_type', 'like', 'image/%')
-      .groupBy('Document.id', 'Document_Children.parent_document_id');
-
-    DocumentMetadataDomain.addIncludeMetadataQuery(
-      query,
-      DOCUMENT_IMAGE_METADATA_KEYS
-    );
-
-    const rows: Row[] = await query;
+    const rows: WithParentId<Document>[] =
+      await DocumentChildrenDomain.buildImagesByDocumentIdQuery<
+        WithParentId<Document>
+      >([...ids], {
+        isDataLoader: true,
+      });
 
     const map = new Map<string, Document[]>();
     for (const row of rows) {
@@ -140,11 +93,8 @@ export const DocumentDataLoader = {
   batchLoadUseCasesByDocumentId: async (
     ids: readonly string[]
   ): Promise<UseCase[][]> => {
-    type Row = UseCase & { _document_id: string };
-    const rows: Row[] = await db<Row>('UseCase')
-      .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
-      .whereIn('ouc.object_id', ids)
-      .select('UseCase.*', 'ouc.object_id as _document_id');
+    const rows: WithDocumentId<UseCase>[] =
+      await useCaseDomain.buildUseCasesByDocumentIdQuery([...ids]);
 
     const map = new Map<string, UseCase[]>();
     for (const row of rows) {
@@ -158,14 +108,13 @@ export const DocumentDataLoader = {
   batchLoadIntegrationTypes: async (
     ids: readonly string[]
   ): Promise<(IntegrationType | null)[]> => {
-    type Row = { document_id: string; value: string };
-    const rows: Row[] = await db<Row>('Document_Metadata')
-      .select('document_id', 'value')
-      .whereIn('document_id', ids)
-      .where('key', DocumentMetadataKeyCode.IntegrationType);
+    type Row = { document_id: string; value: IntegrationType };
+    const rows: Row[] = await DocumentMetadataDomain.buildIntegrationTypeQuery([
+      ...ids,
+    ]);
 
     const map = new Map<string, IntegrationType>(
-      rows.map((row: Row) => [row.document_id, row.value as IntegrationType])
+      rows.map((row) => [row.document_id, row.value])
     );
     return ids.map((id) => map.get(id) ?? null);
   },

--- a/apps/backend/src/modules/document/document.helper.ts
+++ b/apps/backend/src/modules/document/document.helper.ts
@@ -63,6 +63,8 @@ export const BOOLEAN_METADATA = [
 ];
 
 export type Document = WithUseCases<DocumentModel>;
+export type WithDocumentId<T> = T & { _document_id: string };
+export type WithParentId<T> = T & { _parent_id: string };
 export type FullDocumentMutator = Partial<DocumentModel> & {
   use_cases?: UseCaseId[];
   parent_document_id?: DocumentId;

--- a/apps/backend/src/modules/document/document.resolver.test.ts
+++ b/apps/backend/src/modules/document/document.resolver.test.ts
@@ -32,9 +32,7 @@ import { SubscriptionDomain } from '../subscription/subscription.domain';
 import { DocumentApp } from './document.app';
 import { DocumentHelper } from './document.helper';
 import documentResolver from './document.resolver';
-import { DocumentChildrenDomain } from './domain/document.children.domain';
 import { DocumentDomain } from './domain/document.domain';
-import { DocumentMetadataDomain } from './domain/document.metadata.domain';
 
 describe('create document GraphQL mutation', () => {
   it('should delegate to DocumentApp.createDocument and return result', async () => {
@@ -269,7 +267,7 @@ describe('document.__resolveType', () => {
       const doc = { id: uuidv4(), type } as unknown as DocumentModel;
       const result = await (
         documentResolver.Document as unknown as DocumentResolvers
-      ).__resolveType(doc);
+      ).__resolveType(doc, contextSimpleUserFiligran2);
       expect(result).toBe(expected);
     }
   );
@@ -289,13 +287,14 @@ describe('document.__resolveType', () => {
         id: uuidv4(),
         type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
       } as unknown as DocumentModel;
-      vi.spyOn(DocumentMetadataDomain, 'loadIntegrationType').mockResolvedValue(
-        integrationType
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.integrationTypeLoader,
+        'load'
+      ).mockResolvedValue(integrationType);
 
       const result = await (
         documentResolver.Document as unknown as DocumentResolvers
-      ).__resolveType(doc);
+      ).__resolveType(doc, contextSimpleUserFiligran2);
 
       expect(result).toBe(expected);
     }
@@ -308,7 +307,7 @@ describe('document.__resolveType', () => {
     } as unknown as DocumentModel;
     const result = await (
       documentResolver.Document as unknown as DocumentResolvers
-    ).__resolveType(doc);
+    ).__resolveType(doc, contextSimpleUserFiligran2);
     expect(result).toBe('DefaultDocument');
   });
 });
@@ -316,11 +315,16 @@ describe('document.__resolveType', () => {
 describe('document field resolvers', () => {
   it('children_documents should load children by document id', async () => {
     const id = uuidv4() as DocumentId;
-    const expected = [{ id: uuidv4() }] as unknown as Awaited<
-      ReturnType<typeof DocumentChildrenDomain.loadChildrenDocuments>
-    >;
-    vi.spyOn(DocumentChildrenDomain, 'loadChildrenDocuments').mockResolvedValue(
-      expected
+    const expected = [{ id: uuidv4() }];
+    vi.spyOn(
+      contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader,
+      'load'
+    ).mockResolvedValue(
+      expected as unknown as Awaited<
+        ReturnType<
+          typeof contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader.load
+        >
+      >
     );
 
     const result = await (
@@ -332,32 +336,37 @@ describe('document field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(DocumentChildrenDomain.loadChildrenDocuments).toHaveBeenCalledWith(
-      id,
-      expect.any(Array)
-    );
+    expect(
+      contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader.load
+    ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
 
   it('uploader should load uploader by document id', async () => {
     const id = uuidv4() as DocumentId;
-    const expected = { id: uuidv4() } as unknown as User | undefined;
-    vi.spyOn(DocumentDomain, 'loadUploader').mockResolvedValue(expected);
+    const expected = { id: uuidv4() } as unknown as User | null;
+    vi.spyOn(
+      contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+      'load'
+    ).mockResolvedValue(expected);
 
     const result = await (
       documentResolver.Document as unknown as DocumentResolvers
     ).uploader!({ id }, {}, contextSimpleUserFiligran2, GRAPHQL_RESOLVE_INFO);
 
-    expect(DocumentDomain.loadUploader).toHaveBeenCalledWith(id);
+    expect(
+      contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+    ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
 
   it('uploader_organization should load uploader organization by document id', async () => {
     const id = uuidv4() as DocumentId;
-    const expected = { id: uuidv4() } as unknown as Organization | undefined;
-    vi.spyOn(DocumentDomain, 'loadUploaderOrganization').mockResolvedValue(
-      expected
-    );
+    const expected = { id: uuidv4() } as unknown as Organization | null;
+    vi.spyOn(
+      contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+      'load'
+    ).mockResolvedValue(expected);
 
     const result = await (
       documentResolver.Document as unknown as DocumentResolvers
@@ -368,7 +377,9 @@ describe('document field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(DocumentDomain.loadUploaderOrganization).toHaveBeenCalledWith(id);
+    expect(
+      contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+    ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
 

--- a/apps/backend/src/modules/document/document.resolver.ts
+++ b/apps/backend/src/modules/document/document.resolver.ts
@@ -24,10 +24,7 @@ import { TelemetryApp } from '../telemetry/telemetry.app';
 import { TelemetryHelper } from '../telemetry/telemetry.helper';
 import { DocumentApp } from './document.app';
 import { DocumentHelper } from './document.helper';
-import { DOCUMENT_IMAGE_METADATA_KEYS } from './document.model';
-import { DocumentChildrenDomain } from './domain/document.children.domain';
 import { DocumentDomain } from './domain/document.domain';
-import { DocumentMetadataDomain } from './domain/document.metadata.domain';
 
 const resolvers: Resolvers = {
   DocumentId: createRelayIdScalar<DocumentId>('Document'),
@@ -136,7 +133,7 @@ const resolvers: Resolvers = {
     },
   },
   Document: {
-    async __resolveType(document) {
+    async __resolveType(document, context) {
       const TYPE_MAPPINGS = {
         [OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE]: 'CustomDashboard',
         [OPENCTI_CUSTOM_VIEW_DOCUMENT_TYPE]: 'CustomView',
@@ -157,7 +154,7 @@ const resolvers: Resolvers = {
         return mappedType;
       } else if (document.type === OPENCTI_INTEGRATION_DOCUMENT_TYPE) {
         const integrationType =
-          await DocumentMetadataDomain.loadIntegrationType(document.id);
+          await context.dataLoaders.integrationTypeLoader.load(document.id);
         if (integrationType) {
           const responseType =
             INTEGRATION_MAPPINGS[
@@ -174,14 +171,14 @@ const resolvers: Resolvers = {
       return 'DefaultDocument';
     },
 
-    children_documents: async ({ id }, _) =>
-      (await DocumentChildrenDomain.loadChildrenDocuments(
-        id,
-        DOCUMENT_IMAGE_METADATA_KEYS
+    children_documents: async ({ id }, _, context) =>
+      (await context.dataLoaders.childrenDocumentsLoader.load(
+        id
       )) as ShareableResource[],
-    uploader: ({ id }, _) => DocumentDomain.loadUploader(id),
-    uploader_organization: ({ id }, _) =>
-      DocumentDomain.loadUploaderOrganization(id),
+    uploader: ({ id }, _, context) =>
+      context.dataLoaders.uploaderLoader.load(id),
+    uploader_organization: ({ id }, _, context) =>
+      context.dataLoaders.uploaderOrganizationLoader.load(id),
     service_instance: ({ service_instance_id }, _) => {
       if (!service_instance_id) return null;
       return ServiceInstanceDomain.getServiceInstance(service_instance_id);

--- a/apps/backend/src/modules/document/domain/document.children.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.children.domain.ts
@@ -56,31 +56,52 @@ export const DocumentChildrenDomain = {
     return children.map(({ child_document_id }) => child_document_id);
   },
 
-  loadChildrenDocuments: async (
-    documentId: string,
-    include_metadata: DocumentMetadataKeyCode[] = []
-  ): Promise<Document[]> => {
+  buildChildrenDocumentsQuery: <T extends object = Document>(
+    parentIds: string[],
+    options: {
+      isDataLoader?: boolean;
+      includeMetadata?: DocumentMetadataKeyCode[];
+    } = {}
+  ) => {
+    const { isDataLoader = false, includeMetadata = [] } = options;
     const context = requestContext.get();
-    const query = db<Document>('Document_Children')
+    const query = db<T>('Document_Children')
       .leftJoin(
         'Document',
         'Document.id',
         'Document_Children.child_document_id'
       )
-      .where('Document_Children.parent_document_id', '=', documentId)
+      .whereIn('Document_Children.parent_document_id', parentIds)
       .modify((qb) => {
-        // No restriction when unauthenticated: parent query enforces public-only boundary
         if (context?.user) {
           restrictDocumentToUserOrganization(qb);
         }
       })
       .orderBy('created_at', 'asc')
-      .select('Document.*')
       .groupBy('Document.id');
 
-    DocumentMetadataDomain.addIncludeMetadataQuery(query, include_metadata);
+    if (isDataLoader) {
+      query
+        .select(
+          'Document.*',
+          'Document_Children.parent_document_id as _parent_id'
+        )
+        .groupBy('Document_Children.parent_document_id');
+    } else {
+      query.select('Document.*');
+    }
 
+    DocumentMetadataDomain.addIncludeMetadataQuery(query, includeMetadata);
     return query;
+  },
+
+  loadChildrenDocuments: async (
+    documentId: string,
+    include_metadata: DocumentMetadataKeyCode[] = []
+  ): Promise<Document[]> => {
+    return DocumentChildrenDomain.buildChildrenDocumentsQuery([documentId], {
+      includeMetadata: include_metadata,
+    });
   },
 
   deleteChildrenByParent: async (parentDocumentId: DocumentId) => {
@@ -121,25 +142,44 @@ export const DocumentChildrenDomain = {
     );
   },
 
-  loadImagesByDocumentId: async (documentId: string) => {
-    const query = db<Document>('Document')
-      .select(['Document.*'])
+  buildImagesByDocumentIdQuery: <T extends object = Document>(
+    parentIds: string[],
+    options: { isDataLoader?: boolean } = {}
+  ) => {
+    const { isDataLoader = false } = options;
+    const query = db<T>('Document')
       .join(
         'Document_Children',
         'Document.id',
         '=',
         'Document_Children.child_document_id'
       )
-      .where('Document_Children.parent_document_id', '=', documentId)
+      .whereIn('Document_Children.parent_document_id', parentIds)
       .where('Document.mime_type', 'like', 'image/%')
       .groupBy('Document.id');
+
+    if (isDataLoader) {
+      query
+        .select(
+          'Document.*',
+          'Document_Children.parent_document_id as _parent_id'
+        )
+        .groupBy('Document_Children.parent_document_id');
+    } else {
+      query.select('Document.*');
+    }
 
     DocumentMetadataDomain.addIncludeMetadataQuery(
       query,
       DOCUMENT_IMAGE_METADATA_KEYS
     );
+    return query;
+  },
 
-    const images = await query;
+  loadImagesByDocumentId: async (documentId: string) => {
+    const images = await DocumentChildrenDomain.buildImagesByDocumentIdQuery([
+      documentId,
+    ]);
 
     for (const image of images) {
       image.id = toGlobalId('Document', image.id);

--- a/apps/backend/src/modules/document/domain/document.children.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.children.domain.ts
@@ -57,7 +57,7 @@ export const DocumentChildrenDomain = {
   },
 
   buildChildrenDocumentsQuery: <T extends object = Document>(
-    parentIds: string[],
+    parentIds: readonly string[],
     options: {
       isDataLoader?: boolean;
       includeMetadata?: DocumentMetadataKeyCode[];
@@ -143,7 +143,7 @@ export const DocumentChildrenDomain = {
   },
 
   buildImagesByDocumentIdQuery: <T extends object = Document>(
-    parentIds: string[],
+    parentIds: readonly string[],
     options: { isDataLoader?: boolean } = {}
   ) => {
     const { isDataLoader = false } = options;

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -17,7 +17,7 @@ import User, { UserId } from '../../../model/kanel/public/User';
 import { UnknownErrorCode } from '../../../utils/error/error.code';
 import { formatRawObject } from '../../../utils/query-raw.util';
 import { omit } from '../../../utils/utils';
-import { Document } from '../document.helper';
+import { Document, WithDocumentId } from '../document.helper';
 
 import { requestContext } from '../../../context/request.context';
 import { OrganizationId } from '../../../model/kanel/public/Organization';
@@ -120,26 +120,36 @@ export const DocumentDomain = {
     return docQuery;
   },
 
-  loadUploader: async (documentId: string): Promise<User | undefined> => {
-    return db<User>('User')
+  buildUploaderQuery: (documentIds: string[]) => {
+    return db<WithDocumentId<User>>('User')
       .leftJoin('Document', 'Document.uploader_id', 'User.id')
-      .where('Document.id', '=', documentId)
-      .select('User.*')
-      .first();
+      .whereIn('Document.id', documentIds)
+      .select('User.*', 'Document.id as _document_id');
   },
 
-  loadUploaderOrganization: async (
-    documentId: string
-  ): Promise<Organization | undefined> => {
-    return db<Organization>('Organization')
+  loadUploader: async (documentId: string): Promise<User | undefined> => {
+    const rows = await DocumentDomain.buildUploaderQuery([documentId]);
+    return rows[0];
+  },
+
+  buildUploaderOrganizationQuery: (documentIds: string[]) => {
+    return db<WithDocumentId<Organization>>('Organization')
       .leftJoin(
         'Document',
         'Document.uploader_organization_id',
         'Organization.id'
       )
-      .where('Document.id', '=', documentId)
-      .select('Organization.*')
-      .first();
+      .whereIn('Document.id', documentIds)
+      .select('Organization.*', 'Document.id as _document_id');
+  },
+
+  loadUploaderOrganization: async (
+    documentId: string
+  ): Promise<Organization | undefined> => {
+    const rows = await DocumentDomain.buildUploaderOrganizationQuery([
+      documentId,
+    ]);
+    return rows[0];
   },
 
   loadParentDocumentsByServiceInstance: async (

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -120,19 +120,21 @@ export const DocumentDomain = {
     return docQuery;
   },
 
-  buildUploaderQuery: (documentIds: string[]) => {
+  buildUploaderQuery: (documentIds: readonly string[]) => {
     return db<WithDocumentId<User>>('User')
       .leftJoin('Document', 'Document.uploader_id', 'User.id')
       .whereIn('Document.id', documentIds)
       .select('User.*', 'Document.id as _document_id');
   },
 
-  loadUploader: async (documentId: string): Promise<User | undefined> => {
+  loadUploader: async (
+    documentId: string
+  ): Promise<WithDocumentId<User> | undefined> => {
     const rows = await DocumentDomain.buildUploaderQuery([documentId]);
     return rows[0];
   },
 
-  buildUploaderOrganizationQuery: (documentIds: string[]) => {
+  buildUploaderOrganizationQuery: (documentIds: readonly string[]) => {
     return db<WithDocumentId<Organization>>('Organization')
       .leftJoin(
         'Document',
@@ -145,7 +147,7 @@ export const DocumentDomain = {
 
   loadUploaderOrganization: async (
     documentId: string
-  ): Promise<Organization | undefined> => {
+  ): Promise<WithDocumentId<Organization> | undefined> => {
     const rows = await DocumentDomain.buildUploaderOrganizationQuery([
       documentId,
     ]);

--- a/apps/backend/src/modules/document/domain/document.metadata.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.metadata.domain.ts
@@ -100,7 +100,7 @@ export const DocumentMetadataDomain = {
     return metadata?.value ?? null;
   },
 
-  buildIntegrationTypeQuery: (documentIds: string[]) => {
+  buildIntegrationTypeQuery: (documentIds: readonly string[]) => {
     return db<{ document_id: string; value: IntegrationType }>(
       'Document_Metadata'
     )

--- a/apps/backend/src/modules/document/domain/document.metadata.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.metadata.domain.ts
@@ -100,18 +100,22 @@ export const DocumentMetadataDomain = {
     return metadata?.value ?? null;
   },
 
+  buildIntegrationTypeQuery: (documentIds: string[]) => {
+    return db<{ document_id: string; value: IntegrationType }>(
+      'Document_Metadata'
+    )
+      .select('document_id', 'value')
+      .whereIn('document_id', documentIds)
+      .where('key', DocumentMetadataKeyCode.IntegrationType);
+  },
+
   loadIntegrationType: async (
     document_id: string
   ): Promise<IntegrationType | null> => {
-    const doc = await db('Document_Metadata')
-      .select('value')
-      .where({
-        key: DocumentMetadataKeyCode.IntegrationType,
-        document_id,
-      })
-      .first();
-
-    return doc?.value ?? null;
+    const rows = await DocumentMetadataDomain.buildIntegrationTypeQuery([
+      document_id,
+    ]);
+    return rows[0]?.value ?? null;
   },
 
   deleteMetadata: async ({

--- a/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.test.ts
@@ -15,11 +15,8 @@ import ServiceInstance, {
 } from '../../../../model/kanel/public/ServiceInstance';
 import UseCase from '../../../../model/kanel/public/UseCase';
 import User from '../../../../model/kanel/public/User';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 import scenarioResolver from './scenario.resolver';
 
 describe('openAEVScenario field resolvers', () => {
@@ -28,9 +25,10 @@ describe('openAEVScenario field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = [{ id: uuidv4(), name: 'Use Case A' }];
-      vi.spyOn(useCaseDomain, 'loadUseCasesByDocumentId').mockResolvedValue(
-        expected as unknown as UseCase[]
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as UseCase[]);
 
       // When
       const result = await scenarioResolver.OpenAEVScenario!.use_cases!(
@@ -41,9 +39,9 @@ describe('openAEVScenario field resolvers', () => {
       );
 
       // Then
-      expect(useCaseDomain.loadUseCasesByDocumentId).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -54,11 +52,13 @@ describe('openAEVScenario field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        DocumentChildrenDomain,
-        'loadImagesByDocumentId'
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
-          ReturnType<typeof DocumentChildrenDomain.loadImagesByDocumentId>
+          ReturnType<
+            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+          >
         >
       );
 
@@ -73,7 +73,7 @@ describe('openAEVScenario field resolvers', () => {
 
       // Then
       expect(
-        DocumentChildrenDomain.loadImagesByDocumentId
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
@@ -84,9 +84,10 @@ describe('openAEVScenario field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), email: 'user@test.com' };
-      vi.spyOn(DocumentDomain, 'loadUploader').mockResolvedValue(
-        expected as unknown as User | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as User | null);
 
       // When
       const result = await scenarioResolver.OpenAEVScenario!.uploader!(
@@ -97,7 +98,9 @@ describe('openAEVScenario field resolvers', () => {
       );
 
       // Then
-      expect(DocumentDomain.loadUploader).toHaveBeenCalledWith(documentId);
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -107,9 +110,10 @@ describe('openAEVScenario field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), name: 'Org A' };
-      vi.spyOn(DocumentDomain, 'loadUploaderOrganization').mockResolvedValue(
-        expected as unknown as Organization | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as Organization | null);
 
       // When
       const result = await scenarioResolver.OpenAEVScenario!
@@ -121,9 +125,9 @@ describe('openAEVScenario field resolvers', () => {
       );
 
       // Then
-      expect(DocumentDomain.loadUploaderOrganization).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.ts
@@ -1,18 +1,22 @@
-import { Resolvers } from '../../../../__generated__/resolvers-types';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
+import {
+  Resolvers,
+  ShareableResource,
+} from '../../../../__generated__/resolvers-types';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 
 const resolvers: Resolvers = {
   OpenAEVScenario: {
-    use_cases: ({ id }) => useCaseDomain.loadUseCasesByDocumentId(id),
-    children_documents: ({ id }) =>
-      DocumentChildrenDomain.loadImagesByDocumentId(id),
-    uploader: ({ id }, _) => DocumentDomain.loadUploader(id),
-    uploader_organization: ({ id }, _) =>
-      DocumentDomain.loadUploaderOrganization(id),
+    use_cases: ({ id }, _, context) =>
+      context.dataLoaders.useCasesByDocumentIdLoader.load(id),
+    children_documents: async ({ id }, _, context) =>
+      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+        id
+      )) as unknown as ShareableResource[],
+    uploader: ({ id }, _, context) =>
+      context.dataLoaders.uploaderLoader.load(id),
+    uploader_organization: ({ id }, _, context) =>
+      context.dataLoaders.uploaderOrganizationLoader.load(id),
     service_instance: ({ service_instance_id }, _) => {
       if (!service_instance_id) return null;
       return ServiceInstanceDomain.getServiceInstance(service_instance_id);

--- a/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.test.ts
@@ -15,11 +15,8 @@ import ServiceInstance, {
 } from '../../../../model/kanel/public/ServiceInstance';
 import UseCase from '../../../../model/kanel/public/UseCase';
 import User from '../../../../model/kanel/public/User';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 import customDashboardResolver from './custom-dashboard.resolver';
 
 describe('customDashboard field resolvers', () => {
@@ -28,9 +25,10 @@ describe('customDashboard field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = [{ id: uuidv4(), name: 'Use Case A' }];
-      vi.spyOn(useCaseDomain, 'loadUseCasesByDocumentId').mockResolvedValue(
-        expected as unknown as UseCase[]
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as UseCase[]);
 
       // When
       const result = await customDashboardResolver.CustomDashboard!.use_cases!(
@@ -41,9 +39,9 @@ describe('customDashboard field resolvers', () => {
       );
 
       // Then
-      expect(useCaseDomain.loadUseCasesByDocumentId).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -54,11 +52,13 @@ describe('customDashboard field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        DocumentChildrenDomain,
-        'loadImagesByDocumentId'
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
-          ReturnType<typeof DocumentChildrenDomain.loadImagesByDocumentId>
+          ReturnType<
+            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+          >
         >
       );
 
@@ -73,7 +73,7 @@ describe('customDashboard field resolvers', () => {
 
       // Then
       expect(
-        DocumentChildrenDomain.loadImagesByDocumentId
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
@@ -84,9 +84,10 @@ describe('customDashboard field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), email: 'user@test.com' };
-      vi.spyOn(DocumentDomain, 'loadUploader').mockResolvedValue(
-        expected as unknown as User | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as User | null);
 
       // When
       const result = await customDashboardResolver.CustomDashboard!.uploader!(
@@ -97,7 +98,9 @@ describe('customDashboard field resolvers', () => {
       );
 
       // Then
-      expect(DocumentDomain.loadUploader).toHaveBeenCalledWith(documentId);
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -107,9 +110,10 @@ describe('customDashboard field resolvers', () => {
       // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), name: 'Org A' };
-      vi.spyOn(DocumentDomain, 'loadUploaderOrganization').mockResolvedValue(
-        expected as unknown as Organization | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as Organization | null);
 
       // When
       const result = await customDashboardResolver.CustomDashboard!
@@ -121,9 +125,9 @@ describe('customDashboard field resolvers', () => {
       );
 
       // Then
-      expect(DocumentDomain.loadUploaderOrganization).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.ts
@@ -1,18 +1,22 @@
-import { Resolvers } from '../../../../__generated__/resolvers-types';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
+import {
+  Resolvers,
+  ShareableResource,
+} from '../../../../__generated__/resolvers-types';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 
 const resolvers: Resolvers = {
   CustomDashboard: {
-    use_cases: ({ id }) => useCaseDomain.loadUseCasesByDocumentId(id),
-    children_documents: ({ id }) =>
-      DocumentChildrenDomain.loadImagesByDocumentId(id),
-    uploader: ({ id }, _) => DocumentDomain.loadUploader(id),
-    uploader_organization: ({ id }, _) =>
-      DocumentDomain.loadUploaderOrganization(id),
+    use_cases: ({ id }, _, context) =>
+      context.dataLoaders.useCasesByDocumentIdLoader.load(id),
+    children_documents: async ({ id }, _, context) =>
+      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+        id
+      )) as unknown as ShareableResource[],
+    uploader: ({ id }, _, context) =>
+      context.dataLoaders.uploaderLoader.load(id),
+    uploader_organization: ({ id }, _, context) =>
+      context.dataLoaders.uploaderOrganizationLoader.load(id),
     service_instance: ({ service_instance_id }, _) => {
       if (!service_instance_id) return null;
       return ServiceInstanceDomain.getServiceInstance(service_instance_id);

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
@@ -17,11 +17,8 @@ import ServiceInstance, {
 import UseCase from '../../../../model/kanel/public/UseCase';
 import User from '../../../../model/kanel/public/User';
 import { logApp } from '../../../../utils/app-logger.util';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 import { Integration } from './integration.model';
 import integrationResolver from './integration.resolver';
 
@@ -46,22 +43,18 @@ describe('integration.__resolveType', () => {
   `(
     'should resolve $integrationType to $expectedTypeName',
     ({ integrationType, expectedTypeName }) => {
-      // Given
       const feed = {
         integration_type: integrationType,
         id: uuidv4(),
       } as unknown as Integration;
 
-      // When
       const result = getResolveType()(feed);
 
-      // Then
       expect(result).toBe(expectedTypeName);
     }
   );
 
   it('should call logApp.error and return undefined for unknown integration type', () => {
-    // Given
     const unknownType = 'unknown_type' as IntegrationType;
     const integrationId = uuidv4();
     const feed = {
@@ -70,10 +63,8 @@ describe('integration.__resolveType', () => {
     } as unknown as Integration;
     vi.spyOn(logApp, 'error').mockImplementation(() => undefined);
 
-    // When
     const result = getResolveType()(feed);
 
-    // Then
     expect(logApp.error).toHaveBeenCalledWith(
       `Unknown resolve type for integration ${integrationId} and integration type ${unknownType}`
     );
@@ -84,14 +75,13 @@ describe('integration.__resolveType', () => {
 describe('integration field resolvers', () => {
   describe('integration.use_cases', () => {
     it('should load use cases by document id', async () => {
-      // Given
       const documentId = uuidv4();
       const expected = [{ id: uuidv4(), name: 'Use Case A' }];
-      vi.spyOn(useCaseDomain, 'loadUseCasesByDocumentId').mockResolvedValue(
-        expected as unknown as UseCase[]
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as UseCase[]);
 
-      // When
       const result = await integrationResolver.Integration!.use_cases!(
         { id: documentId } as unknown as Connector,
         {},
@@ -99,29 +89,28 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
-      expect(useCaseDomain.loadUseCasesByDocumentId).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
 
   describe('integration.children_documents', () => {
     it('should load children images by document id', async () => {
-      // Given
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        DocumentChildrenDomain,
-        'loadImagesByDocumentId'
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
-          ReturnType<typeof DocumentChildrenDomain.loadImagesByDocumentId>
+          ReturnType<
+            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+          >
         >
       );
 
-      // When
       const result = await integrationResolver.Integration!.children_documents!(
         { id: documentId } as unknown as Connector,
         {},
@@ -129,9 +118,8 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
       expect(
-        DocumentChildrenDomain.loadImagesByDocumentId
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
@@ -139,14 +127,13 @@ describe('integration field resolvers', () => {
 
   describe('integration.uploader', () => {
     it('should load uploader by document id', async () => {
-      // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), email: 'user@test.com' };
-      vi.spyOn(DocumentDomain, 'loadUploader').mockResolvedValue(
-        expected as unknown as User | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as User | null);
 
-      // When
       const result = await integrationResolver.Integration!.uploader!(
         { id: documentId } as unknown as Connector,
         {},
@@ -154,22 +141,22 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
-      expect(DocumentDomain.loadUploader).toHaveBeenCalledWith(documentId);
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
 
   describe('integration.uploader_organization', () => {
     it('should load uploader organization by document id', async () => {
-      // Given
       const documentId = uuidv4();
       const expected = { id: uuidv4(), name: 'Org A' };
-      vi.spyOn(DocumentDomain, 'loadUploaderOrganization').mockResolvedValue(
-        expected as unknown as Organization | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as Organization | null);
 
-      // When
       const result = await integrationResolver.Integration!
         .uploader_organization!(
         { id: documentId } as unknown as Connector,
@@ -178,24 +165,21 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
-      expect(DocumentDomain.loadUploaderOrganization).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
 
   describe('integration.service_instance', () => {
     it('should load service instance by service_instance_id', async () => {
-      // Given
       const serviceInstanceId = SERVICES.INSTANCES.INTEGRATIONS.ID;
       const expected = { id: serviceInstanceId, name: 'integrations' };
       vi.spyOn(ServiceInstanceDomain, 'getServiceInstance').mockResolvedValue(
         expected as unknown as ServiceInstance | undefined
       );
 
-      // When
       const result = await integrationResolver.Integration!.service_instance!(
         { service_instance_id: serviceInstanceId } as unknown as Connector,
         {},
@@ -203,7 +187,6 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
       expect(ServiceInstanceDomain.getServiceInstance).toHaveBeenCalledWith(
         serviceInstanceId
       );
@@ -213,7 +196,6 @@ describe('integration field resolvers', () => {
 
   describe('integration.subscription', () => {
     it('should load subscription model using context user and service_instance_id', async () => {
-      // Given
       const serviceInstanceId = SERVICES.INSTANCES.INTEGRATIONS
         .ID as ServiceInstanceId;
       const expected = { id: uuidv4() } as unknown as SubscriptionModel;
@@ -221,7 +203,6 @@ describe('integration field resolvers', () => {
         expected
       );
 
-      // When
       const result = await integrationResolver.Integration!.subscription!(
         { service_instance_id: serviceInstanceId } as unknown as Connector,
         {},
@@ -229,7 +210,6 @@ describe('integration field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      // Then
       expect(subscriptionApp.loadSubscriptionModel).toHaveBeenCalledWith(
         contextSimpleUserFiligran2.user,
         serviceInstanceId

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
@@ -1,13 +1,11 @@
 import {
   IntegrationType,
   Resolvers,
+  ShareableResource,
 } from '../../../../__generated__/resolvers-types';
 import { logApp } from '../../../../utils/app-logger.util';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 
 const resolvers: Resolvers = {
   Integration: {
@@ -31,12 +29,16 @@ const resolvers: Resolvers = {
 
       return resolvedType;
     },
-    use_cases: ({ id }) => useCaseDomain.loadUseCasesByDocumentId(id),
-    children_documents: ({ id }) =>
-      DocumentChildrenDomain.loadImagesByDocumentId(id),
-    uploader: ({ id }, _) => DocumentDomain.loadUploader(id),
-    uploader_organization: ({ id }, _) =>
-      DocumentDomain.loadUploaderOrganization(id),
+    use_cases: ({ id }, _, context) =>
+      context.dataLoaders.useCasesByDocumentIdLoader.load(id),
+    children_documents: async ({ id }, _, context) =>
+      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+        id
+      )) as unknown as ShareableResource[],
+    uploader: ({ id }, _, context) =>
+      context.dataLoaders.uploaderLoader.load(id),
+    uploader_organization: ({ id }, _, context) =>
+      context.dataLoaders.uploaderOrganizationLoader.load(id),
     service_instance: ({ service_instance_id }, _) => {
       if (!service_instance_id) return null;
       return ServiceInstanceDomain.getServiceInstance(service_instance_id);

--- a/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.test.ts
@@ -15,11 +15,8 @@ import ServiceInstance, {
 } from '../../../../model/kanel/public/ServiceInstance';
 import UseCase from '../../../../model/kanel/public/UseCase';
 import User from '../../../../model/kanel/public/User';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 import playbookResolver from './playbook.resolver';
 
 describe('openCTIPlaybook field resolvers', () => {
@@ -27,9 +24,10 @@ describe('openCTIPlaybook field resolvers', () => {
     it('should load use cases by document id', async () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4(), name: 'Use Case A' }];
-      vi.spyOn(useCaseDomain, 'loadUseCasesByDocumentId').mockResolvedValue(
-        expected as unknown as UseCase[]
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as UseCase[]);
 
       const result = await playbookResolver.OpenCTIPlaybook!.use_cases!(
         { id: documentId } as unknown as OpenCtiPlaybook,
@@ -38,9 +36,9 @@ describe('openCTIPlaybook field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      expect(useCaseDomain.loadUseCasesByDocumentId).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -50,11 +48,13 @@ describe('openCTIPlaybook field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        DocumentChildrenDomain,
-        'loadImagesByDocumentId'
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
-          ReturnType<typeof DocumentChildrenDomain.loadImagesByDocumentId>
+          ReturnType<
+            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+          >
         >
       );
 
@@ -67,7 +67,7 @@ describe('openCTIPlaybook field resolvers', () => {
       );
 
       expect(
-        DocumentChildrenDomain.loadImagesByDocumentId
+        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
@@ -77,9 +77,10 @@ describe('openCTIPlaybook field resolvers', () => {
     it('should load uploader by document id', async () => {
       const documentId = uuidv4();
       const expected = { id: uuidv4(), email: 'user@test.com' };
-      vi.spyOn(DocumentDomain, 'loadUploader').mockResolvedValue(
-        expected as unknown as User | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as User | null);
 
       const result = await playbookResolver.OpenCTIPlaybook!.uploader!(
         { id: documentId } as unknown as OpenCtiPlaybook,
@@ -88,7 +89,9 @@ describe('openCTIPlaybook field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      expect(DocumentDomain.loadUploader).toHaveBeenCalledWith(documentId);
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });
@@ -97,9 +100,10 @@ describe('openCTIPlaybook field resolvers', () => {
     it('should load uploader organization by document id', async () => {
       const documentId = uuidv4();
       const expected = { id: uuidv4(), name: 'Org A' };
-      vi.spyOn(DocumentDomain, 'loadUploaderOrganization').mockResolvedValue(
-        expected as unknown as Organization | undefined
-      );
+      vi.spyOn(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+        'load'
+      ).mockResolvedValue(expected as unknown as Organization | null);
 
       const result = await playbookResolver.OpenCTIPlaybook!
         .uploader_organization!(
@@ -109,9 +113,9 @@ describe('openCTIPlaybook field resolvers', () => {
         GRAPHQL_RESOLVE_INFO
       );
 
-      expect(DocumentDomain.loadUploaderOrganization).toHaveBeenCalledWith(
-        documentId
-      );
+      expect(
+        contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+      ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.ts
@@ -1,18 +1,22 @@
-import { Resolvers } from '../../../../__generated__/resolvers-types';
-import { DocumentChildrenDomain } from '../../../document/domain/document.children.domain';
-import { DocumentDomain } from '../../../document/domain/document.domain';
+import {
+  Resolvers,
+  ShareableResource,
+} from '../../../../__generated__/resolvers-types';
 import { ServiceInstanceDomain } from '../../../service/instance/service-instance.domain';
 import { subscriptionApp } from '../../../subscription/subscription.app';
-import { useCaseDomain } from '../../../use-case/use-case.domain';
 
 const resolvers: Resolvers = {
   OpenCTIPlaybook: {
-    use_cases: ({ id }) => useCaseDomain.loadUseCasesByDocumentId(id),
-    children_documents: ({ id }) =>
-      DocumentChildrenDomain.loadImagesByDocumentId(id),
-    uploader: ({ id }, _) => DocumentDomain.loadUploader(id),
-    uploader_organization: ({ id }, _) =>
-      DocumentDomain.loadUploaderOrganization(id),
+    use_cases: ({ id }, _, context) =>
+      context.dataLoaders.useCasesByDocumentIdLoader.load(id),
+    children_documents: async ({ id }, _, context) =>
+      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+        id
+      )) as unknown as ShareableResource[],
+    uploader: ({ id }, _, context) =>
+      context.dataLoaders.uploaderLoader.load(id),
+    uploader_organization: ({ id }, _, context) =>
+      context.dataLoaders.uploaderOrganizationLoader.load(id),
     service_instance: ({ service_instance_id }, _) => {
       if (!service_instance_id) return null;
       return ServiceInstanceDomain.getServiceInstance(service_instance_id);

--- a/apps/backend/src/modules/use-case/use-case.domain.ts
+++ b/apps/backend/src/modules/use-case/use-case.domain.ts
@@ -55,7 +55,7 @@ export const useCaseDomain = {
     );
   },
 
-  buildUseCasesByDocumentIdQuery: (documentIds: string[]) => {
+  buildUseCasesByDocumentIdQuery: (documentIds: readonly string[]) => {
     return db<WithDocumentId<UseCase>>('UseCase')
       .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
       .whereIn('ouc.object_id', documentIds)

--- a/apps/backend/src/modules/use-case/use-case.domain.ts
+++ b/apps/backend/src/modules/use-case/use-case.domain.ts
@@ -9,6 +9,7 @@ import UseCase, {
   UseCaseMutator,
 } from '../../model/kanel/public/UseCase';
 import { UnknownErrorCode } from '../../utils/error/error.code';
+import { WithDocumentId } from '../document/document.helper';
 
 export const useCaseDomain = {
   insertUseCase: async (input: UseCaseInitializer): Promise<UseCase> => {
@@ -52,6 +53,13 @@ export const useCaseDomain = {
       undefined,
       useCaseQuery
     );
+  },
+
+  buildUseCasesByDocumentIdQuery: (documentIds: string[]) => {
+    return db<WithDocumentId<UseCase>>('UseCase')
+      .leftJoin('Object_UseCase as ouc', 'ouc.use_case_id', 'UseCase.id')
+      .whereIn('ouc.object_id', documentIds)
+      .select('UseCase.*', 'ouc.object_id as _document_id');
   },
 
   loadUseCasesByDocumentId: (documentId: string): Promise<UseCase[]> => {

--- a/apps/backend/tests/tests.const.ts
+++ b/apps/backend/tests/tests.const.ts
@@ -18,6 +18,7 @@ import { ServiceDefinitionId } from '../src/model/kanel/public/ServiceDefinition
 import { ServiceInstanceId } from '../src/model/kanel/public/ServiceInstance';
 import { UserId } from '../src/model/kanel/public/User';
 import { PortalContext } from '../src/model/portal-context';
+import type { DocumentDataLoaders } from '../src/modules/document/document.dataloader';
 import {
   CAPABILITY_BYPASS,
   PLATFORM_ORGANIZATION_UUID,
@@ -363,6 +364,14 @@ export const contextSimpleUserFiligran2: PortalContext = {
     capabilities: [],
     roles_portal: [],
   },
+  dataLoaders: {
+    uploaderLoader: { load: () => Promise.resolve(null) },
+    uploaderOrganizationLoader: { load: () => Promise.resolve(null) },
+    childrenDocumentsLoader: { load: () => Promise.resolve([]) },
+    imagesByDocumentIdLoader: { load: () => Promise.resolve([]) },
+    useCasesByDocumentIdLoader: { load: () => Promise.resolve([]) },
+    integrationTypeLoader: { load: () => Promise.resolve(null) },
+  } as unknown as DocumentDataLoaders,
 } as unknown as PortalContext;
 
 export const requestContextSimpleUserFiligran2 = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,6 +8551,7 @@ __metadata:
     config: "npm:4.4.1"
     cors: "npm:2.8.6"
     cpy-cli: "npm:7.0.0"
+    dataloader: "npm:2.2.3"
     esbuild: "npm:0.28.1"
     eslint: "catalog:"
     eslint-config-prettier: "catalog:"
@@ -10572,7 +10573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:^2.2.3":
+"dataloader@npm:2.2.3, dataloader@npm:^2.2.3":
   version: 2.2.3
   resolution: "dataloader@npm:2.2.3"
   checksum: 10/83fe6259abe00ae64c5f48252ef59d8e5fcabda9fd4d26685f14a76eeca596bf6f9500d9f22a0094c50c3ea782a0977728f9367e232dfa0fdb5c9d646de279b2


### PR DESCRIPTION
# Context
The `publicDocumentsByServiceSlugQuery` and `publicDocumentBySlugQuery` queries suffer from  from N+1 performance issues. Each document returned triggers individual SQL queries for its field resolvers (`uploader`, `uploader_organization`, `children_documents`, `images`, `use_cases`, `integration_Type`)

This PR implements DataLoader to batch and deduplicate these field resolver queries per request.

From my local testing with 67 documents, I went from 5*67=335 queries, to only 5, and from ~350ms to ~13ms

## How to test

## Related issues

- Related to #2567

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.