### PR TITLE
feat(homepage): make homepage responsive for mobile (#2582)

### DIFF
--- a/apps/frontend/app/(public)/[locale]/layout.tsx
+++ b/apps/frontend/app/(public)/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { CookieSettingsLink } from '@/components/cookie-consent/CookieSettingsLink';
 import Copilot from '@/components/external/Copilot';
 import PublicMenu from '@/components/menu/PublicMenu';
+import { PublicMobileMenuButton } from '@/components/menu/PublicMobileMenuButton';
 import { ReactQueryProvider } from '@/components/ReactQueryProvider';
 import { PublicTryFiligranProductsBanner } from '@/components/service/trial-instances/banner/PublicTryFiligranProductsBanner';
 import { publicLocales, type PublicLocale } from '@/i18n/config';
@@ -58,14 +59,21 @@ const RootLayout = async ({
               <Link
                 href={`/${locale}`}
                 className={isHomePageV2Enabled ? 'md:hidden' : undefined}>
-                <LogoXTMDark className="text-primary mr-2 w-[10rem] h-auto py-l" />
+                <LogoXTMDark className="text-primary mr-2 h-8 w-auto" />
                 <span className="sr-only">XTM Hub by Filigran</span>
               </Link>
-              <Button
-                asChild
-                className="ml-auto whitespace-nowrap">
-                <Link href={`/login`}>{t('PublicLayout.SignIn')}</Link>
-              </Button>
+              <div className="ml-auto flex items-center gap-s">
+                <Button
+                  asChild
+                  className="whitespace-nowrap">
+                  <Link href={`/login`}>{t('PublicLayout.SignIn')}</Link>
+                </Button>
+                {isHomePageV2Enabled && (
+                  <div className="md:hidden">
+                    <PublicMobileMenuButton />
+                  </div>
+                )}
+              </div>
             </header>
             <main className="grow overflow-auto">
               <div className="container pt-l">{children}</div>

--- a/apps/frontend/app/(public)/[locale]/layout.tsx
+++ b/apps/frontend/app/(public)/[locale]/layout.tsx
@@ -69,7 +69,7 @@ const RootLayout = async ({
                   <Link href={`/login`}>{t('PublicLayout.SignIn')}</Link>
                 </Button>
                 {isHomePageV2Enabled && (
-                  <div className="md:hidden">
+                  <div className="md:hidden flex items-center">
                     <PublicMobileMenuButton />
                   </div>
                 )}
@@ -78,7 +78,7 @@ const RootLayout = async ({
             <main className="grow overflow-auto">
               <div className="container pt-l">{children}</div>
             </main>
-            <footer className="container text-muted-foreground">
+            <footer className="container text-muted-foreground max-md:mt-xxl">
               <div className="items-center justify-between flex flex-col md:flex-row w-full px-4 py-2 gap-l text-center">
                 <span className="text-xs">
                   <Link

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -300,6 +300,7 @@
   "GoToProd": "Go to production",
   "Header": {
     "BrandName": "Filigran",
+    "CloseMenu": "Close Menu",
     "OpenMenu": "Open Menu"
   },
   "HomePage": {

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -299,7 +299,8 @@
   },
   "GoToProd": "Go to production",
   "Header": {
-    "BrandName": "Filigran"
+    "BrandName": "Filigran",
+    "OpenMenu": "Open Menu"
   },
   "HomePage": {
     "Homepage": "Homepage",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -299,7 +299,8 @@
   },
   "GoToProd": "Allez sur la production",
   "Header": {
-    "BrandName": "Filigran"
+    "BrandName": "Filigran",
+    "OpenMenu": "Ouvrir le menu"
   },
   "HomePage": {
     "Homepage": "Page d'accueil",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -300,6 +300,7 @@
   "GoToProd": "Allez sur la production",
   "Header": {
     "BrandName": "Filigran",
+    "CloseMenu": "Fermer le menu",
     "OpenMenu": "Ouvrir le menu"
   },
   "HomePage": {

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -299,7 +299,8 @@
   },
   "GoToProd": "プロダクションへ",
   "Header": {
-    "BrandName": "Filigran"
+    "BrandName": "Filigran",
+    "OpenMenu": "メニューを開く"
   },
   "HomePage": {
     "Homepage": "ホームページ",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -300,6 +300,7 @@
   "GoToProd": "プロダクションへ",
   "Header": {
     "BrandName": "Filigran",
+    "CloseMenu": "メニューを閉じる",
     "OpenMenu": "メニューを開く"
   },
   "HomePage": {

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -11,10 +11,11 @@ import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
 import { cn } from '@/lib/utils';
 import { APP_PATH } from '@/utils/path/constant';
 
-import { MenuIcon } from '@filigran/icon';
+import { CloseIcon, MenuIcon } from '@filigran/icon';
 import { Avatar } from '@filigran/ui';
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetHeader,
   SheetTitle,
@@ -24,6 +25,7 @@ import { OrganizationCapabilityEnum } from '@generated/models/OrganizationCapabi
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
+import Logo from '@public/logo.svg';
 import { usePathname, useRouter } from 'next/navigation';
 import { useContext, useEffect, useState } from 'react';
 import { useMutation } from 'react-relay';
@@ -110,8 +112,22 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
             />
           </SheetTrigger>
           <SheetContent side="left">
-            <SheetHeader>
-              <SheetTitle>{t('Header.BrandName')}</SheetTitle>
+            <SheetHeader className="flex flex-row justify-between pl-l">
+              <div className="flex items-center gap-s">
+                <Logo
+                  className="h-8 w-8"
+                  aria-hidden={true}
+                />
+                <SheetTitle>{t('Header.BrandName')}</SheetTitle>
+              </div>
+              <SheetClose>
+                <CloseIcon
+                  aria-hidden={true}
+                  focusable={false}
+                  className="h-4 w-4 mr-xl"
+                />
+                <span className="sr-only">{t('Header.CloseMenu')}</span>
+              </SheetClose>
             </SheetHeader>
             <div className="flex flex-1 flex-col h-full justify-between">
               <NavigationApp open={true} />

--- a/apps/frontend/src/components/homepage/HomepageResourceCard.tsx
+++ b/apps/frontend/src/components/homepage/HomepageResourceCard.tsx
@@ -45,7 +45,7 @@ const HomepageResourceCard = ({
   const titlePaddingRight = computeTitlePaddingRight(iconCount);
 
   return (
-    <div className="overflow-hidden flex flex-col relative rounded bg-page-background hover:bg-hover">
+    <div className="overflow-hidden flex flex-col relative rounded bg-page-background hover:bg-hover max-w-75">
       <div className="absolute top-m right-m flex gap-xs z-10">
         <ResourceStatusIcons
           active={active}

--- a/apps/frontend/src/components/homepage/MostDeployedResources.tsx
+++ b/apps/frontend/src/components/homepage/MostDeployedResources.tsx
@@ -48,7 +48,7 @@ const MostDeployedResources = async ({ locale }: { locale: PublicLocale }) => {
     <section className="flex flex-col gap-l">
       <h2 className="text-xl leading-tight">{t('Title')}</h2>
       <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-l">
-        {resources.map((resource, index) => {
+        {resources.map((resource) => {
           const resourceType = resource.type as ShareableResourceType;
           const serviceSlug =
             SHAREABLE_RESOURCE_SERVICE_SLUG_MAPPING[resourceType];
@@ -73,11 +73,7 @@ const MostDeployedResources = async ({ locale }: { locale: PublicLocale }) => {
             resource.type !== ShareableResourceType.OPENCTI_INTEGRATION;
 
           return (
-            <li
-              key={resource.id}
-              className={
-                index === 3 ? 'block sm:block lg:hidden xl:block' : ''
-              }>
+            <li key={resource.id}>
               <HomepageResourceCard
                 key={resource.id}
                 name={resource.name ?? ''}

--- a/apps/frontend/src/components/homepage/MostDeployedResources.tsx
+++ b/apps/frontend/src/components/homepage/MostDeployedResources.tsx
@@ -47,7 +47,7 @@ const MostDeployedResources = async ({ locale }: { locale: PublicLocale }) => {
   return (
     <section className="flex flex-col gap-l">
       <h2 className="text-xl leading-tight">{t('Title')}</h2>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-l">
+      <ul className="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-l">
         {resources.map((resource) => {
           const resourceType = resource.type as ShareableResourceType;
           const serviceSlug =

--- a/apps/frontend/src/components/homepage/MostDeployedResources.tsx
+++ b/apps/frontend/src/components/homepage/MostDeployedResources.tsx
@@ -47,7 +47,7 @@ const MostDeployedResources = async ({ locale }: { locale: PublicLocale }) => {
   return (
     <section className="flex flex-col gap-l">
       <h2 className="text-xl leading-tight">{t('Title')}</h2>
-      <ul className="grid grid-cols-3 xl:grid-cols-4 gap-l">
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-l">
         {resources.map((resource, index) => {
           const resourceType = resource.type as ShareableResourceType;
           const serviceSlug =
@@ -75,7 +75,9 @@ const MostDeployedResources = async ({ locale }: { locale: PublicLocale }) => {
           return (
             <li
               key={resource.id}
-              className={index === 3 ? 'hidden xl:block' : ''}>
+              className={
+                index === 3 ? 'block sm:block lg:hidden xl:block' : ''
+              }>
               <HomepageResourceCard
                 key={resource.id}
                 name={resource.name ?? ''}

--- a/apps/frontend/src/components/homepage/XtmPlatform.tsx
+++ b/apps/frontend/src/components/homepage/XtmPlatform.tsx
@@ -6,7 +6,7 @@ const XtmPlatform = async () => {
   const t = await getTranslations('PublicHomePage.XtmPlatform');
 
   return (
-    <section className="grid grid-cols-2 gap-l items-center">
+    <section className="grid grid-cols-1 md:grid-cols-2 gap-l items-center">
       <div className="flex flex-col gap-l">
         <span className="text-primary txt-small font-semibold tracking-wide">
           {t('Label')}

--- a/apps/frontend/src/components/homepage/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.tsx
@@ -46,8 +46,8 @@ const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
   }));
 
   return (
-    <section className="grid grid-cols-[1fr_1fr] min-[1330px]:grid-cols-[3fr_2fr_auto] gap-l items-center bg-card border border-primary/30 rounded-lg px-xl py-4">
-      <div className="flex flex-col gap-l">
+    <section className="flex flex-col lg:flex-row gap-l items-center bg-card border border-primary/30 rounded-lg px-xl py-4">
+      <div className="flex flex-col gap-l flex-3">
         <h2 className="text-xl leading-tight">{t('Title')}</h2>
         <p className="text-muted-foreground text-sm min-[1330px]:text-xs">
           {t('Description')}
@@ -65,29 +65,33 @@ const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
         </div>
       </div>
 
-      <div className="hidden min-[1330px]:block relative h-24 mx-auto w-full rounded-lg overflow-hidden">
+      <div className="hidden min-[1330px]:block relative h-24 flex-2 rounded-lg overflow-hidden">
         <Image
           src="/xtm_roadmap_space.png"
           alt={t('ImageAlt')}
           fill
-          sizes="(max-width: 768px) 100vw, 33vw"
+          sizes="33vw"
           className="object-contain"
         />
       </div>
 
-      <div className="flex gap-l justify-end">
+      <div className="flex gap-l max-md:gap-m justify-center lg:justify-end">
         {roadmapStats.map(({ count, labelKey, bg, text }) => (
           <div
             key={labelKey}
             className="flex flex-col gap-xs">
-            <div className="flex items-center gap-s pr-8">
-              <div className="relative w-6 h-6 flex items-center justify-center shrink-0">
+            <div className="flex items-center gap-s max-md:gap-xs pr-8 max-md:pr-5">
+              <div className="relative w-6 h-6 max-md:w-5 max-md:h-5 flex items-center justify-center shrink-0">
                 <div
                   className={`absolute inset-0 ${bg} opacity-20 rounded-full`}
                 />
-                <span className={`relative z-10 text-sm ${text}`}>{count}</span>
+                <span
+                  className={`relative z-10 text-sm max-md:text-xs ${text}`}>
+                  {count}
+                </span>
               </div>
-              <span className={`text-m whitespace-nowrap ${text}`}>
+              <span
+                className={`text-m max-md:text-sm whitespace-nowrap ${text}`}>
                 {t(labelKey)}
               </span>
             </div>

--- a/apps/frontend/src/components/homepage/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.tsx
@@ -75,28 +75,28 @@ const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
         />
       </div>
 
-      <div className="flex gap-l max-md:gap-m justify-center lg:justify-end">
+      <div className="flex gap-l max-md:gap-m max-sm:gap-xs justify-center lg:justify-end">
         {roadmapStats.map(({ count, labelKey, bg, text }) => (
           <div
             key={labelKey}
-            className="flex flex-col gap-xs">
-            <div className="flex items-center gap-s max-md:gap-xs pr-8 max-md:pr-5">
-              <div className="relative w-6 h-6 max-md:w-5 max-md:h-5 flex items-center justify-center shrink-0">
+            className="flex flex-col gap-xs max-sm:gap-[2px]">
+            <div className="flex items-center gap-s max-md:gap-xs max-sm:gap-[4px] pr-8 max-md:pr-5 max-sm:pr-1">
+              <div className="relative w-6 h-6 max-md:w-5 max-md:h-5 max-sm:w-4 max-sm:h-4 flex items-center justify-center shrink-0">
                 <div
                   className={`absolute inset-0 ${bg} opacity-20 rounded-full`}
                 />
                 <span
-                  className={`relative z-10 text-sm max-md:text-xs ${text}`}>
+                  className={`relative z-10 text-sm max-md:text-xs max-sm:text-[10px] ${text}`}>
                   {count}
                 </span>
               </div>
               <span
-                className={`text-m max-md:text-sm whitespace-nowrap ${text}`}>
+                className={`text-m max-md:text-sm max-sm:text-xs whitespace-nowrap ${text}`}>
                 {t(labelKey)}
               </span>
             </div>
             <div
-              className={`h-0.5 mt-xs w-full ${bg} opacity-70 rounded-full`}
+              className={`h-0.5 mt-xs max-sm:mt-px w-full ${bg} opacity-70 rounded-full`}
             />
           </div>
         ))}

--- a/apps/frontend/src/components/menu/PublicMobileMenuButton.test.tsx
+++ b/apps/frontend/src/components/menu/PublicMobileMenuButton.test.tsx
@@ -6,6 +6,10 @@ import { usePathname } from 'next/navigation';
 import { describe, expect, it, vi } from 'vitest';
 import { PublicMobileMenuButton } from './PublicMobileMenuButton';
 
+vi.mock('@public/logo.svg', () => ({
+  default: () => <svg data-testid="logo" />,
+}));
+
 vi.mock('@/components/menu/PublicNavigation', () => ({
   default: () => (
     <div data-testid="public-navigation">

--- a/apps/frontend/src/components/menu/PublicMobileMenuButton.test.tsx
+++ b/apps/frontend/src/components/menu/PublicMobileMenuButton.test.tsx
@@ -1,0 +1,105 @@
+import testRender from '@/utils/test/test-render';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { describe, expect, it, vi } from 'vitest';
+import { PublicMobileMenuButton } from './PublicMobileMenuButton';
+
+vi.mock('@/components/menu/PublicNavigation', () => ({
+  default: () => (
+    <div data-testid="public-navigation">
+      <Link href="/en/some-page">Some page</Link>
+    </div>
+  ),
+}));
+
+describe('PublicMobileMenuButton', () => {
+  it('renders the trigger with a screen-reader label', () => {
+    testRender(<PublicMobileMenuButton />);
+
+    const srText = screen.getByText('Header.OpenMenu');
+    expect(srText).toBeInTheDocument();
+    expect(srText).toHaveClass('sr-only');
+  });
+
+  it('renders the menu icon trigger', () => {
+    testRender(<PublicMobileMenuButton />);
+
+    // The SheetTrigger wraps the icon; the sr-only span makes it accessible
+    expect(screen.getByText('Header.OpenMenu')).toBeInTheDocument();
+  });
+
+  it('opens the sheet and shows PublicNavigation when trigger is clicked', async () => {
+    const user = userEvent.setup();
+    testRender(<PublicMobileMenuButton />);
+
+    expect(screen.queryByTestId('public-navigation')).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByText('Header.OpenMenu').closest('button') ??
+        screen.getByText('Header.OpenMenu')
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('public-navigation')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the brand name in the sheet header when open', async () => {
+    const user = userEvent.setup();
+    testRender(<PublicMobileMenuButton />);
+
+    await user.click(
+      screen.getByText('Header.OpenMenu').closest('button') ??
+        screen.getByText('Header.OpenMenu')
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Header.BrandName')).toBeInTheDocument();
+    });
+  });
+
+  it('closes the sheet when the pathname changes', async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue('/en');
+
+    const { rerender } = testRender(<PublicMobileMenuButton />);
+
+    await user.click(
+      screen.getByText('Header.OpenMenu').closest('button') ??
+        screen.getByText('Header.OpenMenu')
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('public-navigation')).toBeInTheDocument();
+    });
+
+    vi.mocked(usePathname).mockReturnValue('/en/new-path');
+    rerender(<PublicMobileMenuButton />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('public-navigation')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes the sheet when a link inside the content is clicked', async () => {
+    const user = userEvent.setup();
+    testRender(<PublicMobileMenuButton />);
+
+    await user.click(
+      screen.getByText('Header.OpenMenu').closest('button') ??
+        screen.getByText('Header.OpenMenu')
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('public-navigation')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('link', { name: 'Some page' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('public-navigation')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
+++ b/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import PublicNavigation from '@/components/menu/PublicNavigation';
+import { MenuIcon } from '@filigran/icon';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@filigran/ui/clients';
+import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export const PublicMobileMenuButton = () => {
+  const [open, setOpen] = useState(false);
+  const currentPath = usePathname();
+  const t = useTranslations();
+  // Legitimate effect: close the menu on route change.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => setOpen(false), [currentPath]);
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={setOpen}>
+      <SheetTrigger>
+        <MenuIcon
+          aria-hidden={true}
+          focusable={false}
+          className="h-6 w-6"
+        />
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>{t('Header.BrandName')}</SheetTitle>
+        </SheetHeader>
+        <div
+          className="h-full overflow-y-auto"
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('a')) {
+              setOpen(false);
+            }
+          }}>
+          <PublicNavigation open={true} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
+++ b/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
@@ -26,6 +26,7 @@ export const PublicMobileMenuButton = () => {
       open={open}
       onOpenChange={setOpen}>
       <SheetTrigger>
+        <span className="sr-only">{t('Header.OpenMenu')}</span>
         <MenuIcon
           aria-hidden={true}
           focusable={false}

--- a/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
+++ b/apps/frontend/src/components/menu/PublicMobileMenuButton.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import PublicNavigation from '@/components/menu/PublicNavigation';
-import { MenuIcon } from '@filigran/icon';
+import { CloseIcon, MenuIcon } from '@filigran/icon';
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from '@filigran/ui/clients';
+import Logo from '@public/logo.svg';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -34,11 +36,24 @@ export const PublicMobileMenuButton = () => {
         />
       </SheetTrigger>
       <SheetContent side="left">
-        <SheetHeader>
-          <SheetTitle>{t('Header.BrandName')}</SheetTitle>
+        <SheetHeader className="flex flex-row justify-between pl-l">
+          <div className="flex items-center gap-s">
+            <Logo
+              className="h-8 w-8"
+              aria-hidden={true}
+            />
+            <SheetTitle>{t('Header.BrandName')}</SheetTitle>
+          </div>
+          <SheetClose>
+            <CloseIcon
+              aria-hidden={true}
+              focusable={false}
+              className="h-4 w-4 mr-xl"
+            />
+            <span className="sr-only">{t('Header.CloseMenu')}</span>
+          </SheetClose>
         </SheetHeader>
         <div
-          className="h-full overflow-y-auto"
           onClick={(e) => {
             if ((e.target as HTMLElement).closest('a')) {
               setOpen(false);


### PR DESCRIPTION
# Context
make the new home page responsive, especially for mobile, make the menu accessible in a button, like the current private menu

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Test responsivity on the public homepage, and that menu is accessible to navigate the public site.

## Related issues

- Related to #2582

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.