### PR TITLE
ci: add Husky setup reminder when lint job fails (#2712)

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -87,6 +87,13 @@ jobs:
         run: |
           yarn i18n:check
 
+      - name: Husky setup reminder
+        if: failure()
+        run: |
+          echo "::warning::This should have been caught locally by the Husky pre-commit hook."
+          echo "::warning::Since enableScripts is disabled in .yarnrc.yml, Husky is not set up automatically."
+          echo "::warning::Run 'yarn workspace @xtm-hub/backend prepare' to install the git hooks."
+
   build-images-tests:
     needs:
       - detect-changes


### PR DESCRIPTION
Closes #2712

When the `run-lint` CI job fails, a warning annotation now reminds developers that this should have been caught locally by Husky, and to run `yarn workspace @xtm-hub/backend prepare` to install git hooks (since `enableScripts: false` prevents automatic setup).