### PR TITLE
feat(homepage): add titles for products and implement private roadmap (#2664)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -324,9 +324,7 @@
       "ImageAlt": "XTM Platform illustration"
     },
     "XtmRoadmap": {
-      "Title": "XTM Platform Roadmap",
-      "OpenCTITitle": "OpenCTI Roadmap",
-      "OpenAEVTitle": "OpenAEV Roadmap",
+      "Title": "{product, select, opencti {OpenCTI Roadmap} openaev {OpenAEV Roadmap} other {XTM Platform Roadmap}}",
       "Description": "Explore what we're building, what's coming next, and where the XTM Platform is headed. Full transparency. No surprises.",
       "SeeMore": "See more",
       "ImageAlt": "XTM Platform Roadmap space illustration",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -325,6 +325,8 @@
     },
     "XtmRoadmap": {
       "Title": "XTM Platform Roadmap",
+      "OpenCTITitle": "OpenCTI Roadmap",
+      "OpenAEVTitle": "OpenAEV Roadmap",
       "Description": "Explore what we're building, what's coming next, and where the XTM Platform is headed. Full transparency. No surprises.",
       "SeeMore": "See more",
       "ImageAlt": "XTM Platform Roadmap space illustration",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -324,7 +324,8 @@
       "ImageAlt": "XTM Platform illustration"
     },
     "XtmRoadmap": {
-      "Title": "{product, select, opencti {OpenCTI Roadmap} openaev {OpenAEV Roadmap} other {XTM Platform Roadmap}}",
+      "Title": "XTM Platform Roadmap",
+      "TitleWithProduct": "{product} Roadmap",
       "Description": "Explore what we're building, what's coming next, and where the XTM Platform is headed. Full transparency. No surprises.",
       "SeeMore": "See more",
       "ImageAlt": "XTM Platform Roadmap space illustration",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -324,7 +324,8 @@
       "ImageAlt": "Illustration de la plateforme XTM"
     },
     "XtmRoadmap": {
-      "Title": "{product, select, opencti {Feuille de route OpenCTI} openaev {Feuille de route OpenAEV} other {Feuille de route de la plateforme XTM}}",
+      "Title": "XTM Platform Roadmap",
+      "TitleWithProduct": "{product} Roadmap",
       "Description": "Découvrez ce que nous développons, les prochaines étapes et l’orientation future de la plateforme XTM. Transparence totale. Pas de surprises.",
       "SeeMore": "En savoir plus",
       "ImageAlt": "Illustration de la feuille de route de la plateforme XTM",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -325,6 +325,8 @@
     },
     "XtmRoadmap": {
       "Title": "Feuille de route de la plateforme XTM",
+      "OpenCTITitle": "Feuille de route OpenCTI",
+      "OpenAEVTitle": "Feuille de route OpenAEV",
       "Description": "Découvrez ce que nous développons, les prochaines étapes et l’orientation future de la plateforme XTM. Transparence totale. Pas de surprises.",
       "SeeMore": "En savoir plus",
       "ImageAlt": "Illustration de la feuille de route de la plateforme XTM",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -324,9 +324,7 @@
       "ImageAlt": "Illustration de la plateforme XTM"
     },
     "XtmRoadmap": {
-      "Title": "Feuille de route de la plateforme XTM",
-      "OpenCTITitle": "Feuille de route OpenCTI",
-      "OpenAEVTitle": "Feuille de route OpenAEV",
+      "Title": "{product, select, opencti {Feuille de route OpenCTI} openaev {Feuille de route OpenAEV} other {Feuille de route de la plateforme XTM}}",
       "Description": "Découvrez ce que nous développons, les prochaines étapes et l’orientation future de la plateforme XTM. Transparence totale. Pas de surprises.",
       "SeeMore": "En savoir plus",
       "ImageAlt": "Illustration de la feuille de route de la plateforme XTM",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -324,7 +324,8 @@
       "ImageAlt": "XTM Platformの図解"
     },
     "XtmRoadmap": {
-      "Title": "{product, select, opencti {OpenCTIのロードマップ} openaev {OpenAEVのロードマップ} other {XTM Platformのロードマップ}}",
+      "Title": "XTM Platform Roadmap",
+      "TitleWithProduct": "{product} Roadmap",
       "Description": "現在開発中の機能、今後の予定、そしてXTM Platformの将来像をご覧ください。完全な透明性を確保し、予期せぬ事態は発生しません。",
       "SeeMore": "詳細を見る",
       "ImageAlt": "XTM Platformロードマップの宇宙イラスト",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -325,6 +325,8 @@
     },
     "XtmRoadmap": {
       "Title": "XTM Platformのロードマップ",
+      "OpenCTITitle": "OpenCTIのロードマップ",
+      "OpenAEVTitle": "OpenAEVのロードマップ",
       "Description": "現在開発中の機能、今後の予定、そしてXTM Platformの将来像をご覧ください。完全な透明性を確保し、予期せぬ事態は発生しません。",
       "SeeMore": "詳細を見る",
       "ImageAlt": "XTM Platformロードマップの宇宙イラスト",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -324,9 +324,7 @@
       "ImageAlt": "XTM Platformの図解"
     },
     "XtmRoadmap": {
-      "Title": "XTM Platformのロードマップ",
-      "OpenCTITitle": "OpenCTIのロードマップ",
-      "OpenAEVTitle": "OpenAEVのロードマップ",
+      "Title": "{product, select, opencti {OpenCTIのロードマップ} openaev {OpenAEVのロードマップ} other {XTM Platformのロードマップ}}",
       "Description": "現在開発中の機能、今後の予定、そしてXTM Platformの将来像をご覧ください。完全な透明性を確保し、予期せぬ事態は発生しません。",
       "SeeMore": "詳細を見る",
       "ImageAlt": "XTM Platformロードマップの宇宙イラスト",

--- a/apps/frontend/src/components/homepage/Homepage.utils.test.ts
+++ b/apps/frontend/src/components/homepage/Homepage.utils.test.ts
@@ -1,3 +1,4 @@
+import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import {
   DocumentImageType,
@@ -7,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   findLogoUrl,
   resolveHomepagePlatformIdentifiers,
+  resolveHomepageRoadmapResolution,
 } from './Homepage.utils';
 
 describe('resolveHomepagePlatformIdentifiers', () => {
@@ -112,4 +114,47 @@ describe('findLogoUrl', () => {
       );
     }
   );
+});
+
+describe('resolveHomepageRoadmapResolution', () => {
+  it.each([
+    {
+      identifiers: [],
+      expected: {
+        productFilter: undefined,
+        titleKey: 'Title',
+      },
+      description: 'returns default roadmap resolution for an empty array',
+    },
+    {
+      identifiers: [ServiceDefinitionIdentifier.OpenaevRegistration],
+      expected: {
+        productFilter: FiligranProductEnum.OPENAEV,
+        titleKey: 'OpenAEVTitle',
+      },
+      description: 'returns OAEV roadmap resolution for OAEV-only identifiers',
+    },
+    {
+      identifiers: [ServiceDefinitionIdentifier.OpenctiRegistration],
+      expected: {
+        productFilter: FiligranProductEnum.OPENCTI,
+        titleKey: 'OpenCTITitle',
+      },
+      description: 'returns OCTI roadmap resolution for OCTI-only identifiers',
+    },
+    {
+      identifiers: [
+        ServiceDefinitionIdentifier.OpenctiRegistration,
+        ServiceDefinitionIdentifier.OpenaevRegistration,
+      ],
+      expected: {
+        productFilter: undefined,
+        titleKey: 'Title',
+      },
+      description:
+        'returns default roadmap resolution when both platforms are registered',
+    },
+  ])('$description', ({ identifiers, expected }) => {
+    expect(resolveHomepageRoadmapResolution(identifiers)).toEqual(expected);
+  });
 });

