### PR TITLE
fix(seo): allow Next.js internal assets in robots.txt (#2684)

### DIFF
--- a/apps/frontend/app/robots.ts
+++ b/apps/frontend/app/robots.ts
@@ -25,6 +25,9 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
             '/favicon.ico',
             '/apple-icon.png',
             '/favicon-*.png',
+            '/_next/static/',
+            '/_next/image',
+            '/_next/data/',
             ...localizedRootAllowRules,
             ...publicLocales.flatMap((locale) => [
               `/${locale}/cybersecurity-solutions`,


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

On the production domain, `robots.txt` uses a default-deny pattern (`Disallow: /`)
plus an allowlist. This blocks `/_next/*`, so crawlers (e.g. Googlebot) cannot
fetch the JS/CSS needed to render pages, which degrades indexing and ranking.

This PR allows the Next.js internal asset paths on the production domain so that
crawlers can render public pages correctly.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #2684

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.