### PR TITLE
feat(sign-up): integrate new sign up in current login flow (#2617)

### DIFF
--- a/apps/backend/src/modules/organization-management/user/user.helper.ts
+++ b/apps/backend/src/modules/organization-management/user/user.helper.ts
@@ -58,7 +58,8 @@ export const createUserWithPersonalSpace = async (
   > & {
     password?: string | null;
     selected_organization_id?: OrganizationId;
-  }
+  },
+  sendWelcomeEmail = true
 ): Promise<User> => {
   const { salt, hash } = hashPassword(data.password ?? '');
   const uuid = uuidv4();
@@ -98,16 +99,21 @@ export const createUserWithPersonalSpace = async (
     capabilities_name: [OrganizationCapability.AdministrateOrganization],
   });
 
-  await sendMail({
-    to: addedUser.email,
-    template: 'welcome',
-    params: {},
-  });
+  if (sendWelcomeEmail) {
+    await sendMail({
+      to: addedUser.email,
+      template: 'welcome',
+      params: {},
+    });
+  }
 
   return addedUser;
 };
 
-async function createOrganisationWithAdminUser(email: string) {
+async function createOrganisationWithAdminUser(
+  email: string,
+  sendWelcomeEmail = true
+) {
   const extractedDomain = extractDomain(email);
 
   if (!extractedDomain) {
@@ -119,9 +125,12 @@ async function createOrganisationWithAdminUser(email: string) {
     name: extractedDomain,
     domains: [extractedDomain],
   });
-  const addedUser = await createUserWithPersonalSpace({
-    email,
-  });
+  const addedUser = await createUserWithPersonalSpace(
+    {
+      email,
+    },
+    sendWelcomeEmail
+  );
 
   try {
     const createOrgaEvent = TelemetryHelper.buildCreateOrganizationEvent(
@@ -161,14 +170,18 @@ export const createNewUserWithPendingOrga = async (
     last_name,
     picture,
   }: Pick<UserInitializer, 'email' | 'first_name' | 'last_name' | 'picture'>,
-  organization: Organization
+  organization: Organization,
+  sendWelcomeEmail = true
 ) => {
-  const addedUser = await createUserWithPersonalSpace({
-    email,
-    last_name,
-    first_name,
-    picture,
-  });
+  const addedUser = await createUserWithPersonalSpace(
+    {
+      email,
+      last_name,
+      first_name,
+      picture,
+    },
+    sendWelcomeEmail
+  );
   await UserOrganizationPendingDomain.insertNewUserOrganizationPending({
     user_id: addedUser.id,
     organization_id: organization.id,
@@ -183,20 +196,27 @@ export const createNewUserFromInvitation = async (
     last_name,
     picture,
   }: Pick<UserInitializer, 'email' | 'first_name' | 'last_name' | 'picture'>,
-  isFiligranUser: boolean = false
+  isFiligranUser: boolean = false,
+  sendWelcomeEmail = true
 ): Promise<User> => {
   const [organization] =
     await OrganizationDomain.loadOrganizationsFromEmail(email);
   let userWithRoles: User;
   if (!organization) {
-    userWithRoles = await createOrganisationWithAdminUser(email);
-  } else if (isFiligranUser) {
-    userWithRoles = await createUserWithPersonalSpace({
+    userWithRoles = await createOrganisationWithAdminUser(
       email,
-      last_name,
-      first_name,
-      picture,
-    });
+      sendWelcomeEmail
+    );
+  } else if (isFiligranUser) {
+    userWithRoles = await createUserWithPersonalSpace(
+      {
+        email,
+        last_name,
+        first_name,
+        picture,
+      },
+      sendWelcomeEmail
+    );
   } else {
     userWithRoles = await createNewUserWithPendingOrga(
       {
@@ -205,7 +225,8 @@ export const createNewUserFromInvitation = async (
         first_name,
         picture,
       },
-      organization
+      organization,
+      sendWelcomeEmail
     );
   }
 
@@ -222,7 +243,8 @@ export const getOrCreateUser = async (
     'email' | 'first_name' | 'last_name' | 'picture'
   >,
   upsert = false,
-  isFiligranUser = false
+  isFiligranUser = false,
+  sendWelcomeEmail = true
 ): Promise<User> => {
   const user = await UserDomain.loadUserBy({ email: userInfo.email });
   if (user && upsert) {
@@ -241,7 +263,11 @@ export const getOrCreateUser = async (
   }
   return user
     ? user
-    : await createNewUserFromInvitation(userInfo, isFiligranUser);
+    : await createNewUserFromInvitation(
+        userInfo,
+        isFiligranUser,
+        sendWelcomeEmail
+      );
 };
 
 export const insertUserIntoOrganization = async (

--- a/apps/backend/src/modules/organization-management/user/user.helper.ts
+++ b/apps/backend/src/modules/organization-management/user/user.helper.ts
@@ -51,6 +51,10 @@ import { UserDomain } from './user-domain/user.domain';
 import { UserOrganizationDomain } from './user-organization/user-organization.domain';
 import { UserOrganizationPendingDomain } from './user-pending/user-organization-pending.domain';
 
+interface WelcomeEmailOptions {
+  sendWelcomeEmail?: boolean;
+}
+
 export const createUserWithPersonalSpace = async (
   data: Pick<
     UserInitializer,
@@ -59,7 +63,7 @@ export const createUserWithPersonalSpace = async (
     password?: string | null;
     selected_organization_id?: OrganizationId;
   },
-  sendWelcomeEmail = true
+  { sendWelcomeEmail = true }: WelcomeEmailOptions = {}
 ): Promise<User> => {
   const { salt, hash } = hashPassword(data.password ?? '');
   const uuid = uuidv4();
@@ -112,7 +116,7 @@ export const createUserWithPersonalSpace = async (
 
 async function createOrganisationWithAdminUser(
   email: string,
-  sendWelcomeEmail = true
+  { sendWelcomeEmail = true }: WelcomeEmailOptions = {}
 ) {
   const extractedDomain = extractDomain(email);
 
@@ -129,7 +133,7 @@ async function createOrganisationWithAdminUser(
     {
       email,
     },
-    sendWelcomeEmail
+    { sendWelcomeEmail }
   );
 
   try {
@@ -171,7 +175,7 @@ export const createNewUserWithPendingOrga = async (
     picture,
   }: Pick<UserInitializer, 'email' | 'first_name' | 'last_name' | 'picture'>,
   organization: Organization,
-  sendWelcomeEmail = true
+  { sendWelcomeEmail = true }: WelcomeEmailOptions = {}
 ) => {
   const addedUser = await createUserWithPersonalSpace(
     {
@@ -180,7 +184,7 @@ export const createNewUserWithPendingOrga = async (
       first_name,
       picture,
     },
-    sendWelcomeEmail
+    { sendWelcomeEmail }
   );
   await UserOrganizationPendingDomain.insertNewUserOrganizationPending({
     user_id: addedUser.id,
@@ -189,6 +193,10 @@ export const createNewUserWithPendingOrga = async (
   return addedUser;
 };
 
+interface CreateNewUserOptions extends WelcomeEmailOptions {
+  isFiligranUser?: boolean;
+}
+
 export const createNewUserFromInvitation = async (
   {
     email,
@@ -196,17 +204,15 @@ export const createNewUserFromInvitation = async (
     last_name,
     picture,
   }: Pick<UserInitializer, 'email' | 'first_name' | 'last_name' | 'picture'>,
-  isFiligranUser: boolean = false,
-  sendWelcomeEmail = true
+  { isFiligranUser = false, sendWelcomeEmail = true }: CreateNewUserOptions = {}
 ): Promise<User> => {
   const [organization] =
     await OrganizationDomain.loadOrganizationsFromEmail(email);
   let userWithRoles: User;
   if (!organization) {
-    userWithRoles = await createOrganisationWithAdminUser(
-      email,
-      sendWelcomeEmail
-    );
+    userWithRoles = await createOrganisationWithAdminUser(email, {
+      sendWelcomeEmail,
+    });
   } else if (isFiligranUser) {
     userWithRoles = await createUserWithPersonalSpace(
       {
@@ -215,7 +221,7 @@ export const createNewUserFromInvitation = async (
         first_name,
         picture,
       },
-      sendWelcomeEmail
+      { sendWelcomeEmail }
     );
   } else {
     userWithRoles = await createNewUserWithPendingOrga(
@@ -226,7 +232,7 @@ export const createNewUserFromInvitation = async (
         picture,
       },
       organization,
-      sendWelcomeEmail
+      { sendWelcomeEmail }
     );
   }
 
@@ -237,14 +243,20 @@ export const createNewUserFromInvitation = async (
   return user;
 };
 
+interface GetOrCreateUserOptions extends CreateNewUserOptions {
+  upsert?: boolean;
+}
+
 export const getOrCreateUser = async (
   userInfo: Pick<
     UserInitializer,
     'email' | 'first_name' | 'last_name' | 'picture'
   >,
-  upsert = false,
-  isFiligranUser = false,
-  sendWelcomeEmail = true
+  {
+    upsert = false,
+    isFiligranUser = false,
+    sendWelcomeEmail = true,
+  }: GetOrCreateUserOptions = {}
 ): Promise<User> => {
   const user = await UserDomain.loadUserBy({ email: userInfo.email });
   if (user && upsert) {
@@ -263,11 +275,10 @@ export const getOrCreateUser = async (
   }
   return user
     ? user
-    : await createNewUserFromInvitation(
-        userInfo,
+    : await createNewUserFromInvitation(userInfo, {
         isFiligranUser,
-        sendWelcomeEmail
-      );
+        sendWelcomeEmail,
+      });
 };
 
 export const insertUserIntoOrganization = async (

--- a/apps/backend/src/modules/organization-management/user/user.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.test.ts
@@ -145,7 +145,10 @@ describe('user helpers', async () => {
       const sendMailSpy = vi.spyOn(MailService, 'sendMail').mockResolvedValue();
       const testMail = `testWelcomeEmail${uuidv4()}@whatever.io`;
 
-      await createNewUserFromInvitation({ email: testMail }, false, false);
+      await createNewUserFromInvitation(
+        { email: testMail },
+        { sendWelcomeEmail: false }
+      );
 
       expect(sendMailSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ template: 'welcome' })

--- a/apps/backend/src/modules/organization-management/user/user.test.ts
+++ b/apps/backend/src/modules/organization-management/user/user.test.ts
@@ -10,6 +10,7 @@ import { requestContext } from '../../../context/request.context';
 import Organization from '../../../model/kanel/public/Organization';
 import { UserId } from '../../../model/kanel/public/User';
 import { UserLoadUserBy } from '../../../model/user';
+import * as MailService from '../../../server/mail-service';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { UserOrganizationCapabilityDomain } from '../../security-management/user-organization-capability/user-organization-capability.domain';
 import { TelemetryApp } from '../../telemetry/telemetry.app';
@@ -124,6 +125,34 @@ describe('user helpers', async () => {
       expect(newUser.selected_org_capabilities).toHaveLength(1);
 
       expect(newUserPendingOrg).toHaveLength(0);
+    });
+
+    it('should send a welcome email by default when creating a new user', async () => {
+      const sendMailSpy = vi.spyOn(MailService, 'sendMail').mockResolvedValue();
+      const testMail = `testWelcomeEmail${uuidv4()}@whatever.io`;
+
+      await createNewUserFromInvitation({ email: testMail });
+
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ to: testMail, template: 'welcome' })
+      );
+
+      await removeUser({ email: testMail });
+      sendMailSpy.mockRestore();
+    });
+
+    it('should not send a welcome email when sendWelcomeEmail is false', async () => {
+      const sendMailSpy = vi.spyOn(MailService, 'sendMail').mockResolvedValue();
+      const testMail = `testWelcomeEmail${uuidv4()}@whatever.io`;
+
+      await createNewUserFromInvitation({ email: testMail }, false, false);
+
+      expect(sendMailSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ template: 'welcome' })
+      );
+
+      await removeUser({ email: testMail });
+      sendMailSpy.mockRestore();
     });
   });
 

--- a/apps/backend/src/modules/security-management/authentication/auth-user.ts
+++ b/apps/backend/src/modules/security-management/authentication/auth-user.ts
@@ -21,7 +21,7 @@ export const loginFromProvider = async (userInfo: UserInfo) => {
   }
   const isFiligranUser = email.endsWith('@filigran.io');
 
-  const user = await getOrCreateUser(userInfo, true, isFiligranUser);
+  const user = await getOrCreateUser(userInfo, true, isFiligranUser, false);
   if (!user) {
     throw new Error(ErrorCode.UserNotFound);
   }

--- a/apps/backend/src/modules/security-management/authentication/auth-user.ts
+++ b/apps/backend/src/modules/security-management/authentication/auth-user.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import { FeatureFlag } from '../../../__generated__/resolvers-types';
 import { UserInfo } from '../../../model/user';
 import { PLATFORM_ORGANIZATION_UUID } from '../../../portal.const';
 import {
@@ -7,6 +8,7 @@ import {
 } from '../../../server/initialize.helper';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { ForbiddenAccess } from '../../../utils/error/error.util';
+import { isFeatureEnabled } from '../../../utils/feature-flag.util';
 import { isEmptyField } from '../../../utils/utils';
 import { UserDomain } from '../../organization-management/user/user-domain/user.domain';
 import { getOrCreateUser } from '../../organization-management/user/user.helper';
@@ -21,7 +23,12 @@ export const loginFromProvider = async (userInfo: UserInfo) => {
   }
   const isFiligranUser = email.endsWith('@filigran.io');
 
-  const user = await getOrCreateUser(userInfo, true, isFiligranUser, false);
+  const sendWelcomeEmail = !isFeatureEnabled(FeatureFlag.HomePageV2);
+  const user = await getOrCreateUser(userInfo, {
+    upsert: true,
+    isFiligranUser,
+    sendWelcomeEmail,
+  });
   if (!user) {
     throw new Error(ErrorCode.UserNotFound);
   }

--- a/apps/backend/src/utils/feature-flag.util.test.ts
+++ b/apps/backend/src/utils/feature-flag.util.test.ts
@@ -53,33 +53,47 @@ describe('resolveFeatureFlags', () => {
 });
 
 describe('isFeatureEnabled', () => {
-  describe('when feature is enabled', () => {
-    it.each`
-      enabledFeatures       | description
-      ${['DUMMY']}          | ${'flag is explicitly listed'}
-      ${['DUMMY', 'OTHER']} | ${'flag is among multiple flags'}
-      ${['*']}              | ${'wildcard is present'}
-      ${['*', 'DUMMY']}     | ${'wildcard is mixed with flag'}
-    `('should return true when $description', ({ enabledFeatures }) => {
+  it.each([
+    {
+      enabledFeatures: ['DUMMY'],
+      expected: true,
+      description: 'flag is explicitly listed',
+    },
+    {
+      enabledFeatures: ['DUMMY', 'OTHER'],
+      expected: true,
+      description: 'flag is among multiple flags',
+    },
+    {
+      enabledFeatures: ['*'],
+      expected: true,
+      description: 'wildcard is present',
+    },
+    {
+      enabledFeatures: ['*', 'DUMMY'],
+      expected: true,
+      description: 'wildcard is mixed with flag',
+    },
+    {
+      enabledFeatures: [],
+      expected: false,
+      description: 'list is empty',
+    },
+    {
+      enabledFeatures: ['OTHER'],
+      expected: false,
+      description: 'flag is not in list',
+    },
+    {
+      enabledFeatures: undefined,
+      expected: false,
+      description: 'config returns undefined',
+    },
+  ])(
+    'should return $expected when $description',
+    ({ enabledFeatures, expected }) => {
       vi.mocked(config.get).mockReturnValue(enabledFeatures);
-      expect(isFeatureEnabled(FeatureFlag.Dummy)).toBe(true);
-    });
-  });
-
-  describe('when feature is not enabled', () => {
-    it.each`
-      enabledFeatures | description
-      ${[]}           | ${'list is empty'}
-      ${['OTHER']}    | ${'flag is not in list'}
-      ${undefined}    | ${'config returns undefined'}
-    `(
-      'should throw ForbiddenAccess when $description',
-      ({ enabledFeatures }) => {
-        vi.mocked(config.get).mockReturnValue(enabledFeatures);
-        expect(() => isFeatureEnabled(FeatureFlag.Dummy)).toThrow(
-          "Feature 'DUMMY' is not enabled."
-        );
-      }
-    );
-  });
+      expect(isFeatureEnabled(FeatureFlag.Dummy)).toBe(expected);
+    }
+  );
 });

--- a/apps/backend/src/utils/feature-flag.util.ts
+++ b/apps/backend/src/utils/feature-flag.util.ts
@@ -1,7 +1,6 @@
 import config from 'config';
 import { FeatureFlag } from '../__generated__/resolvers-types';
 import { logApp } from './app-logger.util';
-import { ForbiddenAccess } from './error/error.util';
 
 export const resolveFeatureFlags = (
   enabledFeatures: string[]
@@ -23,14 +22,7 @@ export const resolveFeatureFlags = (
   });
 };
 
-export const isFeatureEnabled = (requiredFlag: FeatureFlag) => {
-  const isEnabled = (config.get<string[]>('enabled_features') ?? []).some(
-    (flag) => ['*', requiredFlag].includes(flag)
+export const isFeatureEnabled = (requiredFlag: FeatureFlag): boolean =>
+  (config.get<string[]>('enabled_features') ?? []).some((flag) =>
+    ['*', requiredFlag].includes(flag)
   );
-
-  if (!isEnabled) {
-    throw ForbiddenAccess(`Feature '${requiredFlag}' is not enabled.`);
-  }
-
-  return true;
-};

--- a/apps/e2e/tests/tests_files/public/redirections.spec.ts
+++ b/apps/e2e/tests/tests_files/public/redirections.spec.ts
@@ -26,10 +26,12 @@ test.describe('Public redirections', () => {
       await expect(page.locator('#hubspot-form')).toBeAttached();
     });
 
-    await test.step('should navigate user to login page from a public page', async () => {
+    await test.step('should navigate user to auth provider from a public page', async () => {
       await cyberSecurityPage.navigateTo();
       await cyberSecurityPage.clickOnSignIn();
-      await loginPage.assertCurrentPage();
+      await page.waitForURL((url) => !url.pathname.startsWith('/en'), {
+        timeout: 5000,
+      });
     });
 
     await test.step('should navigate user to sign up page from a public page', async () => {
@@ -37,6 +39,12 @@ test.describe('Public redirections', () => {
       await cyberSecurityPage.clickOnSignUp();
       await page.waitForURL('**/sign-up**');
       await expect(page.locator('#hubspot-form')).toBeAttached();
+    });
+
+    await test.step('should navigate user to login page from sign up page', async () => {
+      await page.goto('/sign-up');
+      await page.getByRole('link', { name: /login with local/i }).click();
+      await loginPage.assertCurrentPage();
     });
 
     await test.step('should log in user and redirect him to home', async () => {
@@ -49,19 +57,10 @@ test.describe('Public redirections', () => {
       await cyberSecurityPage.assertCurrentPage();
     });
 
-    await test.step('should redirect user on home when user is connected and wants to sign in', async () => {
-      await cyberSecurityPage.clickOnSignIn();
-      await homePage.assertCurrentPage();
-    });
-
     await test.step('should redirect user to public pages when user logs out', async () => {
+      await homePage.navigateTo();
       await loginPage.logout();
       await cyberSecurityPage.assertCurrentPage();
-    });
-
-    await test.step('should navigate user to login page when user clicks on sign in', async () => {
-      await cyberSecurityPage.clickOnSignIn();
-      await loginPage.assertCurrentPage();
     });
 
     await test.step('should redirect to specified page after sign in', async () => {

--- a/apps/e2e/tests/tests_files/public/redirections.spec.ts
+++ b/apps/e2e/tests/tests_files/public/redirections.spec.ts
@@ -20,9 +20,10 @@ test.describe('Public redirections', () => {
   test('should redirect user between public pages and login page', async ({
     page,
   }) => {
-    await test.step('should redirect user to login page if unlogged', async () => {
+    await test.step('should redirect user to sign up page if unlogged', async () => {
       await homePage.navigateTo();
-      await loginPage.assertCurrentPage();
+      await page.waitForURL('**/sign-up**');
+      await expect(page.locator('#hubspot-form')).toBeAttached();
     });
 
     await test.step('should navigate user to login page from a public page', async () => {
@@ -64,7 +65,8 @@ test.describe('Public redirections', () => {
     });
 
     await test.step('should redirect to specified page after sign in', async () => {
-      await page.goto('/app/manage/user');
+      const redirectParam = encodeURIComponent(btoa('/app/manage/user'));
+      await page.goto(`/login?redirect=${redirectParam}`);
       await loginPage.login();
       await userPage.assertCurrentPage();
     });

--- a/apps/frontend/app/(application)/app/layout.tsx
+++ b/apps/frontend/app/(application)/app/layout.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@graphql/generated';
 import * as React from 'react';
 
 import '@styles/globals.css';
@@ -23,6 +22,7 @@ import meLoaderQueryNode, {
   meLoaderQuery,
   meLoaderQuery$data,
 } from '@generated/meLoaderQuery.graphql';
+import { FeatureFlag } from '@graphql/generated';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';

--- a/apps/frontend/app/(application)/app/layout.tsx
+++ b/apps/frontend/app/(application)/app/layout.tsx
@@ -66,8 +66,6 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
     );
   }
 
-
-
   return (
     <RelayProvider>
       <ReactQueryProvider>

--- a/apps/frontend/app/(application)/app/layout.tsx
+++ b/apps/frontend/app/(application)/app/layout.tsx
@@ -16,7 +16,7 @@ import { TryFiligranProductsBanner } from '@/components/service/trial-instances/
 import { RelayProvider } from '@/relay/relay-provider';
 import { getMetadataBase } from '@/utils/metadata';
 import { APP_PATH } from '@/utils/path/constant';
-import { buildLoginRedirect } from '@/utils/redirect';
+import { buildLoginRedirect, buildSignupRedirect } from '@/utils/redirect';
 import { isFeatureEnabled } from '@/utils/settings.service';
 import { meContext_fragment$data } from '@generated/meContext_fragment.graphql';
 import meLoaderQueryNode, {
@@ -55,12 +55,18 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
       {}
     );
 
+  const isHomePageV2Enabled = await isFeatureEnabled(FeatureFlag.HomePageV2);
+
   const me = meData.me as unknown as meContext_fragment$data;
   if (!me) {
-    redirect(buildLoginRedirect(pathname));
+    redirect(
+      isHomePageV2Enabled
+        ? buildSignupRedirect(pathname)
+        : buildLoginRedirect(pathname)
+    );
   }
 
-  const isHomePageV2Enabled = await isFeatureEnabled(FeatureFlag.HomePageV2);
+
 
   return (
     <RelayProvider>

--- a/apps/frontend/app/(public)/[locale]/layout.tsx
+++ b/apps/frontend/app/(public)/[locale]/layout.tsx
@@ -66,7 +66,7 @@ const RootLayout = async ({
                     asChild
                     variant="outline"
                     className="whitespace-nowrap border-primary text-primary bg-primary/10">
-                    <Link href={`/login`}>{t('PublicLayout.Login')}</Link>
+                    <Link href="/auth/oidc">{t('PublicLayout.Login')}</Link>
                   </Button>
                   <Button
                     asChild

--- a/apps/frontend/app/sign-up/page.tsx
+++ b/apps/frontend/app/sign-up/page.tsx
@@ -4,15 +4,14 @@ import { FeatureFlag } from '@graphql/generated';
 import '@styles/globals.css';
 
 import SignUp from '@/components/signup/SignUp';
-import serverPortalApiFetch from '@/relay/server-portal-api-fetch';
+import {
+  getAuthenticatedGraphqlClient,
+  UnauthenticatedError,
+} from '@/lib/graphql-client';
 import { getMetadataBase } from '@/utils/metadata';
 import { APP_PATH } from '@/utils/path/constant';
-import { isFeatureEnabled } from '@/utils/settings.service';
-import { meContext_fragment$data } from '@generated/meContext_fragment.graphql';
-import meLoaderQueryNode, {
-  meLoaderQuery,
-  meLoaderQuery$data,
-} from '@generated/meLoaderQuery.graphql';
+import { hasLocalProvider, isFeatureEnabled } from '@/utils/settings.service';
+import { useMeCheckQuery } from '@graphql/generated';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
@@ -32,24 +31,24 @@ const Page = async () => {
   if (!isHomePageV2Enabled) {
     notFound();
   }
-
   try {
-    // @ts-expect-error
-    const { data: meData }: { data: meLoaderQuery$data } =
-      await serverPortalApiFetch<typeof meLoaderQueryNode, meLoaderQuery>(
-        meLoaderQueryNode,
-        {}
-      );
+    const client = await getAuthenticatedGraphqlClient();
+    const data = await useMeCheckQuery.fetcher(client)();
 
-    const me = meData.me as unknown as meContext_fragment$data;
-    if (me) {
+    if (data.me) {
       redirect(`/${APP_PATH}`);
     }
   } catch (_error) {
-    // If user is not authenticated or API is unreachable, show signup form
+    if (_error instanceof UnauthenticatedError) {
+      // User is not authenticated — show signup form
+    } else {
+      throw _error;
+    }
   }
 
-  return <SignUp />;
+  const showLocalLogin = await hasLocalProvider();
+
+  return <SignUp showLocalLogin={showLocalLogin} />;
 };
 
 export default Page;

--- a/apps/frontend/app/sign-up/page.tsx
+++ b/apps/frontend/app/sign-up/page.tsx
@@ -1,6 +1,5 @@
 import '@/components/signup/SignUp.css';
 import '@filigran/ui/theme.css';
-import { FeatureFlag } from '@graphql/generated';
 import '@styles/globals.css';
 
 import SignUp from '@/components/signup/SignUp';
@@ -11,7 +10,7 @@ import {
 import { getMetadataBase } from '@/utils/metadata';
 import { APP_PATH } from '@/utils/path/constant';
 import { hasLocalProvider, isFeatureEnabled } from '@/utils/settings.service';
-import { useMeCheckQuery } from '@graphql/generated';
+import { FeatureFlag, useMeCheckQuery } from '@graphql/generated';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -2718,6 +2718,11 @@ export type NewestDocumentsQueryQueryVariables = Exact<{
 
 export type NewestDocumentsQueryQuery = { __typename?: 'Query', newestDocuments: Array<{ __typename?: 'Connector', verified: boolean, manager_supported: boolean, id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'CsvFeed', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'CustomDashboard', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'CustomView', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'DefaultDocument', id: string, name: string | null, short_description: string | null, type: string, active: boolean, slug: string | null, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'IntegrationHack', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'OpenAEVScenario', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'OpenCTIPlaybook', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'RssFeed', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'Stream', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'TaxiiFeed', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null } | { __typename?: 'ThirdPartyIntegration', id: string, name: string, short_description: string | null, type: string, active: boolean, slug: string, service_instance_id: any | null, children_documents: Array<{ __typename?: 'ShareableResource', id: string, image_type: DocumentImageType | null }> | null, use_cases: Array<{ __typename?: 'UseCase', id: string, name: string }> | null }> };
 
+export type MeCheckQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MeCheckQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string } | null };
+
 export type OrganizationSubscribedServicesBreadcrumbQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -2965,6 +2970,59 @@ export const useInfiniteNewestDocumentsQueryQuery = <
 useInfiniteNewestDocumentsQueryQuery.getKey = (variables: NewestDocumentsQueryQueryVariables) => ['NewestDocumentsQuery.infinite', variables];
 useInfiniteNewestDocumentsQueryQuery.getRootKey = () => ['NewestDocumentsQuery.infinite'] as const;
 useNewestDocumentsQueryQuery.fetcher = (client: GraphQLClient, variables: NewestDocumentsQueryQueryVariables, headers?: RequestInit['headers']) => fetcher<NewestDocumentsQueryQuery, NewestDocumentsQueryQueryVariables>(client, NewestDocumentsQueryDocument, variables, headers);
+
+export const MeCheckDocument = `
+    query meCheck {
+  me {
+    id
+  }
+}
+    `;
+
+export const useMeCheckQuery = <
+      TData = MeCheckQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables?: MeCheckQueryVariables,
+      options?: Omit<UseQueryOptions<MeCheckQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<MeCheckQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useQuery<MeCheckQuery, TError, TData>(
+      {
+    queryKey: variables === undefined ? ['meCheck'] : ['meCheck', variables],
+    queryFn: fetcher<MeCheckQuery, MeCheckQueryVariables>(client, MeCheckDocument, variables, headers),
+    ...options
+  }
+    )};
+
+useMeCheckQuery.getKey = (variables?: MeCheckQueryVariables) => variables === undefined ? ['meCheck'] : ['meCheck', variables];
+useMeCheckQuery.getRootKey = () => ['meCheck'] as const;
+export const useInfiniteMeCheckQuery = <
+      TData = InfiniteData<MeCheckQuery>,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: MeCheckQueryVariables,
+      options: Omit<UseInfiniteQueryOptions<MeCheckQuery, TError, TData>, 'queryKey'> & { queryKey?: UseInfiniteQueryOptions<MeCheckQuery, TError, TData>['queryKey'] },
+      headers?: RequestInit['headers']
+    ) => {
+    
+    return useInfiniteQuery<MeCheckQuery, TError, TData>(
+      (() => {
+    const { queryKey: optionsQueryKey, ...restOptions } = options;
+    return {
+      queryKey: optionsQueryKey ?? variables === undefined ? ['meCheck.infinite'] : ['meCheck.infinite', variables],
+      queryFn: (metaData) => fetcher<MeCheckQuery, MeCheckQueryVariables>(client, MeCheckDocument, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
+      ...restOptions
+    }
+  })()
+    )};
+
+useInfiniteMeCheckQuery.getKey = (variables?: MeCheckQueryVariables) => variables === undefined ? ['meCheck.infinite'] : ['meCheck.infinite', variables];
+useInfiniteMeCheckQuery.getRootKey = () => ['meCheck.infinite'] as const;
+useMeCheckQuery.fetcher = (client: GraphQLClient, variables?: MeCheckQueryVariables, headers?: RequestInit['headers']) => fetcher<MeCheckQuery, MeCheckQueryVariables>(client, MeCheckDocument, variables, headers);
 
 export const OrganizationSubscribedServicesBreadcrumbDocument = `
     query OrganizationSubscribedServicesBreadcrumb($id: ID!) {

--- a/apps/frontend/graphql/me/me-check.query.graphql
+++ b/apps/frontend/graphql/me/me-check.query.graphql
@@ -1,0 +1,5 @@
+query meCheck {
+  me {
+    id
+  }
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -425,6 +425,7 @@
     "Subtitle": "XTM Hub, Filigran Academy and Live Demo.",
     "AlreadyHaveAccount": "Already have an account?",
     "LogIn": "Log in",
+    "LoginWithLocal": "Login with local",
     "MadeBy": "Made by",
     "WelcomeTitle": "Welcome to XTM Hub",
     "WelcomeSubtitle": "Extend and scale your XTM Platform"

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -425,6 +425,7 @@
     "Subtitle": "XTM Hub, Filigran Academy et démo en direct.",
     "AlreadyHaveAccount": "Vous avez déjà un compte ?",
     "LogIn": "Se connecter",
+    "LoginWithLocal": "Se connecter en local",
     "MadeBy": "Fait par",
     "WelcomeTitle": "Bienvenue sur XTM Hub",
     "WelcomeSubtitle": "Étendez et dimensionnez votre plateforme XTM"

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -425,6 +425,7 @@
     "Subtitle": "XTM Hub、Filigran Academy、ライブデモ。",
     "AlreadyHaveAccount": "すでにアカウントをお持ちですか？",
     "LogIn": "ログイン",
+    "LoginWithLocal": "ローカルでログイン",
     "MadeBy": "制作",
     "WelcomeTitle": "XTM Hubへようこそ",
     "WelcomeSubtitle": "XTMプラットフォームを拡張・スケール"

--- a/apps/frontend/src/components/AppContext.tsx
+++ b/apps/frontend/src/components/AppContext.tsx
@@ -15,7 +15,7 @@ interface AppProps {
   children: React.ReactNode;
 }
 
-const THEME_SWITCHABLE_PATHS = [`/${APP_PATH}`, '/login'];
+const THEME_SWITCHABLE_PATHS = [`/${APP_PATH}`, '/login', '/sign-up'];
 
 const isThemeSwitchablePath = (pathname: string) => {
   return THEME_SWITCHABLE_PATHS.some(

--- a/apps/frontend/src/components/login/LoginLayout.tsx
+++ b/apps/frontend/src/components/login/LoginLayout.tsx
@@ -5,18 +5,34 @@ import LoginTitleForm from '@/components/login/LoginTitle';
 import { PlatformProviderButton } from '@/components/login/PlatformProviderButton';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
 import useDecodedQuery from '@/hooks/use-decoded-query';
+import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
 import { useToast } from '@filigran/ui/clients';
+import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
 import { useTranslations } from 'next-intl';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 
 export const LoginLayout = ({}) => {
   const { settings } = useContext(SettingsContext);
+  const isHomePageV2Enabled = useIsFeatureEnabled(FeatureFlagEnum.HOME_PAGE_V2);
+  const router = useRouter();
 
-  const { error } = useDecodedQuery();
+  const { error, redirect } = useDecodedQuery();
   const currentPath = usePathname();
   const { toast } = useToast();
   const t = useTranslations();
+
+  const localProvider = settings?.platform_providers?.find(
+    (p) => p.provider === 'local'
+  );
+
+  useEffect(() => {
+    if (isHomePageV2Enabled && !localProvider) {
+      const target = redirect ? `/sign-up?redirect=${redirect}` : '/sign-up';
+      router.replace(target);
+    }
+  }, [isHomePageV2Enabled, localProvider, redirect, router]);
+
   useEffect(() => {
     if (error) {
       toast({
@@ -26,6 +42,11 @@ export const LoginLayout = ({}) => {
       });
     }
   }, [currentPath, error, t, toast]);
+
+  if (isHomePageV2Enabled && !localProvider) {
+    return null;
+  }
+
   return (
     <main className="absolute inset-0 z-0 m-auto flex max-w-[450px] flex-col justify-center">
       <TestEnvBanner />
@@ -33,16 +54,18 @@ export const LoginLayout = ({}) => {
         <LoginTitleForm />
         <div className="space-y-l mt-l w-full flex flex-col items-center">
           <LoginMessage />
-          {settings?.platform_providers?.map((platformProvider) =>
-            platformProvider.provider === 'local' ? (
-              <LoginForm key={platformProvider.provider} />
-            ) : (
-              <PlatformProviderButton
-                key={platformProvider.provider}
-                platformProvider={platformProvider}
-              />
-            )
-          )}
+          {isHomePageV2Enabled
+            ? localProvider && <LoginForm />
+            : settings?.platform_providers?.map((platformProvider) =>
+                platformProvider.provider === 'local' ? (
+                  <LoginForm key={platformProvider.provider} />
+                ) : (
+                  <PlatformProviderButton
+                    key={platformProvider.provider}
+                    platformProvider={platformProvider}
+                  />
+                )
+              )}
         </div>
       </div>
     </main>

--- a/apps/frontend/src/components/login/LoginLayout.tsx
+++ b/apps/frontend/src/components/login/LoginLayout.tsx
@@ -7,14 +7,14 @@ import { SettingsContext } from '@/components/settings/EnvPortalContext';
 import useDecodedQuery from '@/hooks/use-decoded-query';
 import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
 import { useToast } from '@filigran/ui/clients';
-import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
+import { FeatureFlag } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
 import { usePathname, useRouter } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 
 export const LoginLayout = ({}) => {
   const { settings } = useContext(SettingsContext);
-  const isHomePageV2Enabled = useIsFeatureEnabled(FeatureFlagEnum.HOME_PAGE_V2);
+  const isHomePageV2Enabled = useIsFeatureEnabled(FeatureFlag.HomePageV2);
   const router = useRouter();
 
   const { error, redirect } = useDecodedQuery();

--- a/apps/frontend/src/components/signup/SignUp.tsx
+++ b/apps/frontend/src/components/signup/SignUp.tsx
@@ -5,14 +5,23 @@ import FiligranLogoDark from '@public/filigran_logo_dark.svg';
 import SchemeXtmHub from '@public/scheme_xtm_hub_account_creation.svg';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 const HUBSPOT_PORTAL_ID = '26791207';
 const HUBSPOT_FORM_ID = '25cf9561-13c0-4eda-bde2-be099e38438b';
 const HUBSPOT_REGION = 'eu1';
 
-const SignUp = () => {
+const SignUp = ({ showLocalLogin = false }: { showLocalLogin?: boolean }) => {
   const t = useTranslations('SignUpPage');
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect');
+  const oidcHref = redirect
+    ? `/auth/oidc?redirect=${encodeURIComponent(redirect)}`
+    : '/auth/oidc';
+  const loginHref = redirect
+    ? `/login?redirect=${encodeURIComponent(redirect)}`
+    : '/login';
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -92,11 +101,18 @@ const SignUp = () => {
           <p className="text-muted-foreground flex items-center gap-2">
             {t('AlreadyHaveAccount')}
             <Link
-              href="/auth/oidc"
+              href={oidcHref}
               className="text-primary underline">
               {t('LogIn')}
             </Link>
           </p>
+          {showLocalLogin && (
+            <Link
+              href={loginHref}
+              className="text-primary underline">
+              {t('LoginWithLocal')}
+            </Link>
+          )}
           <div className="flex items-center gap-1 text-muted-foreground/20 text-xs">
             {t('MadeBy')}
             <FiligranLogo className="h-4 w-auto" />

--- a/apps/frontend/src/relay/server-portal-api-fetch.ts
+++ b/apps/frontend/src/relay/server-portal-api-fetch.ts
@@ -5,7 +5,7 @@ import {
 } from '@/relay/environment/fetch-fn';
 import { buildLoginRedirect, buildSignupRedirect } from '@/utils/redirect';
 import { isFeatureEnabled } from '@/utils/settings.service';
-import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
+import { FeatureFlag } from '@graphql/generated';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { GraphQLResponse, OperationType, VariablesOf } from 'relay-runtime';
@@ -36,7 +36,7 @@ export default async function serverPortalApiFetch<
     options,
   }).catch(async (e: unknown) => {
     if (e instanceof UnauthenticatedError) {
-      const homePageV2 = await isFeatureEnabled(FeatureFlagEnum.HOME_PAGE_V2);
+      const homePageV2 = await isFeatureEnabled(FeatureFlag.HomePageV2);
       redirect(
         homePageV2
           ? buildSignupRedirect(pathname)

--- a/apps/frontend/src/relay/server-portal-api-fetch.ts
+++ b/apps/frontend/src/relay/server-portal-api-fetch.ts
@@ -3,7 +3,9 @@ import {
   networkFetch,
   UnauthenticatedError,
 } from '@/relay/environment/fetch-fn';
-import { buildLoginRedirect } from '@/utils/redirect';
+import { buildLoginRedirect, buildSignupRedirect } from '@/utils/redirect';
+import { isFeatureEnabled } from '@/utils/settings.service';
+import { FeatureFlagEnum } from '@generated/models/FeatureFlag.enum';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { GraphQLResponse, OperationType, VariablesOf } from 'relay-runtime';
@@ -32,9 +34,14 @@ export default async function serverPortalApiFetch<
     cookieList,
     cache: 'force-cache', //force cache on server-side, can be override by adding options
     options,
-  }).catch((e: unknown) => {
+  }).catch(async (e: unknown) => {
     if (e instanceof UnauthenticatedError) {
-      redirect(buildLoginRedirect(pathname));
+      const homePageV2 = await isFeatureEnabled(FeatureFlagEnum.HOME_PAGE_V2);
+      redirect(
+        homePageV2
+          ? buildSignupRedirect(pathname)
+          : buildLoginRedirect(pathname)
+      );
     }
     throw e;
   });

--- a/apps/frontend/src/utils/redirect.ts
+++ b/apps/frontend/src/utils/redirect.ts
@@ -18,6 +18,18 @@ export const buildLoginRedirect = (
 };
 
 /**
+ * Builds a safe signup redirect URL with the current pathname base64-encoded
+ * as a query param. Used when HOME_PAGE_V2 feature flag is enabled.
+ * Returns '/sign-up' when no pathname is provided.
+ */
+export const buildSignupRedirect = (
+  pathname: string | null | undefined
+): string => {
+  if (!pathname) return '/sign-up';
+  return `/sign-up?redirect=${encodeURIComponent(btoa(pathname))}`;
+};
+
+/**
  * Decodes a base64-encoded redirect parameter and validates it is a safe
  * relative path to prevent open redirect attacks (CWE-601).
  * Logs a warning when the param is unsafe or malformed.

--- a/apps/frontend/src/utils/settings.service.ts
+++ b/apps/frontend/src/utils/settings.service.ts
@@ -6,30 +6,40 @@ import SettingsQuery, {
 import { FeatureFlag } from '@graphql/generated';
 
 let cachedFeatureFlags: string[];
+let cachedProviders: ReadonlyArray<{ provider: string }>;
 
 export interface SettingsResponse {
   data: settingsQuery$data;
 }
 
+async function fetchSettings(): Promise<void> {
+  if (cachedFeatureFlags !== undefined) return;
+  try {
+    const response = (await serverPortalApiFetch<
+      typeof SettingsQuery,
+      settingsQuery
+    >(SettingsQuery, {}, { cache: 'force-cache' })) as SettingsResponse;
+    cachedFeatureFlags = [
+      ...(response.data?.settings?.platform_feature_flags || []),
+    ];
+    cachedProviders = response.data?.settings?.platform_providers ?? [];
+  } catch (error) {
+    console.error('Failed to fetch settings:', error);
+    cachedFeatureFlags = [];
+    cachedProviders = [];
+  }
+}
+
 export async function isFeatureEnabled(
   flagName: FeatureFlag
 ): Promise<boolean> {
-  if (cachedFeatureFlags === undefined) {
-    try {
-      const response = (await serverPortalApiFetch<
-        typeof SettingsQuery,
-        settingsQuery
-      >(SettingsQuery, {}, { cache: 'force-cache' })) as SettingsResponse;
-      cachedFeatureFlags = [
-        ...(response.data?.settings?.platform_feature_flags || []),
-      ];
-    } catch (error) {
-      console.error('Failed to fetch feature flags:', error);
-      cachedFeatureFlags = [];
-    }
-  }
-
-  return !!cachedFeatureFlags?.some((flag) =>
+  await fetchSettings();
+  return cachedFeatureFlags?.some((flag) =>
     [flagName as string].includes(flag)
   );
+}
+
+export async function hasLocalProvider(): Promise<boolean> {
+  await fetchSettings();
+  return cachedProviders.some((p) => p.provider === 'local');
 }


### PR DESCRIPTION
# Context
Signup page was implemented in the previous chunk. The goal of this chunk is to replace old login pages with new page

## How to test
Check that : 
- `auth0` log in is accessible through both the `Log in` header button and the `Sign up` page `Log in` link
- accessing a private page while logged out will redirect to the sign-up page, and login in will redirect you to the page you tried to access

**If there is a local prodiver :** 

- `/login` url only has the LoginForm,  `Login with local` link is present in the `Sign up` page


**If there is no local provider :**
- it should redirect users from `/login` url to `/signup` url
- redirect users to `/signup` page when they try to access an authenticated page without being logged in
- make sure users are redirected to app page when they’re logged in and access signup page

## Related issues

- Related to #2617

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.