--- a/apps/frontend/src/components/homepage/Homepage.utils.test.ts
+++ b/apps/frontend/src/components/homepage/Homepage.utils.test.ts
@@ -122,7 +122,7 @@ describe('resolveHomepageRoadmapResolution', () => {
       identifiers: [],
       expected: {
         productFilter: undefined,
-        titleKey: 'Title',
+        titleProduct: 'default',
       },
       description: 'returns default roadmap resolution for an empty array',
     },
@@ -130,7 +130,7 @@ describe('resolveHomepageRoadmapResolution', () => {
       identifiers: [ServiceDefinitionIdentifier.OpenaevRegistration],
       expected: {
         productFilter: FiligranProductEnum.OPENAEV,
-        titleKey: 'OpenAEVTitle',
+        titleProduct: 'openaev',
       },
       description: 'returns OAEV roadmap resolution for OAEV-only identifiers',
     },
@@ -138,7 +138,7 @@ describe('resolveHomepageRoadmapResolution', () => {
       identifiers: [ServiceDefinitionIdentifier.OpenctiRegistration],
       expected: {
         productFilter: FiligranProductEnum.OPENCTI,
-        titleKey: 'OpenCTITitle',
+        titleProduct: 'opencti',
       },
       description: 'returns OCTI roadmap resolution for OCTI-only identifiers',
     },
@@ -149,7 +149,7 @@ describe('resolveHomepageRoadmapResolution', () => {
       ],
       expected: {
         productFilter: undefined,
-        titleKey: 'Title',
+        titleProduct: 'default',
       },
       description:
         'returns default roadmap resolution when both platforms are registered',

--- a/apps/frontend/src/components/homepage/Homepage.utils.ts
+++ b/apps/frontend/src/components/homepage/Homepage.utils.ts
@@ -36,11 +36,11 @@ export const findLogoUrl = (
     : undefined;
 };
 
-export type HomepageRoadmapTitleKey = 'Title' | 'OpenCTITitle' | 'OpenAEVTitle';
+export type HomepageRoadmapTitleProduct = 'opencti' | 'openaev' | 'default';
 
 export type HomepageRoadmapResolution = {
   productFilter: FiligranProductEnum | undefined;
-  titleKey: HomepageRoadmapTitleKey;
+  titleProduct: HomepageRoadmapTitleProduct;
 };
 
 export const resolveHomepageRoadmapResolution = (
@@ -52,19 +52,19 @@ export const resolveHomepageRoadmapResolution = (
   if (platformIdentifier === PlatformIdentifierEnum.OPENAEV) {
     return {
       productFilter: FiligranProductEnum.OPENAEV,
-      titleKey: 'OpenAEVTitle',
+      titleProduct: 'openaev',
     };
   }
 
   if (platformIdentifier === PlatformIdentifierEnum.OPENCTI) {
     return {
       productFilter: FiligranProductEnum.OPENCTI,
-      titleKey: 'OpenCTITitle',
+      titleProduct: 'opencti',
     };
   }
 
   return {
     productFilter: undefined,
-    titleKey: 'Title',
+    titleProduct: 'default',
   };
 };

--- a/apps/frontend/src/components/homepage/Homepage.utils.ts
+++ b/apps/frontend/src/components/homepage/Homepage.utils.ts
@@ -1,4 +1,5 @@
 import { ServiceDefinitionIdentifierToPlatformIdentifier } from '@/components/registration/platform-identifier-mapping';
+import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
 import {
@@ -33,4 +34,37 @@ export const findLogoUrl = (
   return logo && resource.service_instance_id
     ? `/document/images/${String(resource.service_instance_id)}/${logo.id}`
     : undefined;
+};
+
+export type HomepageRoadmapTitleKey = 'Title' | 'OpenCTITitle' | 'OpenAEVTitle';
+
+export type HomepageRoadmapResolution = {
+  productFilter: FiligranProductEnum | undefined;
+  titleKey: HomepageRoadmapTitleKey;
+};
+
+export const resolveHomepageRoadmapResolution = (
+  registeredIdentifiers: ServiceDefinitionIdentifier[]
+): HomepageRoadmapResolution => {
+  const [platformIdentifier] =
+    resolveHomepagePlatformIdentifiers(registeredIdentifiers) ?? [];
+
+  if (platformIdentifier === PlatformIdentifierEnum.OPENAEV) {
+    return {
+      productFilter: FiligranProductEnum.OPENAEV,
+      titleKey: 'OpenAEVTitle',
+    };
+  }
+
+  if (platformIdentifier === PlatformIdentifierEnum.OPENCTI) {
+    return {
+      productFilter: FiligranProductEnum.OPENCTI,
+      titleKey: 'OpenCTITitle',
+    };
+  }
+
+  return {
+    productFilter: undefined,
+    titleKey: 'Title',
+  };
 };

--- a/apps/frontend/src/components/homepage/PrivateHomepage.test.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepage.test.tsx
@@ -1,16 +1,23 @@
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { ServiceDefinitionIdentifier } from '@graphql/generated';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockFetcher, mockNewestResources, mockMostDeployedResources } =
-  vi.hoisted(() => ({
-    mockFetcher: vi.fn(),
-    mockNewestResources: vi.fn(() => <div data-testid="newest-resources" />),
-    mockMostDeployedResources: vi.fn(() => (
-      <div data-testid="most-deployed-resources" />
-    )),
-  }));
+const {
+  mockFetcher,
+  mockNewestResources,
+  mockMostDeployedResources,
+  mockPrivateHomepageRoadmapSection,
+} = vi.hoisted(() => ({
+  mockFetcher: vi.fn(),
+  mockNewestResources: vi.fn(() => <div data-testid="newest-resources" />),
+  mockMostDeployedResources: vi.fn(() => (
+    <div data-testid="most-deployed-resources" />
+  )),
+  mockPrivateHomepageRoadmapSection: vi.fn(() => (
+    <div data-testid="private-homepage-roadmap-section" />
+  )),
+}));
 
 vi.mock('@graphql/generated', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@graphql/generated')>();
@@ -38,12 +45,18 @@ vi.mock('@/components/homepage/MostDeployedResources', () => ({
   default: mockMostDeployedResources,
 }));
 
+vi.mock('@/components/homepage/PrivateHomepageRoadmapSection', () => ({
+  default: mockPrivateHomepageRoadmapSection,
+}));
+
 import { PrivateHomepage } from './PrivateHomepage';
 
 describe('PrivateHomepage', () => {
   beforeEach(() => {
+    mockFetcher.mockClear();
     mockNewestResources.mockClear();
     mockMostDeployedResources.mockClear();
+    mockPrivateHomepageRoadmapSection.mockClear();
   });
 
   it('passes a single-item platformIdentifiers array when only one platform is registered', async () => {
@@ -61,6 +74,18 @@ describe('PrivateHomepage', () => {
     const element = await PrivateHomepage();
     render(element);
 
+    expect(mockFetcher).toHaveBeenCalledTimes(1);
+    expect(mockFetcher.mock.calls[0]?.[1]).toEqual({
+      input: { identifier: null, onlyActive: true, onlyTrial: null },
+    });
+    expect(mockPrivateHomepageRoadmapSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registeredIdentifiers: [
+          ServiceDefinitionIdentifier.OpenctiRegistration,
+        ],
+      }),
+      undefined
+    );
     expect(mockNewestResources).toHaveBeenCalledWith(
       expect.objectContaining({
         platformIdentifiers: [PlatformIdentifierEnum.OPENCTI],
@@ -94,6 +119,19 @@ describe('PrivateHomepage', () => {
     const element = await PrivateHomepage();
     render(element);
 
+    expect(mockFetcher).toHaveBeenCalledTimes(1);
+    expect(mockFetcher.mock.calls[0]?.[1]).toEqual({
+      input: { identifier: null, onlyActive: true, onlyTrial: null },
+    });
+    expect(mockPrivateHomepageRoadmapSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registeredIdentifiers: [
+          ServiceDefinitionIdentifier.OpenctiRegistration,
+          ServiceDefinitionIdentifier.OpenaevRegistration,
+        ],
+      }),
+      undefined
+    );
     expect(mockNewestResources).toHaveBeenCalledWith(
       expect.objectContaining({ platformIdentifiers: undefined }),
       undefined
@@ -114,6 +152,16 @@ describe('PrivateHomepage', () => {
     const element = await PrivateHomepage();
     render(element);
 
+    expect(mockFetcher).toHaveBeenCalledTimes(1);
+    expect(mockFetcher.mock.calls[0]?.[1]).toEqual({
+      input: { identifier: null, onlyActive: true, onlyTrial: null },
+    });
+    expect(mockPrivateHomepageRoadmapSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registeredIdentifiers: [],
+      }),
+      undefined
+    );
     expect(mockNewestResources).toHaveBeenCalledWith(
       expect.objectContaining({ platformIdentifiers: undefined }),
       undefined
@@ -122,5 +170,17 @@ describe('PrivateHomepage', () => {
       expect.objectContaining({ platformIdentifiers: undefined }),
       undefined
     );
+  });
+
+  it('renders roadmap section', async () => {
+    mockFetcher.mockReturnValue(() =>
+      Promise.resolve({
+        registeredPlatforms: [],
+      })
+    );
+
+    render(await PrivateHomepage());
+
+    expect(screen.getByTestId('private-homepage-roadmap-section')).toBeTruthy();
   });
 });

--- a/apps/frontend/src/components/homepage/PrivateHomepage.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepage.tsx
@@ -1,6 +1,7 @@
 import { resolveHomepagePlatformIdentifiers } from '@/components/homepage/Homepage.utils';
 import MostDeployedResources from '@/components/homepage/MostDeployedResources';
 import NewestResources from '@/components/homepage/NewestResources';
+import PrivateHomepageRoadmapSection from '@/components/homepage/PrivateHomepageRoadmapSection';
 import { defaultLocale, publicLocales } from '@/i18n/config';
 import { getAuthenticatedGraphqlClient } from '@/lib/graphql-client';
 import { useRegisteredPlatformsQuery } from '@graphql/generated';
@@ -17,16 +18,24 @@ export const PrivateHomepage = async () => {
   const registeredPlatformsData = await useRegisteredPlatformsQuery.fetcher(
     authenticatedClient,
     {
-      input: { identifier: null, onlyActive: null, onlyTrial: null },
+      input: { identifier: null, onlyActive: true, onlyTrial: null },
     }
   )();
 
+  const registeredIdentifiers = registeredPlatformsData.registeredPlatforms.map(
+    (platform) => platform.identifier
+  );
+
   const platformIdentifiers = resolveHomepagePlatformIdentifiers(
-    registeredPlatformsData.registeredPlatforms.map((p) => p.identifier)
+    registeredIdentifiers
   );
 
   return (
     <div className="p-xl flex flex-col gap-xl">
+      <PrivateHomepageRoadmapSection
+        locale={locale}
+        registeredIdentifiers={registeredIdentifiers}
+      />
       <NewestResources
         locale={locale}
         platformIdentifiers={platformIdentifiers}

--- a/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.test.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.test.tsx
@@ -1,0 +1,181 @@
+import { FiligranProductEnum } from '@generated/models/FiligranProduct.enum';
+import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
+import { ServiceDefinitionIdentifier } from '@graphql/generated';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockServerFetchGraphQL, mockXtmRoadmap } = vi.hoisted(() => ({
+  mockServerFetchGraphQL: vi.fn(),
+  mockXtmRoadmap: vi.fn(),
+}));
+
+vi.mock('@/relay/server-portal-api-fetch', () => ({
+  serverFetchGraphQL: mockServerFetchGraphQL,
+}));
+
+vi.mock('@/components/homepage/XtmRoadmap', () => ({
+  default: mockXtmRoadmap,
+}));
+
+import PrivateHomepageRoadmapSection from './PrivateHomepageRoadmapSection';
+
+describe('PrivateHomepageRoadmapSection', () => {
+  beforeEach(() => {
+    mockServerFetchGraphQL.mockReset();
+    mockXtmRoadmap.mockReset();
+    mockXtmRoadmap.mockReturnValue(<div data-testid="xtm-roadmap" />);
+  });
+
+  it('passes OCTI product filter when only OCTI is active', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [{ node: { id: 'roadmap-1' } }],
+        },
+      },
+    });
+
+    render(
+      await PrivateHomepageRoadmapSection({
+        locale: 'en',
+        registeredIdentifiers: [
+          ServiceDefinitionIdentifier.OpenctiRegistration,
+        ],
+      })
+    );
+
+    expect(mockXtmRoadmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seeMoreHref: `/app/service/xtm_platform_roadmap/roadmap-1?product=${FiligranProductEnum.OPENCTI}`,
+        titleKey: 'OpenCTITitle',
+      }),
+      undefined
+    );
+  });
+
+  it('passes OAEV product filter when only OAEV is active', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [{ node: { id: 'roadmap-2' } }],
+        },
+      },
+    });
+
+    render(
+      await PrivateHomepageRoadmapSection({
+        locale: 'en',
+        registeredIdentifiers: [
+          ServiceDefinitionIdentifier.OpenaevRegistration,
+        ],
+      })
+    );
+
+    expect(mockXtmRoadmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seeMoreHref: `/app/service/xtm_platform_roadmap/roadmap-2?product=${FiligranProductEnum.OPENAEV}`,
+        titleKey: 'OpenAEVTitle',
+      }),
+      undefined
+    );
+  });
+
+  it('uses full roadmap when both platforms are active', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [{ node: { id: 'roadmap-3' } }],
+        },
+      },
+    });
+
+    render(
+      await PrivateHomepageRoadmapSection({
+        locale: 'en',
+        registeredIdentifiers: [
+          ServiceDefinitionIdentifier.OpenctiRegistration,
+          ServiceDefinitionIdentifier.OpenaevRegistration,
+        ],
+      })
+    );
+
+    expect(mockXtmRoadmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seeMoreHref: '/app/service/xtm_platform_roadmap/roadmap-3',
+        titleKey: 'Title',
+      }),
+      undefined
+    );
+  });
+
+  it('uses full roadmap when no active platform is registered', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [{ node: { id: 'roadmap-0' } }],
+        },
+      },
+    });
+
+    render(
+      await PrivateHomepageRoadmapSection({
+        locale: 'en',
+        registeredIdentifiers: [],
+      })
+    );
+
+    expect(mockXtmRoadmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seeMoreHref: '/app/service/xtm_platform_roadmap/roadmap-0',
+        titleKey: 'Title',
+      }),
+      undefined
+    );
+  });
+
+  it('returns null when no roadmap service instance exists', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [],
+        },
+      },
+    });
+
+    const result = await PrivateHomepageRoadmapSection({
+      locale: 'en',
+      registeredIdentifiers: [],
+    });
+
+    expect(result).toBeNull();
+    expect(mockXtmRoadmap).not.toHaveBeenCalled();
+  });
+
+  it('queries roadmap service instances by identifier', async () => {
+    mockServerFetchGraphQL.mockResolvedValue({
+      data: {
+        serviceInstances: {
+          edges: [{ node: { id: 'roadmap-4' } }],
+        },
+      },
+    });
+
+    await PrivateHomepageRoadmapSection({
+      locale: 'en',
+      registeredIdentifiers: [],
+    });
+
+    expect(mockServerFetchGraphQL).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        count: 1,
+        filters: [
+          {
+            key: 'service_definition_identifier',
+            value: [ServiceDefinitionIdentifierEnum.XTM_PLATFORM_ROADMAP],
+          },
+        ],
+      })
+    );
+  });
+});

