### PR TITLE
ci: add development tag alias for prod images on main push (#2641)

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -452,6 +452,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             ${{ contains(github.ref, 'refs/tags/') && 'latest' }}
+            ${{ github.ref == 'refs/heads/main' && 'type=raw,value=development' || '' }}
 
       - name: Determine version
         id: version


### PR DESCRIPTION
AWX/K8s deployments still pull the 'development' tag. Keep publishing it as an alias of 'main' until infrastructure is updated.