### PR TITLE
fix(search): search documents also in use cases (#2631)

### DIFF
--- a/apps/backend/knexfile.ts
+++ b/apps/backend/knexfile.ts
@@ -469,6 +469,13 @@ export const applySearch = async <T extends object>(
             .whereRaw(`"${metaAlias}"."document_id" = "Document"."id"`)
             .andWhereILike(`${metaAlias}.value`, `%${searchTerm}%`);
         });
+        qb.orWhereExists(function () {
+          this.select(dbRaw('1'))
+            .from('Object_UseCase')
+            .join('UseCase', 'UseCase.id', '=', 'Object_UseCase.use_case_id')
+            .whereRaw('"Object_UseCase"."object_id" = "Document"."id"')
+            .andWhereILike('UseCase.name', `%${searchTerm}%`);
+        });
       }
       qb.orWhereILike(`${type}.${first}`, `%${normalizedSearchTerm}%`);
       others.forEach((i) =>

--- a/apps/backend/src/modules/document/domain/document.domain.test.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import {
   DocumentConnection,
   DocumentMetadataKeyCode,
@@ -24,6 +32,8 @@ import {
 import { TestHelper } from '../../../../tests/helper/test.helper';
 import { SERVICES, TEST_ORGANIZATIONS } from '../../../../tests/tests.const';
 import Document from '../../../model/kanel/public/Document';
+import { ObjectUseCaseObjectId } from '../../../model/kanel/public/ObjectUseCase';
+import { UseCaseId } from '../../../model/kanel/public/UseCase';
 import { ADMIN_UUID } from '../../../portal.const';
 import { DocumentUploadsHelper } from '../document.uploads.helper';
 import { DocumentDomain } from './document.domain';
@@ -893,5 +903,103 @@ describe('document domain', () => {
       expect(resultFound).toMatchObject({ id: doc.id });
       expect(resultNotFound).toBeUndefined();
     });
+  });
+
+  describe('search by use case name', () => {
+    let docWithThreatHunting: Document;
+    let docWithIncidentResponse: Document;
+    let threatHuntingUseCaseId: UseCaseId;
+    let incidentResponseUseCaseId: UseCaseId;
+
+    beforeAll(async () => {
+      // Use cases are not wiped by the outer beforeEach, so create them once.
+      const uc1 = await TestHelper.useCase.create({
+        name: 'threat-hunting-label',
+        color: '#ff0000',
+      });
+      const uc2 = await TestHelper.useCase.create({
+        name: 'incident-response-label',
+        color: '#0000ff',
+      });
+      threatHuntingUseCaseId = uc1.id;
+      incidentResponseUseCaseId = uc2.id;
+    });
+
+    beforeEach(async () => {
+      docWithThreatHunting = await TestHelper.document.create({
+        slug: 'doc-alpha-uc-search',
+        name: 'doc-alpha-uc-search',
+        active: true,
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      });
+      docWithIncidentResponse = await TestHelper.document.create({
+        slug: 'doc-beta-uc-search',
+        name: 'doc-beta-uc-search',
+        active: true,
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      });
+      await TestHelper.objectUseCase.insert([
+        {
+          object_id:
+            docWithThreatHunting.id as unknown as ObjectUseCaseObjectId,
+          use_case_id: threatHuntingUseCaseId,
+        },
+        {
+          object_id:
+            docWithIncidentResponse.id as unknown as ObjectUseCaseObjectId,
+          use_case_id: incidentResponseUseCaseId,
+        },
+      ]);
+    });
+
+    afterAll(async () => {
+      await TestHelper.objectUseCase.delete({
+        use_case_id: threatHuntingUseCaseId,
+      });
+      await TestHelper.objectUseCase.delete({
+        use_case_id: incidentResponseUseCaseId,
+      });
+      await TestHelper.useCase.delete({ id: threatHuntingUseCaseId });
+      await TestHelper.useCase.delete({ id: incidentResponseUseCaseId });
+    });
+
+    it.each`
+      description                                   | searchTerm                   | expectedCount | getExpectedId
+      ${'exact use case name match'}                | ${'threat-hunting-label'}    | ${1}          | ${() => docWithThreatHunting.id}
+      ${'partial use case name match'}              | ${'hunting-label'}           | ${1}          | ${() => docWithThreatHunting.id}
+      ${'case-insensitive use case name match'}     | ${'THREAT-HUNTING-LABEL'}    | ${1}          | ${() => docWithThreatHunting.id}
+      ${'no match returns no test documents'}       | ${'no-match-label-zzz'}      | ${0}          | ${() => null}
+      ${'other use case does not leak into result'} | ${'incident-response-label'} | ${1}          | ${() => docWithIncidentResponse.id}
+    `(
+      'should return $expectedCount test document(s) when searching "$searchTerm" ($description)',
+      async ({
+        searchTerm,
+        expectedCount,
+        getExpectedId,
+      }: {
+        searchTerm: string;
+        expectedCount: number;
+        getExpectedId: () => string | null;
+      }) => {
+        const result = await DocumentDomain.loadDocuments(
+          {
+            searchTerm,
+            first: 100,
+            orderBy: DocumentOrdering.CreatedAt,
+            orderMode: OrderingMode.Desc,
+          },
+          {}
+        );
+
+        const ids = result.edges.map((e) => e.node.id as string);
+
+        expect(ids).toHaveLength(expectedCount);
+        if (expectedCount > 0) {
+          expect(ids).toContain(getExpectedId());
+        }
+      }
+    );
   });
 });