--- a/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.test.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.test.tsx
@@ -47,7 +47,7 @@ describe('PrivateHomepageRoadmapSection', () => {
     expect(mockXtmRoadmap).toHaveBeenCalledWith(
       expect.objectContaining({
         seeMoreHref: `/app/service/xtm_platform_roadmap/roadmap-1?product=${FiligranProductEnum.OPENCTI}`,
-        titleKey: 'OpenCTITitle',
+        titleProduct: 'opencti',
       }),
       undefined
     );
@@ -74,7 +74,7 @@ describe('PrivateHomepageRoadmapSection', () => {
     expect(mockXtmRoadmap).toHaveBeenCalledWith(
       expect.objectContaining({
         seeMoreHref: `/app/service/xtm_platform_roadmap/roadmap-2?product=${FiligranProductEnum.OPENAEV}`,
-        titleKey: 'OpenAEVTitle',
+        titleProduct: 'openaev',
       }),
       undefined
     );
@@ -102,7 +102,7 @@ describe('PrivateHomepageRoadmapSection', () => {
     expect(mockXtmRoadmap).toHaveBeenCalledWith(
       expect.objectContaining({
         seeMoreHref: '/app/service/xtm_platform_roadmap/roadmap-3',
-        titleKey: 'Title',
+        titleProduct: 'default',
       }),
       undefined
     );
@@ -127,7 +127,7 @@ describe('PrivateHomepageRoadmapSection', () => {
     expect(mockXtmRoadmap).toHaveBeenCalledWith(
       expect.objectContaining({
         seeMoreHref: '/app/service/xtm_platform_roadmap/roadmap-0',
-        titleKey: 'Title',
+        titleProduct: 'default',
       }),
       undefined
     );

--- a/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.tsx
@@ -45,8 +45,10 @@ const PrivateHomepageRoadmapSection = async ({
     return null;
   }
 
-  const { productFilter: roadmapProductFilter, titleKey: roadmapTitleKey } =
-    resolveHomepageRoadmapResolution(registeredIdentifiers);
+  const {
+    productFilter: roadmapProductFilter,
+    titleProduct: roadmapTitleProduct,
+  } = resolveHomepageRoadmapResolution(registeredIdentifiers);
   const roadmapHref = `${PRIVATE_ROADMAP_BASE_PATH}/${encodeURIComponent(serviceInstanceId)}`;
   const seeMoreHref = roadmapProductFilter
     ? `${roadmapHref}?product=${encodeURIComponent(roadmapProductFilter)}`
@@ -56,7 +58,7 @@ const PrivateHomepageRoadmapSection = async ({
     <XtmRoadmap
       locale={locale}
       seeMoreHref={seeMoreHref}
-      titleKey={roadmapTitleKey}
+      titleProduct={roadmapTitleProduct}
     />
   );
 };

--- a/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.tsx
+++ b/apps/frontend/src/components/homepage/PrivateHomepageRoadmapSection.tsx
@@ -1,0 +1,64 @@
+import { resolveHomepageRoadmapResolution } from '@/components/homepage/Homepage.utils';
+import XtmRoadmap from '@/components/homepage/XtmRoadmap';
+import type { PublicLocale } from '@/i18n/config';
+import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
+import { OrderingModeEnum } from '@generated/models/OrderingMode.enum';
+import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
+import { ServiceInstanceFilterKeyEnum } from '@generated/models/ServiceInstanceFilterKey.enum';
+import { ServiceInstanceOrderingEnum } from '@generated/models/ServiceInstanceOrdering.enum';
+import ServiceInstancesListQuery, {
+  serviceInstancesListQuery,
+} from '@generated/serviceInstancesListQuery.graphql';
+import { ServiceDefinitionIdentifier } from '@graphql/generated';
+
+const PRIVATE_ROADMAP_BASE_PATH = '/app/service/xtm_platform_roadmap';
+
+type PrivateHomepageRoadmapSectionProps = {
+  locale: PublicLocale;
+  registeredIdentifiers: ServiceDefinitionIdentifier[];
+};
+
+const PrivateHomepageRoadmapSection = async ({
+  locale,
+  registeredIdentifiers,
+}: PrivateHomepageRoadmapSectionProps) => {
+  const response = await serverFetchGraphQL<serviceInstancesListQuery>(
+    ServiceInstancesListQuery,
+    {
+      count: 1,
+      cursor: null,
+      orderBy: ServiceInstanceOrderingEnum.NAME,
+      orderMode: OrderingModeEnum.ASC,
+      filters: [
+        {
+          key: ServiceInstanceFilterKeyEnum.SERVICE_DEFINITION_IDENTIFIER,
+          value: [ServiceDefinitionIdentifierEnum.XTM_PLATFORM_ROADMAP],
+        },
+      ],
+      searchTerm: null,
+    }
+  );
+
+  const serviceInstanceId = response.data.serviceInstances.edges[0]?.node?.id;
+
+  if (!serviceInstanceId) {
+    return null;
+  }
+
+  const { productFilter: roadmapProductFilter, titleKey: roadmapTitleKey } =
+    resolveHomepageRoadmapResolution(registeredIdentifiers);
+  const roadmapHref = `${PRIVATE_ROADMAP_BASE_PATH}/${encodeURIComponent(serviceInstanceId)}`;
+  const seeMoreHref = roadmapProductFilter
+    ? `${roadmapHref}?product=${encodeURIComponent(roadmapProductFilter)}`
+    : roadmapHref;
+
+  return (
+    <XtmRoadmap
+      locale={locale}
+      seeMoreHref={seeMoreHref}
+      titleKey={roadmapTitleKey}
+    />
+  );
+};
+
+export default PrivateHomepageRoadmapSection;

--- a/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockEpicCountFetcher, mockGetTranslations } = vi.hoisted(() => ({
+  mockEpicCountFetcher: vi.fn(),
+  mockGetTranslations: vi.fn(),
+}));
+
+vi.mock('@graphql/generated', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@graphql/generated')>();
+
+  return {
+    ...actual,
+    useEpicCountPerTimelineQueryQuery: {
+      fetcher: mockEpicCountFetcher,
+    },
+  };
+});
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: mockGetTranslations,
+}));
+
+import XtmRoadmap from './XtmRoadmap';
+
+describe('XtmRoadmap', () => {
+  beforeEach(() => {
+    mockEpicCountFetcher.mockReset();
+    mockGetTranslations.mockReset();
+    mockGetTranslations.mockResolvedValue((key: string) => key);
+    mockEpicCountFetcher.mockReturnValue(() =>
+      Promise.resolve({
+        countEpicsPerTimeline: [],
+      })
+    );
+  });
+
+  it('uses public roadmap url by default', async () => {
+    render(await XtmRoadmap({ locale: 'en' }));
+
+    expect(screen.getByRole('link', { name: 'SeeMore' })).toHaveAttribute(
+      'href',
+      '/en/cybersecurity-solutions/xtm-platform-roadmap'
+    );
+  });
+
+  it('uses custom roadmap href when provided', async () => {
+    render(
+      await XtmRoadmap({
+        locale: 'en',
+        seeMoreHref:
+          '/app/service/xtm_platform_roadmap/instance-1?product=opencti',
+      })
+    );
+
+    expect(screen.getByRole('link', { name: 'SeeMore' })).toHaveAttribute(
+      'href',
+      '/app/service/xtm_platform_roadmap/instance-1?product=opencti'
+    );
+  });
+
+  it('uses default title key when no titleKey is provided', async () => {
+    render(await XtmRoadmap({ locale: 'en' }));
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Title' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses custom title key when provided', async () => {
+    render(
+      await XtmRoadmap({
+        locale: 'en',
+        titleKey: 'OpenCTITitle',
+      })
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'OpenCTITitle' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
@@ -27,10 +27,39 @@ describe('XtmRoadmap', () => {
   beforeEach(() => {
     mockEpicCountFetcher.mockReset();
     mockGetTranslations.mockReset();
-    mockGetTranslations.mockResolvedValue(
-      (key: string, values?: { product?: string }) =>
-        key === 'Title' ? `Title-${values?.product ?? 'missing'}` : key
-    );
+
+    mockGetTranslations.mockImplementation(async (namespace: string) => {
+      if (namespace === 'PublicHomePage.XtmRoadmap') {
+        return (key: string, values?: { product?: string }) => {
+          if (key === 'Title') {
+            return 'Title';
+          }
+
+          if (key === 'TitleWithProduct') {
+            return `TitleWithProduct-${values?.product ?? 'missing'}`;
+          }
+
+          return key;
+        };
+      }
+
+      if (namespace === 'PlatformIdentifier') {
+        return (key: string) => {
+          if (key === 'opencti') {
+            return 'OpenCTI';
+          }
+
+          if (key === 'openaev') {
+            return 'OpenAEV';
+          }
+
+          return key;
+        };
+      }
+
+      return (key: string) => key;
+    });
+
     mockEpicCountFetcher.mockReturnValue(() =>
       Promise.resolve({
         countEpicsPerTimeline: [],
@@ -62,15 +91,15 @@ describe('XtmRoadmap', () => {
     );
   });
 
-  it('uses default title key when no titleKey is provided', async () => {
+  it('uses default title when no titleProduct is provided', async () => {
     render(await XtmRoadmap({ locale: 'en' }));
 
     expect(
-      screen.getByRole('heading', { level: 2, name: 'Title-default' })
+      screen.getByRole('heading', { level: 2, name: 'Title' })
     ).toBeInTheDocument();
   });
 
-  it('uses custom title key when provided', async () => {
+  it('uses product title when titleProduct is provided', async () => {
     render(
       await XtmRoadmap({
         locale: 'en',
@@ -79,28 +108,10 @@ describe('XtmRoadmap', () => {
     );
 
     expect(
-      screen.getByRole('heading', { level: 2, name: 'Title-opencti' })
-    ).toBeInTheDocument();
-  });
-
-  it('uses default title product when no titleProduct is provided', async () => {
-    render(await XtmRoadmap({ locale: 'en' }));
-
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Title-default' })
-    ).toBeInTheDocument();
-  });
-
-  it('uses custom title product when provided', async () => {
-    render(
-      await XtmRoadmap({
-        locale: 'en',
-        titleProduct: 'opencti',
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'TitleWithProduct-OpenCTI',
       })
-    );
-
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Title-opencti' })
     ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.test.tsx
@@ -27,7 +27,10 @@ describe('XtmRoadmap', () => {
   beforeEach(() => {
     mockEpicCountFetcher.mockReset();
     mockGetTranslations.mockReset();
-    mockGetTranslations.mockResolvedValue((key: string) => key);
+    mockGetTranslations.mockResolvedValue(
+      (key: string, values?: { product?: string }) =>
+        key === 'Title' ? `Title-${values?.product ?? 'missing'}` : key
+    );
     mockEpicCountFetcher.mockReturnValue(() =>
       Promise.resolve({
         countEpicsPerTimeline: [],
@@ -63,7 +66,7 @@ describe('XtmRoadmap', () => {
     render(await XtmRoadmap({ locale: 'en' }));
 
     expect(
-      screen.getByRole('heading', { level: 2, name: 'Title' })
+      screen.getByRole('heading', { level: 2, name: 'Title-default' })
     ).toBeInTheDocument();
   });
 
@@ -71,12 +74,33 @@ describe('XtmRoadmap', () => {
     render(
       await XtmRoadmap({
         locale: 'en',
-        titleKey: 'OpenCTITitle',
+        titleProduct: 'opencti',
       })
     );
 
     expect(
-      screen.getByRole('heading', { level: 2, name: 'OpenCTITitle' })
+      screen.getByRole('heading', { level: 2, name: 'Title-opencti' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses default title product when no titleProduct is provided', async () => {
+    render(await XtmRoadmap({ locale: 'en' }));
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Title-default' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses custom title product when provided', async () => {
+    render(
+      await XtmRoadmap({
+        locale: 'en',
+        titleProduct: 'opencti',
+      })
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Title-opencti' })
     ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/homepage/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.tsx
@@ -1,4 +1,4 @@
-import type { HomepageRoadmapTitleKey } from '@/components/homepage/Homepage.utils';
+import type { HomepageRoadmapTitleProduct } from '@/components/homepage/Homepage.utils';
 import type { PublicLocale } from '@/i18n/config';
 import { portalGraphqlClientCached } from '@/lib/graphql-client';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
@@ -35,15 +35,19 @@ const TIMELINE_CONFIG = [
 export type XtmRoadmapProps = {
   locale: PublicLocale;
   seeMoreHref?: string;
-  titleKey?: HomepageRoadmapTitleKey;
+  titleProduct?: HomepageRoadmapTitleProduct;
 };
 
 const XtmRoadmap = async ({
   locale,
   seeMoreHref,
-  titleKey = 'Title',
+  titleProduct = 'default',
 }: XtmRoadmapProps) => {
   const t = await getTranslations('PublicHomePage.XtmRoadmap');
+
+  const titleTranslationValues: { product: HomepageRoadmapTitleProduct } = {
+    product: titleProduct,
+  };
 
   const data = await useEpicCountPerTimelineQueryQuery.fetcher(
     portalGraphqlClientCached
@@ -61,7 +65,9 @@ const XtmRoadmap = async ({
   return (
     <section className="flex flex-col lg:flex-row gap-l items-center bg-card border border-primary/30 rounded-lg px-xl py-4">
       <div className="flex flex-col gap-l flex-3">
-        <h2 className="text-xl leading-tight">{t(titleKey)}</h2>
+        <h2 className="text-xl leading-tight">
+          {t('Title', titleTranslationValues)}
+        </h2>
         <p className="text-muted-foreground text-sm min-[1330px]:text-xs">
           {t('Description')}
         </p>

--- a/apps/frontend/src/components/homepage/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.tsx
@@ -44,10 +44,17 @@ const XtmRoadmap = async ({
   titleProduct = 'default',
 }: XtmRoadmapProps) => {
   const t = await getTranslations('PublicHomePage.XtmRoadmap');
+  const tPlatformIdentifier = await getTranslations('PlatformIdentifier');
 
-  const titleTranslationValues: { product: HomepageRoadmapTitleProduct } = {
-    product: titleProduct,
-  };
+  const title =
+    titleProduct === 'default'
+      ? t('Title')
+      : t('TitleWithProduct', {
+          product:
+            titleProduct === 'opencti'
+              ? tPlatformIdentifier('opencti')
+              : tPlatformIdentifier('openaev'),
+        });
 
   const data = await useEpicCountPerTimelineQueryQuery.fetcher(
     portalGraphqlClientCached
@@ -65,9 +72,7 @@ const XtmRoadmap = async ({
   return (
     <section className="flex flex-col lg:flex-row gap-l items-center bg-card border border-primary/30 rounded-lg px-xl py-4">
       <div className="flex flex-col gap-l flex-3">
-        <h2 className="text-xl leading-tight">
-          {t('Title', titleTranslationValues)}
-        </h2>
+        <h2 className="text-xl leading-tight">{title}</h2>
         <p className="text-muted-foreground text-sm min-[1330px]:text-xs">
           {t('Description')}
         </p>

--- a/apps/frontend/src/components/homepage/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/XtmRoadmap.tsx
@@ -1,3 +1,4 @@
+import type { HomepageRoadmapTitleKey } from '@/components/homepage/Homepage.utils';
 import type { PublicLocale } from '@/i18n/config';
 import { portalGraphqlClientCached } from '@/lib/graphql-client';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
@@ -31,7 +32,17 @@ const TIMELINE_CONFIG = [
   },
 ];
 
-const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
+export type XtmRoadmapProps = {
+  locale: PublicLocale;
+  seeMoreHref?: string;
+  titleKey?: HomepageRoadmapTitleKey;
+};
+
+const XtmRoadmap = async ({
+  locale,
+  seeMoreHref,
+  titleKey = 'Title',
+}: XtmRoadmapProps) => {
   const t = await getTranslations('PublicHomePage.XtmRoadmap');
 
   const data = await useEpicCountPerTimelineQueryQuery.fetcher(
@@ -45,10 +56,12 @@ const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
     ...config,
   }));
 
+  const defaultSeeMoreHref = `/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/xtm-platform-roadmap`;
+
   return (
     <section className="flex flex-col lg:flex-row gap-l items-center bg-card border border-primary/30 rounded-lg px-xl py-4">
       <div className="flex flex-col gap-l flex-3">
-        <h2 className="text-xl leading-tight">{t('Title')}</h2>
+        <h2 className="text-xl leading-tight">{t(titleKey)}</h2>
         <p className="text-muted-foreground text-sm min-[1330px]:text-xs">
           {t('Description')}
         </p>
@@ -57,10 +70,7 @@ const XtmRoadmap = async ({ locale }: { locale: PublicLocale }) => {
             asChild
             variant="outline"
             className="text-primary border-primary/20">
-            <Link
-              href={`/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/xtm-platform-roadmap`}>
-              {t('SeeMore')}
-            </Link>
+            <Link href={seeMoreHref ?? defaultSeeMoreHref}>{t('SeeMore')}</Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


This PR enhances the homepage roadmap experience by making the roadmap section reusable across public and private contexts, with dynamic titles and “See more” links tailored to the user’s active platform registrations (OpenCTI vs OpenAEV).

**Changes:**

- Extend `XtmRoadmap` to support an overridable roadmap title key and “See more” URL.
- Add `PrivateHomepageRoadmapSection` that queries the user’s roadmap service instance and builds a private roadmap link (optionally filtered by product).
- Introduce `resolveHomepageRoadmapResolution()` and add i18n keys for OpenCTI/OpenAEV-specific roadmap titles.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- go to signed in page
- check platform roadmap is displayed
- register an OpenCTI product
- check title is changed to OpenCTI
- register an OpenAEV product
- check title is changed to Platform Roadmap

## Related issues

- Related to #2664 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.