### PR TITLE
feat(homepage): connected products dropdown in header (#2662)

### DIFF
--- a/apps/e2e/tests/tests_files/organization-switcher.spec.ts
+++ b/apps/e2e/tests/tests_files/organization-switcher.spec.ts
@@ -51,7 +51,7 @@ test.describe('Organization switcher', async () => {
       await expect(
         page.getByRole('link', { name: 'Open CTI Instance' })
       ).toBeVisible();
-      await expect(page.getByText('1 Active trial')).toBeVisible();
+      await expect(page.getByText('2 connected products')).toBeVisible();
     });
 
     // When User switch on personal space
@@ -66,7 +66,7 @@ test.describe('Organization switcher', async () => {
         page.getByRole('button', { name: 'My products' })
       ).not.toBeVisible();
 
-      await expect(page.getByText('1 Active trial')).not.toBeVisible();
+      await expect(page.getByText('2 connected products')).not.toBeVisible();
     });
 
     // WHen User comes back to organization
@@ -82,7 +82,7 @@ test.describe('Organization switcher', async () => {
         page.getByRole('link', { name: 'Open CTI Instance' })
       ).toBeVisible();
 
-      await expect(page.getByText('1 Active trial')).toBeVisible();
+      await expect(page.getByText('2 connected products')).toBeVisible();
     });
   });
 });

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -2713,10 +2713,12 @@ export type OrganizationSubscribedServicesListQueryVariables = Exact<{
 
 export type OrganizationSubscribedServicesListQuery = { __typename?: 'Query', subscriptions: { __typename?: 'SubscriptionConnection', totalCount: number, edges: Array<{ __typename?: 'SubscriptionEdge', node: { __typename?: 'SubscriptionModel', id: string, start_date: any | null, service_instance: { __typename?: 'ServiceInstance', id: string, name: string, creation_status: ServiceInstanceCreationStatus | null, tags: Array<ServiceInstanceTag> | null, service_definition: { __typename?: 'ServiceDefinition', id: string, name: string, identifier: ServiceDefinitionIdentifier } | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null } } };
 
-export type RegisteredPlatformsListQueryVariables = Exact<{ [key: string]: never; }>;
+export type RegisteredPlatformsListQueryVariables = Exact<{
+  input: RegisteredPlatformsInput;
+}>;
 
 
-export type RegisteredPlatformsListQuery = { __typename?: 'Query', registeredPlatforms: Array<{ __typename?: 'RegisteredPlatform', title: string, url: string, identifier: ServiceDefinitionIdentifier, subscription: { __typename?: 'SubscriptionModel', service_instance: { __typename?: 'ServiceInstance', id: string } } | null }> };
+export type RegisteredPlatformsListQuery = { __typename?: 'Query', registeredPlatforms: Array<{ __typename?: 'RegisteredPlatform', id: string, platform_id: string, title: string, url: string, contract: PlatformContract, identifier: ServiceDefinitionIdentifier, subscription: { __typename?: 'SubscriptionModel', end_date: any | null, start_date: any | null, service_instance: { __typename?: 'ServiceInstance', id: string, name: string } } | null }> };
 
 export type RegisteredPlatformsQueryVariables = Exact<{
   input: RegisteredPlatformsInput;
@@ -3060,14 +3062,20 @@ useInfiniteOrganizationSubscribedServicesListQuery.getRootKey = () => ['Organiza
 useOrganizationSubscribedServicesListQuery.fetcher = (client: GraphQLClient, variables: OrganizationSubscribedServicesListQueryVariables, headers?: RequestInit['headers']) => fetcher<OrganizationSubscribedServicesListQuery, OrganizationSubscribedServicesListQueryVariables>(client, OrganizationSubscribedServicesListDocument, variables, headers);
 
 export const RegisteredPlatformsListDocument = `
-    query RegisteredPlatformsList {
-  registeredPlatforms(input: {}) {
+    query RegisteredPlatformsList($input: RegisteredPlatformsInput!) {
+  registeredPlatforms(input: $input) {
+    id
+    platform_id
     title
     url
+    contract
     identifier
     subscription {
+      end_date
+      start_date
       service_instance {
         id
+        name
       }
     }
   }
@@ -3079,20 +3087,20 @@ export const useRegisteredPlatformsListQuery = <
       TError = unknown
     >(
       client: GraphQLClient,
-      variables?: RegisteredPlatformsListQueryVariables,
+      variables: RegisteredPlatformsListQueryVariables,
       options?: Omit<UseQueryOptions<RegisteredPlatformsListQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<RegisteredPlatformsListQuery, TError, TData>['queryKey'] },
       headers?: RequestInit['headers']
     ) => {
     
     return useQuery<RegisteredPlatformsListQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['RegisteredPlatformsList'] : ['RegisteredPlatformsList', variables],
+    queryKey: ['RegisteredPlatformsList', variables],
     queryFn: fetcher<RegisteredPlatformsListQuery, RegisteredPlatformsListQueryVariables>(client, RegisteredPlatformsListDocument, variables, headers),
     ...options
   }
     )};
 
-useRegisteredPlatformsListQuery.getKey = (variables?: RegisteredPlatformsListQueryVariables) => variables === undefined ? ['RegisteredPlatformsList'] : ['RegisteredPlatformsList', variables];
+useRegisteredPlatformsListQuery.getKey = (variables: RegisteredPlatformsListQueryVariables) => ['RegisteredPlatformsList', variables];
 useRegisteredPlatformsListQuery.getRootKey = () => ['RegisteredPlatformsList'] as const;
 export const useInfiniteRegisteredPlatformsListQuery = <
       TData = InfiniteData<RegisteredPlatformsListQuery>,
@@ -3108,16 +3116,16 @@ export const useInfiniteRegisteredPlatformsListQuery = <
       (() => {
     const { queryKey: optionsQueryKey, ...restOptions } = options;
     return {
-      queryKey: optionsQueryKey ?? variables === undefined ? ['RegisteredPlatformsList.infinite'] : ['RegisteredPlatformsList.infinite', variables],
+      queryKey: optionsQueryKey ?? ['RegisteredPlatformsList.infinite', variables],
       queryFn: (metaData) => fetcher<RegisteredPlatformsListQuery, RegisteredPlatformsListQueryVariables>(client, RegisteredPlatformsListDocument, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
       ...restOptions
     }
   })()
     )};
 
-useInfiniteRegisteredPlatformsListQuery.getKey = (variables?: RegisteredPlatformsListQueryVariables) => variables === undefined ? ['RegisteredPlatformsList.infinite'] : ['RegisteredPlatformsList.infinite', variables];
+useInfiniteRegisteredPlatformsListQuery.getKey = (variables: RegisteredPlatformsListQueryVariables) => ['RegisteredPlatformsList.infinite', variables];
 useInfiniteRegisteredPlatformsListQuery.getRootKey = () => ['RegisteredPlatformsList.infinite'] as const;
-useRegisteredPlatformsListQuery.fetcher = (client: GraphQLClient, variables?: RegisteredPlatformsListQueryVariables, headers?: RequestInit['headers']) => fetcher<RegisteredPlatformsListQuery, RegisteredPlatformsListQueryVariables>(client, RegisteredPlatformsListDocument, variables, headers);
+useRegisteredPlatformsListQuery.fetcher = (client: GraphQLClient, variables: RegisteredPlatformsListQueryVariables, headers?: RequestInit['headers']) => fetcher<RegisteredPlatformsListQuery, RegisteredPlatformsListQueryVariables>(client, RegisteredPlatformsListDocument, variables, headers);
 
 export const RegisteredPlatformsDocument = `
     query RegisteredPlatforms($input: RegisteredPlatformsInput!) {

--- a/apps/frontend/graphql/registered-platforms/registered-platforms-list.query.graphql
+++ b/apps/frontend/graphql/registered-platforms/registered-platforms-list.query.graphql
@@ -1,11 +1,17 @@
-query RegisteredPlatformsList {
-  registeredPlatforms(input: {}) {
+query RegisteredPlatformsList($input: RegisteredPlatformsInput!) {
+  registeredPlatforms(input: $input) {
+    id
+    platform_id
     title
     url
+    contract
     identifier
     subscription {
+      end_date
+      start_date
       service_instance {
         id
+        name
       }
     }
   }

--- a/apps/frontend/graphql/registered-platforms/registered-platforms.keys.ts
+++ b/apps/frontend/graphql/registered-platforms/registered-platforms.keys.ts
@@ -1,6 +1,10 @@
-import { useRegisteredPlatformsListQuery } from '@graphql/generated';
+import {
+  type RegisteredPlatformsListQueryVariables,
+  useRegisteredPlatformsListQuery,
+} from '@graphql/generated';
 
 export const registeredPlatformsKeys = {
   all: useRegisteredPlatformsListQuery.getRootKey,
-  list: () => useRegisteredPlatformsListQuery.getKey(undefined),
+  list: (variables: RegisteredPlatformsListQueryVariables) =>
+    useRegisteredPlatformsListQuery.getKey(variables),
 };

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -301,7 +301,14 @@
   "Header": {
     "BrandName": "Filigran",
     "CloseMenu": "Close Menu",
-    "OpenMenu": "Open Menu"
+    "OpenMenu": "Open Menu",
+    "ConnectedProducts": {
+      "Count": "{count, plural, =0 {No connected product} one {# connected product} other {# connected products}}",
+      "GoToPlatform": "Go to {title}",
+      "Details": "Details",
+      "Documentation": "Documentation",
+      "ConnectPlatform": "Connect {platformName}"
+    }
   },
   "HomePage": {
     "Homepage": "Homepage",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -301,7 +301,14 @@
   "Header": {
     "BrandName": "Filigran",
     "CloseMenu": "Fermer le menu",
-    "OpenMenu": "Ouvrir le menu"
+    "OpenMenu": "Ouvrir le menu",
+    "ConnectedProducts": {
+      "Count": "{count, plural, =0 {Aucun produit connecté} one {# produit connecté} other {# produits connectés}}",
+      "GoToPlatform": "Accéder à {title}",
+      "Details": "Détails",
+      "Documentation": "Documentation",
+      "ConnectPlatform": "Connecter {platformName}"
+    }
   },
   "HomePage": {
     "Homepage": "Page d'accueil",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -301,7 +301,14 @@
   "Header": {
     "BrandName": "Filigran",
     "CloseMenu": "メニューを閉じる",
-    "OpenMenu": "メニューを開く"
+    "OpenMenu": "メニューを開く",
+    "ConnectedProducts": {
+      "Count": "{count, plural, =0 {接続された製品はありません} one {# 件の接続された製品} other {# 件の接続された製品}}",
+      "GoToPlatform": "{title} に移動",
+      "Details": "詳細",
+      "Documentation": "ドキュメント",
+      "ConnectPlatform": "{platformName} を接続"
+    }
   },
   "HomePage": {
     "Homepage": "ホームページ",

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ConnectedProductsDropdown } from '@/components/connected-products/ConnectedProductsDropdown';
 import { LogoutMutation } from '@/components/logout.graphql';
 import { PortalContext } from '@/components/me/AppPortalContext';
 import HeaderOrganizationSwitcher from '@/components/menu/HeaderOrganizationSwitcher';
@@ -9,14 +10,13 @@ import { NotificationButton } from '@/components/notification/NotificationButton
 import { DisplayTrialList } from '@/components/service/trial-instances/display-trial-header/DisplayTrialList';
 import { DisplayLogo } from '@/components/ui/DisplayLogo';
 import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
-
 import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
 import { cn } from '@/lib/utils';
 import { APP_PATH } from '@/utils/path/constant';
 
-import { CloseIcon, MenuIcon } from '@filigran/icon';
-import { Avatar } from '@filigran/ui';
+import { CloseIcon, IndividualIcon, MenuIcon } from '@filigran/icon';
 import {
+  Avatar,
   Sheet,
   SheetClose,
   SheetContent,
@@ -51,7 +51,6 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
   // Legitimate effect: close the menu on route change.
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setOpen(false), [currentPath]);
-
   const canManageUser =
     hasOrganizationCapability &&
     (hasOrganizationCapability(
@@ -79,15 +78,23 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
       <DisplayLogo className="text-primary mr-2 h-full py-l sm:hidden" />
 
       <div className="mobile:hidden flex items-center gap-s">
-        <DisplayTrialList />
+        {isHomePageV2Enabled ? (
+          <ConnectedProductsDropdown />
+        ) : (
+          <DisplayTrialList />
+        )}
         {canManageUser && <NotificationButton />}
         <IconActions
           className="rounded-full"
           icon={
             <>
-              <div className="my-auto size-10 [&_img]:object-cover">
-                <Avatar src={me?.picture || undefined} />
-              </div>
+              {isHomePageV2Enabled ? (
+                <IndividualIcon className="h-5 w-5 text-primary" />
+              ) : (
+                <div className="my-auto size-10 [&_img]:object-cover">
+                  <Avatar src={me?.picture || undefined} />
+                </div>
+              )}
               <span className="sr-only">{t('MenuUser.ToggleUser')}</span>
             </>
           }>

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -14,7 +14,7 @@ import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
 import { cn } from '@/lib/utils';
 import { APP_PATH } from '@/utils/path/constant';
 
-import { CloseIcon, IndividualIcon, MenuIcon } from '@filigran/icon';
+import { CloseIcon, MenuIcon } from '@filigran/icon';
 import {
   Avatar,
   Sheet,
@@ -88,13 +88,10 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
           className="rounded-full"
           icon={
             <>
-              {isHomePageV2Enabled ? (
-                <IndividualIcon className="h-5 w-5 text-primary" />
-              ) : (
-                <div className="my-auto size-10 [&_img]:object-cover">
-                  <Avatar src={me?.picture || undefined} />
-                </div>
-              )}
+              <div
+                className={`my-auto [&_img]:object-cover ${isHomePageV2Enabled ? 'size-6 text-primary [&_span]:bg-transparent' : 'size-10'}`}>
+                <Avatar src={me?.picture || undefined} />
+              </div>
               <span className="sr-only">{t('MenuUser.ToggleUser')}</span>
             </>
           }>

--- a/apps/frontend/src/components/connected-products/ConnectPlatformButton.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectPlatformButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import {
+  PlatformMetadata,
+  PlatformMetadataMapping,
+} from '@/components/registration/platform-identifier-mapping';
+import { UseTranslationsProps } from '@/i18n/config';
+import { AddIcon } from '@filigran/icon';
+import { Button } from '@filigran/ui';
+import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
+import Link from 'next/link';
+
+interface ConnectPlatformButtonProps {
+  platformIdentifier: PlatformIdentifierEnum;
+  t: UseTranslationsProps;
+}
+
+export const ConnectPlatformButton = ({
+  platformIdentifier,
+  t,
+}: ConnectPlatformButtonProps) => {
+  const meta: PlatformMetadata = PlatformMetadataMapping[platformIdentifier];
+
+  return (
+    <Button
+      variant="outline"
+      className="w-full text-primary bg-transparent justify-center gap-xs"
+      asChild>
+      <Link
+        href={meta.docUrl}
+        target="_blank"
+        rel="noopener noreferrer">
+        <span>
+          {t('Header.ConnectedProducts.ConnectPlatform', {
+            platformName: meta.name,
+          })}
+        </span>
+        <AddIcon className="h-3 w-3" />
+      </Link>
+    </Button>
+  );
+};

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -9,7 +9,6 @@ import { UseTranslationsProps } from '@/i18n/config';
 import { APP_PATH } from '@/utils/path/constant';
 import { OpenInNewIcon, TextSnippetIcon } from '@filigran/icon';
 import { Button } from '@filigran/ui';
-import { ServiceDefinitionIdentifier } from '@generated/serviceInstance_fragment.graphql';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -23,9 +22,7 @@ export const ConnectedProductItem = ({
   t,
 }: ConnectedProductItemProps) => {
   const platformIdentifier =
-    ServiceDefinitionIdentifierToPlatformIdentifier[
-      platform.identifier as ServiceDefinitionIdentifier
-    ];
+    ServiceDefinitionIdentifierToPlatformIdentifier[platform.identifier];
   const platformMeta = platformIdentifier
     ? PlatformMetadataMapping[platformIdentifier]
     : undefined;

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -1,50 +1,38 @@
 'use client';
 
-import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { ConnectedPlatform } from '@/components/connected-products/useConnectedPlatforms';
+import {
+  PlatformMetadataMapping,
+  ServiceDefinitionIdentifierToPlatformIdentifier,
+} from '@/components/registration/platform-identifier-mapping';
 import { UseTranslationsProps } from '@/i18n/config';
 import { APP_PATH } from '@/utils/path/constant';
 import { OpenInNewIcon, TextSnippetIcon } from '@filigran/icon';
 import { Button } from '@filigran/ui';
-import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
-import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
-import { registerRegisteredPlatformFragment$data } from '@generated/registerRegisteredPlatformFragment.graphql';
+import { ServiceDefinitionIdentifier } from '@generated/serviceInstance_fragment.graphql';
 import Image from 'next/image';
 import Link from 'next/link';
 
 interface ConnectedProductItemProps {
-  platform: registerRegisteredPlatformFragment$data;
+  platform: ConnectedPlatform;
   t: UseTranslationsProps;
 }
-
-const identifierToPlatformIdentifier: Partial<
-  Record<string, PlatformIdentifierEnum>
-> = {
-  [ServiceDefinitionIdentifierEnum.OPENCTI_REGISTRATION]:
-    PlatformIdentifierEnum.OPENCTI,
-  [ServiceDefinitionIdentifierEnum.OPENAEV_REGISTRATION]:
-    PlatformIdentifierEnum.OPENAEV,
-};
-
-const platformRegistrationPaths: Record<PlatformIdentifierEnum, string> = {
-  [PlatformIdentifierEnum.OPENCTI]: 'opencti_registration',
-  [PlatformIdentifierEnum.OPENAEV]: 'openaev_registration',
-};
 
 export const ConnectedProductItem = ({
   platform,
   t,
 }: ConnectedProductItemProps) => {
-  const platformIdentifier = identifierToPlatformIdentifier[
-    platform.identifier
-  ] as PlatformIdentifierEnum | undefined;
+  const platformIdentifier =
+    ServiceDefinitionIdentifierToPlatformIdentifier[
+      platform.identifier as ServiceDefinitionIdentifier
+    ];
   const platformMeta = platformIdentifier
     ? PlatformMetadataMapping[platformIdentifier]
     : undefined;
   const serviceInstanceId = platform.subscription?.service_instance?.id;
-  const detailPath =
-    platformIdentifier && serviceInstanceId
-      ? `/${APP_PATH}/service/${platformRegistrationPaths[platformIdentifier]}/${serviceInstanceId}`
-      : undefined;
+  const detailPath = serviceInstanceId
+    ? `/${APP_PATH}/service/${platform.identifier}/${serviceInstanceId}`
+    : undefined;
 
   return (
     <div className="flex w-full items-center justify-between gap-m px-m py-s">

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { UseTranslationsProps } from '@/i18n/config';
+import { APP_PATH } from '@/utils/path/constant';
+import { OpenInNewIcon, TextSnippetIcon } from '@filigran/icon';
+import { Button } from '@filigran/ui';
+import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
+import { ServiceDefinitionIdentifierEnum } from '@generated/models/ServiceDefinitionIdentifier.enum';
+import { registerRegisteredPlatformFragment$data } from '@generated/registerRegisteredPlatformFragment.graphql';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ConnectedProductItemProps {
+  platform: registerRegisteredPlatformFragment$data;
+  t: UseTranslationsProps;
+}
+
+const identifierToPlatformIdentifier: Partial<
+  Record<string, PlatformIdentifierEnum>
+> = {
+  [ServiceDefinitionIdentifierEnum.OPENCTI_REGISTRATION]:
+    PlatformIdentifierEnum.OPENCTI,
+  [ServiceDefinitionIdentifierEnum.OPENAEV_REGISTRATION]:
+    PlatformIdentifierEnum.OPENAEV,
+};
+
+const platformRegistrationPaths: Record<PlatformIdentifierEnum, string> = {
+  [PlatformIdentifierEnum.OPENCTI]: 'opencti_registration',
+  [PlatformIdentifierEnum.OPENAEV]: 'openaev_registration',
+};
+
+export const ConnectedProductItem = ({
+  platform,
+  t,
+}: ConnectedProductItemProps) => {
+  const platformIdentifier = identifierToPlatformIdentifier[
+    platform.identifier
+  ] as PlatformIdentifierEnum | undefined;
+  const platformMeta = platformIdentifier
+    ? PlatformMetadataMapping[platformIdentifier]
+    : undefined;
+  const serviceInstanceId = platform.subscription?.service_instance?.id;
+  const detailPath =
+    platformIdentifier && serviceInstanceId
+      ? `/${APP_PATH}/service/${platformRegistrationPaths[platformIdentifier]}/${serviceInstanceId}`
+      : undefined;
+
+  return (
+    <div className="flex w-full items-center justify-between gap-m px-m py-s">
+      <div className="flex items-center gap-s">
+        {platformMeta?.logoUrl && (
+          <Image
+            src={platformMeta.logoUrl}
+            alt={platformMeta.name}
+            width={20}
+            height={20}
+            className="shrink-0 brightness-0 dark:brightness-0 dark:invert"
+          />
+        )}
+        <span className="text-sm font-medium">
+          {platform.title ?? platformMeta?.name ?? platform.identifier}
+        </span>
+      </div>
+      <div className="flex items-center gap-xs">
+        {detailPath && (
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            asChild>
+            <Link
+              href={detailPath}
+              aria-label={t('Header.ConnectedProducts.Details')}>
+              <TextSnippetIcon className="h-4 w-4" />
+            </Link>
+          </Button>
+        )}
+        {platform.url && (
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            asChild>
+            <Link
+              href={platform.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t('Header.ConnectedProducts.GoToPlatform', {
+                title:
+                  platform.title ?? platformMeta?.name ?? platform.identifier,
+              })}>
+              <OpenInNewIcon className="h-4 w-4" />
+            </Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
@@ -3,7 +3,6 @@
 import { ConnectedProductItem } from '@/components/connected-products/ConnectedProductItem';
 import { ConnectPlatformButton } from '@/components/connected-products/ConnectPlatformButton';
 import { useConnectedPlatforms } from '@/components/connected-products/useConnectedPlatforms';
-import { PortalContext } from '@/components/me/AppPortalContext';
 import { ArrowDropDownIcon } from '@filigran/icon';
 import {
   Button,
@@ -15,7 +14,7 @@ import {
 } from '@filigran/ui';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { useTranslations } from 'next-intl';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 
 const CONNECTABLE_PLATFORMS = [
   PlatformIdentifierEnum.OPENCTI,
@@ -24,12 +23,9 @@ const CONNECTABLE_PLATFORMS = [
 
 export const ConnectedProductsDropdown = () => {
   const t = useTranslations();
-  const { isPersonalSpace } = useContext(PortalContext);
   const { connectedPlatforms } = useConnectedPlatforms();
 
   const [open, setOpen] = useState(false);
-
-  if (isPersonalSpace) return null;
 
   return (
     <DropdownMenu

--- a/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { ConnectedProductItem } from '@/components/connected-products/ConnectedProductItem';
+import { ConnectPlatformButton } from '@/components/connected-products/ConnectPlatformButton';
 import { useConnectedPlatforms } from '@/components/connected-products/useConnectedPlatforms';
 import { PortalContext } from '@/components/me/AppPortalContext';
-import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
-import { AddIcon, ArrowDropDownIcon } from '@filigran/icon';
+import { ArrowDropDownIcon } from '@filigran/icon';
 import {
   Button,
   DropdownMenu,
@@ -15,11 +15,12 @@ import {
 } from '@filigran/ui';
 import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
 import { useContext, useState } from 'react';
 
-const OPENCTI_DOC_URL = 'https://docs.opencti.io/latest/administration/hub/';
-const OPENAEV_DOC_URL = 'https://docs.openaev.io/latest/administration/hub/';
+const CONNECTABLE_PLATFORMS = [
+  PlatformIdentifierEnum.OPENCTI,
+  PlatformIdentifierEnum.OPENAEV,
+];
 
 export const ConnectedProductsDropdown = () => {
   const t = useTranslations();
@@ -68,42 +69,13 @@ export const ConnectedProductsDropdown = () => {
           </>
         )}
         <div className="flex flex-col gap-s p-m">
-          <Button
-            variant="outline"
-            className="w-full text-primary bg-transparent justify-center gap-xs"
-            asChild>
-            <Link
-              href={OPENCTI_DOC_URL}
-              target="_blank"
-              rel="noopener noreferrer">
-              <span>
-                {t('Header.ConnectedProducts.ConnectPlatform', {
-                  platformName:
-                    PlatformMetadataMapping[PlatformIdentifierEnum.OPENCTI]
-                      .name,
-                })}
-              </span>
-              <AddIcon className="h-3 w-3" />
-            </Link>
-          </Button>
-          <Button
-            variant="outline"
-            className="w-full text-primary bg-transparent justify-center gap-xs"
-            asChild>
-            <Link
-              href={OPENAEV_DOC_URL}
-              target="_blank"
-              rel="noopener noreferrer">
-              <span>
-                {t('Header.ConnectedProducts.ConnectPlatform', {
-                  platformName:
-                    PlatformMetadataMapping[PlatformIdentifierEnum.OPENAEV]
-                      .name,
-                })}
-              </span>
-              <AddIcon className="h-3 w-3" />
-            </Link>
-          </Button>
+          {CONNECTABLE_PLATFORMS.map((platformId) => (
+            <ConnectPlatformButton
+              key={platformId}
+              platformIdentifier={platformId}
+              t={t}
+            />
+          ))}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { ConnectedProductItem } from '@/components/connected-products/ConnectedProductItem';
+import { useConnectedPlatforms } from '@/components/connected-products/useConnectedPlatforms';
+import { PortalContext } from '@/components/me/AppPortalContext';
+import { PlatformMetadataMapping } from '@/components/registration/platform-identifier-mapping';
+import { AddIcon, ArrowDropDownIcon } from '@filigran/icon';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@filigran/ui';
+import { PlatformIdentifierEnum } from '@generated/models/PlatformIdentifier.enum';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useContext, useState } from 'react';
+
+const OPENCTI_DOC_URL = 'https://docs.opencti.io/latest/administration/hub/';
+const OPENAEV_DOC_URL = 'https://docs.openaev.io/latest/administration/hub/';
+
+export const ConnectedProductsDropdown = () => {
+  const t = useTranslations();
+  const { isPersonalSpace } = useContext(PortalContext);
+  const { connectedPlatforms } = useConnectedPlatforms();
+
+  const [open, setOpen] = useState(false);
+
+  if (isPersonalSpace) return null;
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex flex-row items-center gap-xs text-primary font-medium">
+          <span>
+            {t('Header.ConnectedProducts.Count', {
+              count: connectedPlatforms.length,
+            })}
+          </span>
+          <ArrowDropDownIcon
+            className={`h-5 w-5 shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80 p-0">
+        {connectedPlatforms.length > 0 && (
+          <>
+            {connectedPlatforms.map((platform, index) => (
+              <div key={platform.id}>
+                <DropdownMenuItem className="p-0">
+                  <ConnectedProductItem
+                    platform={platform}
+                    t={t}
+                  />
+                </DropdownMenuItem>
+                {index < connectedPlatforms.length - 1 && (
+                  <DropdownMenuSeparator className="bg-foreground/20" />
+                )}
+              </div>
+            ))}
+            <DropdownMenuSeparator className="bg-foreground/20" />
+          </>
+        )}
+        <div className="flex flex-col gap-s p-m">
+          <Button
+            variant="outline"
+            className="w-full text-primary bg-transparent justify-center gap-xs"
+            asChild>
+            <Link
+              href={OPENCTI_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer">
+              <span>
+                {t('Header.ConnectedProducts.ConnectPlatform', {
+                  platformName:
+                    PlatformMetadataMapping[PlatformIdentifierEnum.OPENCTI]
+                      .name,
+                })}
+              </span>
+              <AddIcon className="h-3 w-3" />
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full text-primary bg-transparent justify-center gap-xs"
+            asChild>
+            <Link
+              href={OPENAEV_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer">
+              <span>
+                {t('Header.ConnectedProducts.ConnectPlatform', {
+                  platformName:
+                    PlatformMetadataMapping[PlatformIdentifierEnum.OPENAEV]
+                      .name,
+                })}
+              </span>
+              <AddIcon className="h-3 w-3" />
+            </Link>
+          </Button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
+++ b/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
@@ -1,36 +1,36 @@
 'use client';
 
 import { PortalContext } from '@/components/me/AppPortalContext';
+import { portalGraphqlClient } from '@/lib/graphql-client';
 import {
-  registerRegisteredPlatformListFragment,
-  RegisterRegisteredPlatformsQuery,
-} from '@/components/registration/register/register.graphql';
-import { registerRegisteredPlatformFragment$data } from '@generated/registerRegisteredPlatformFragment.graphql';
-import { registerRegisteredPlatformListFragment$key } from '@generated/registerRegisteredPlatformListFragment.graphql';
-import { registerRegisteredPlatformsQuery } from '@generated/registerRegisteredPlatformsQuery.graphql';
+  RegisteredPlatformsListQuery,
+  useRegisteredPlatformsListQuery,
+} from '@graphql/generated';
+import { registeredPlatformsKeys } from '@graphql/registered-platforms/registered-platforms.keys';
 import { useContext } from 'react';
-import { useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
+
+export type ConnectedPlatform =
+  RegisteredPlatformsListQuery['registeredPlatforms'][number];
+
+const CONNECTED_PLATFORMS_VARIABLES = {
+  input: { onlyActive: true, identifier: null, onlyTrial: null },
+};
 
 export const useConnectedPlatforms = () => {
   const { isPersonalSpace } = useContext(PortalContext);
-  const queryData = useLazyLoadQuery<registerRegisteredPlatformsQuery>(
-    RegisterRegisteredPlatformsQuery,
+
+  const { data, isLoading, isError } = useRegisteredPlatformsListQuery(
+    portalGraphqlClient,
+    CONNECTED_PLATFORMS_VARIABLES,
     {
-      input: {
-        onlyActive: true,
-      },
+      queryKey: registeredPlatformsKeys.list(CONNECTED_PLATFORMS_VARIABLES),
     }
   );
 
-  const [data] = useRefetchableFragment<
-    registerRegisteredPlatformsQuery,
-    registerRegisteredPlatformListFragment$key
-  >(registerRegisteredPlatformListFragment, queryData);
+  const connectedPlatforms: ConnectedPlatform[] =
+    !isPersonalSpace && data?.registeredPlatforms
+      ? data.registeredPlatforms
+      : [];
 
-  return {
-    connectedPlatforms:
-      data.registeredPlatforms.length > 0 && !isPersonalSpace
-        ? (data.registeredPlatforms as registerRegisteredPlatformFragment$data[])
-        : ([] as registerRegisteredPlatformFragment$data[]),
-  };
+  return { connectedPlatforms, isLoading, isError };
 };

--- a/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
+++ b/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { PortalContext } from '@/components/me/AppPortalContext';
+import {
+  registerRegisteredPlatformListFragment,
+  RegisterRegisteredPlatformsQuery,
+} from '@/components/registration/register/register.graphql';
+import { registerRegisteredPlatformFragment$data } from '@generated/registerRegisteredPlatformFragment.graphql';
+import { registerRegisteredPlatformListFragment$key } from '@generated/registerRegisteredPlatformListFragment.graphql';
+import { registerRegisteredPlatformsQuery } from '@generated/registerRegisteredPlatformsQuery.graphql';
+import { useContext } from 'react';
+import { useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
+
+export const useConnectedPlatforms = () => {
+  const { isPersonalSpace } = useContext(PortalContext);
+  const queryData = useLazyLoadQuery<registerRegisteredPlatformsQuery>(
+    RegisterRegisteredPlatformsQuery,
+    {
+      input: {
+        onlyActive: true,
+      },
+    }
+  );
+
+  const [data] = useRefetchableFragment<
+    registerRegisteredPlatformsQuery,
+    registerRegisteredPlatformListFragment$key
+  >(registerRegisteredPlatformListFragment, queryData);
+
+  return {
+    connectedPlatforms:
+      data.registeredPlatforms.length > 0 && !isPersonalSpace
+        ? (data.registeredPlatforms as registerRegisteredPlatformFragment$data[])
+        : ([] as registerRegisteredPlatformFragment$data[]),
+  };
+};

--- a/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
+++ b/apps/frontend/src/components/connected-products/useConnectedPlatforms.ts
@@ -1,13 +1,11 @@
 'use client';
 
-import { PortalContext } from '@/components/me/AppPortalContext';
 import { portalGraphqlClient } from '@/lib/graphql-client';
 import {
   RegisteredPlatformsListQuery,
   useRegisteredPlatformsListQuery,
 } from '@graphql/generated';
 import { registeredPlatformsKeys } from '@graphql/registered-platforms/registered-platforms.keys';
-import { useContext } from 'react';
 
 export type ConnectedPlatform =
   RegisteredPlatformsListQuery['registeredPlatforms'][number];
@@ -17,8 +15,6 @@ const CONNECTED_PLATFORMS_VARIABLES = {
 };
 
 export const useConnectedPlatforms = () => {
-  const { isPersonalSpace } = useContext(PortalContext);
-
   const { data, isLoading, isError } = useRegisteredPlatformsListQuery(
     portalGraphqlClient,
     CONNECTED_PLATFORMS_VARIABLES,
@@ -27,10 +23,9 @@ export const useConnectedPlatforms = () => {
     }
   );
 
-  const connectedPlatforms: ConnectedPlatform[] =
-    !isPersonalSpace && data?.registeredPlatforms
-      ? data.registeredPlatforms
-      : [];
-
-  return { connectedPlatforms, isLoading, isError };
+  return {
+    connectedPlatforms: data?.registeredPlatforms ?? [],
+    isLoading,
+    isError,
+  };
 };

--- a/apps/frontend/src/components/menu/PrivateNavigation.test.tsx
+++ b/apps/frontend/src/components/menu/PrivateNavigation.test.tsx
@@ -22,7 +22,11 @@ const graphqlMocks = vi.hoisted(() => ({
     getRootKey: vi.fn(() => ['ServiceInstancesList']),
   }),
   useRegisteredPlatformsListQuery: Object.assign(vi.fn(), {
-    getKey: vi.fn((_variables?: unknown) => ['RegisteredPlatformsList']),
+    getKey: vi.fn((variables?: unknown) =>
+      variables === undefined
+        ? ['RegisteredPlatformsList']
+        : ['RegisteredPlatformsList', variables]
+    ),
     getRootKey: vi.fn(() => ['RegisteredPlatformsList']),
   }),
   useTrialDeploymentsEligibilityQuery: Object.assign(vi.fn(), {

--- a/apps/frontend/src/components/menu/use-private-navigation.test.ts
+++ b/apps/frontend/src/components/menu/use-private-navigation.test.ts
@@ -26,7 +26,11 @@ const graphqlMocks = vi.hoisted(() => ({
     getRootKey: vi.fn(() => ['ServiceInstancesList']),
   }),
   useRegisteredPlatformsListQuery: Object.assign(vi.fn(), {
-    getKey: vi.fn((_variables?: unknown) => ['RegisteredPlatformsList']),
+    getKey: vi.fn((variables?: unknown) =>
+      variables === undefined
+        ? ['RegisteredPlatformsList']
+        : ['RegisteredPlatformsList', variables]
+    ),
     getRootKey: vi.fn(() => ['RegisteredPlatformsList']),
   }),
   useTrialDeploymentsEligibilityQuery: Object.assign(vi.fn(), {
@@ -482,9 +486,16 @@ describe('usePrivateNavigation', () => {
 
       expect(graphqlMocks.useRegisteredPlatformsListQuery).toHaveBeenCalledWith(
         portalGraphqlClient,
-        undefined,
         {
-          queryKey: ['RegisteredPlatformsList'],
+          input: { identifier: null, onlyActive: null, onlyTrial: null },
+        },
+        {
+          queryKey: [
+            'RegisteredPlatformsList',
+            {
+              input: { identifier: null, onlyActive: null, onlyTrial: null },
+            },
+          ],
         }
       );
 

--- a/apps/frontend/src/components/menu/use-private-navigation.ts
+++ b/apps/frontend/src/components/menu/use-private-navigation.ts
@@ -41,6 +41,10 @@ import { serviceInstancesKeys } from '@graphql/service-instances/service-instanc
 import { trialKeys } from '@graphql/trial/trial.keys';
 import { useLocale, useTranslations } from 'next-intl';
 import { useContext, useMemo } from 'react';
+const PRIVATE_NAVIGATION_REGISTERED_PLATFORMS_VARIABLES = {
+  input: { identifier: null, onlyActive: null, onlyTrial: null },
+};
+
 const PRIVATE_NAVIGATION_SERVICE_INSTANCES_VARIABLES: ServiceInstancesListQueryVariables =
   {
     count: 50,
@@ -166,9 +170,15 @@ export const usePrivateNavigation = (): NavigationConfig => {
     }
   );
   const { data: registeredPlatformsQueryData } =
-    useRegisteredPlatformsListQuery(portalGraphqlClient, undefined, {
-      queryKey: registeredPlatformsKeys.list(),
-    });
+    useRegisteredPlatformsListQuery(
+      portalGraphqlClient,
+      PRIVATE_NAVIGATION_REGISTERED_PLATFORMS_VARIABLES,
+      {
+        queryKey: registeredPlatformsKeys.list(
+          PRIVATE_NAVIGATION_REGISTERED_PLATFORMS_VARIABLES
+        ),
+      }
+    );
   const {
     data: trialEligibilityData,
     isLoading: isTrialEligibilityLoading,

--- a/apps/frontend/src/components/registration/platform-identifier-mapping.ts
+++ b/apps/frontend/src/components/registration/platform-identifier-mapping.ts
@@ -10,6 +10,7 @@ export interface PlatformMetadata {
   learnMorePublicUrl: string;
   learnMorePrivateUrl: string;
   logoUrl: string;
+  docUrl: string;
 }
 
 export const PlatformMetadataMapping: Record<
@@ -21,12 +22,14 @@ export const PlatformMetadataMapping: Record<
     learnMorePublicUrl: '/cybersecurity-solutions/opencti-free-trial',
     learnMorePrivateUrl: '/app/service/opencti-free-trial',
     logoUrl: '/logo_opencti_dark.png',
+    docUrl: 'https://docs.opencti.io/latest/administration/hub/',
   },
   [PlatformIdentifierEnum.OPENAEV]: {
     name: 'OpenAEV',
     learnMorePublicUrl: '/cybersecurity-solutions/openaev-free-trial',
     learnMorePrivateUrl: '/app/service/openaev-free-trial',
     logoUrl: '/logo_openaev_dark.png',
+    docUrl: 'https://docs.openaev.io/latest/administration/hub/',
   },
 };
 


### PR DESCRIPTION
# Context
Show the number of how many products connected. Develop the dropdown to have all product information and update the top right icons to fit with new design. 
Old design : 
<img width="367" height="114" alt="Capture d’écran 2026-07-01 à 18 35 54" src="https://github.com/user-attachments/assets/ad55dcf1-9c92-49c4-be30-77ca4f4e79b2" />

New design : 
<img width="318" height="207" alt="Capture d’écran 2026-07-01 à 18 37 08" src="https://github.com/user-attachments/assets/83cd20b7-6bcf-489f-92e0-a5de80a1076a" />

Video : 
https://github.com/user-attachments/assets/d4a20547-b766-4ff3-9611-5bd3a99aae32

## How to test
Check that it displays the right amount of products in the header, and the right amount of trials in the dropdown
Check that buttons links to the right trial page and trial url
Check that footer buttons links to the corresponding documentation

## Related issues

- Related to #2662

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.