### PR TITLE
fix(roadmap): send reminder to correct product-managers group address (#2682)

### DIFF
--- a/apps/backend/src/modules/xtm-platform-roadmap/epic.app.reminder.test.ts
+++ b/apps/backend/src/modules/xtm-platform-roadmap/epic.app.reminder.test.ts
@@ -42,7 +42,7 @@ describe('epicApp.sendPublicRoadmapMonthlyReminder', () => {
     const [payload] = mailServiceMock.sendMail.mock.calls[0] as [
       { to: string; template: string; params: { roadmapLink: string } },
     ];
-    expect(payload.to).toBe('product.managers@filigran.io');
+    expect(payload.to).toBe('product-managers@filigran.io');
     expect(payload.template).toBe('public_roadmap_monthly_reminder');
     // buildServiceLink ran for real against the seeded roadmap instance.
     expect(payload.params.roadmapLink).toMatch(

--- a/apps/backend/src/modules/xtm-platform-roadmap/epic.app.ts
+++ b/apps/backend/src/modules/xtm-platform-roadmap/epic.app.ts
@@ -205,7 +205,7 @@ export const EpicApp = {
       serviceInstanceId: serviceInstance.id,
     });
     await sendMail({
-      to: 'product.managers@filigran.io',
+      to: 'product-managers@filigran.io',
       template: 'public_roadmap_monthly_reminder',
       params: { roadmapLink },
     });


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

The monthly public roadmap reminder (#2554) fires correctly but never reaches any recipient: the hardcoded recipient address had a typo — `product.managers@filigran.io` (dot) instead of the real distribution group `product-managers@filigran.io` (hyphen). SMTP returns `250` (accepted for relay) for the wrong address, so the failure was completely silent.


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

1. From `apps/backend`: `yarn test epic.app.reminder` → both tests green; the send assertion now expects `product-managers@filigran.io`.
2. `grep -rnF "product.managers@filigran.io" src` returns nothing; `grep -rnF "product-managers@filigran.io" src` returns the two corrected lines (code + test).


## Related issues

- Related to #2682

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.