--- a/apps/backend/tests/helper/test.helper.ts
+++ b/apps/backend/tests/helper/test.helper.ts
@@ -17,6 +17,7 @@ import ManifestRebuildQueue, {
   ManifestRebuildQueueMutator,
 } from '../../src/model/kanel/public/ManifestRebuildQueue';
 import ObjectUseCase, {
+  ObjectUseCaseInitializer,
   ObjectUseCaseMutator,
 } from '../../src/model/kanel/public/ObjectUseCase';
 import Organization, {
@@ -26,7 +27,10 @@ import Subscription, {
   SubscriptionId,
   SubscriptionMutator,
 } from '../../src/model/kanel/public/Subscription';
-import UseCase, { UseCaseMutator } from '../../src/model/kanel/public/UseCase';
+import UseCase, {
+  UseCaseInitializer,
+  UseCaseMutator,
+} from '../../src/model/kanel/public/UseCase';
 import { ManifestRebuildQueueStatus } from '../../src/modules/shareable-resource/manifest/manifest.consts';
 import { TEST_ORGANIZATIONS } from '../tests.const';
 import {
@@ -132,6 +136,12 @@ export const TestHelper = {
     },
   },
   useCase: {
+    create: async (data: UseCaseInitializer): Promise<UseCase> => {
+      const [useCase] = await db<UseCase>('UseCase')
+        .insert(data)
+        .returning('*');
+      return useCase!;
+    },
     delete: async (field: UseCaseMutator) => {
       await db<UseCase>('UseCase').where(field).del();
     },
@@ -143,6 +153,14 @@ export const TestHelper = {
     },
   },
   objectUseCase: {
+    insert: async (
+      data: ObjectUseCaseInitializer | ObjectUseCaseInitializer[]
+    ): Promise<void> => {
+      await db<ObjectUseCase>('Object_UseCase').insert(data);
+    },
+    delete: async (field: ObjectUseCaseMutator): Promise<void> => {
+      await db<ObjectUseCase>('Object_UseCase').where(field).del();
+    },
     load: async (
       field: ObjectUseCaseMutator
     ): Promise<ObjectUseCase | undefined> => {


### PR DESCRIPTION
# Context
when searching documents, we also want to search on use cases.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

search documents with a term that matches a use case. Check it is returned

## Related issues

- Related to #2631

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.