### PR TITLE
fix(telemetry): fixed 6h gauge cadence, export only from production/staging (#2761)

### DIFF
--- a/apps/backend/src/modules/telemetry/USAGE_TELEMETRY.md
+++ b/apps/backend/src/modules/telemetry/USAGE_TELEMETRY.md
@@ -7,8 +7,10 @@ The hub has two complementary telemetry pipelines:
 
 ## Transport
 
-- OTLP/HTTP to `https://telemetry.hub.filigran.io/v1/metrics` (production) or `https://telemetry.hub.staging.filigran.io/v1/metrics` (non-production environments).
-- Database counts are refreshed hourly; export happens every 6 hours (tighter cadence outside production).
+- Gauge telemetry only runs when the configured environment is `production` or `staging`. Feature environments, dev, prerelease, CI and developer machines never export (the hub deploys long-lived environments with `NODE_ENV=development`, so a dev-mode export path would flood the staging collector - one upload per 2 minutes per environment - and mint a throwaway instance identity for every CI run).
+- OTLP/HTTP to `https://telemetry.hub.filigran.io/v1/metrics` (production) or `https://telemetry.hub.staging.filigran.io/v1/metrics` (staging).
+- Fixed cadence for every environment: database counts are refreshed hourly, export happens every 6 hours.
+- `TELEMETRY_GAUGE_DEBUG=true` is the explicit opt-in for end-to-end pipeline testing: it enables gauge telemetry in any environment with a tight cadence (1 min refresh / 2 min export) towards the staging collector (production endpoint only in the production environment).
 - At startup the collector is probed once (POST `{}`, expect 200); when unreachable, gauge telemetry silently self-disables for the lifetime of the process.
 - Implemented in `telemetry-snapshot.app.ts` / `telemetry-snapshot.domain.ts` / `telemetry-snapshot.helper.ts`; started from `index.ts`, stopped via a shutdown hook.
 
@@ -42,6 +44,7 @@ All gauges are aggregate counts. Dimensions (OTLP attributes) are low-cardinalit
 
 ## Configuration
 
-| Env var          | Default | Description                                                                                                                               |
-| :--------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `TELEMETRY_TAGS` | (empty) | Comma-separated deployment tags (e.g. `saas,eu-west`) attached to every gauge export as the `filigran.telemetry.tags` resource attribute. |
+| Env var                 | Default | Description                                                                                                                               |
+| :---------------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `TELEMETRY_TAGS`        | (empty) | Comma-separated deployment tags (e.g. `saas,eu-west`) attached to every gauge export as the `filigran.telemetry.tags` resource attribute. |
+| `TELEMETRY_GAUGE_DEBUG` | (unset) | Set to `true` to force-enable gauge telemetry with the tight debug cadence (1 min refresh / 2 min export) for pipeline testing.           |

--- a/apps/backend/src/modules/telemetry/telemetry-snapshot.app.ts
+++ b/apps/backend/src/modules/telemetry/telemetry-snapshot.app.ts
@@ -20,6 +20,7 @@ import {
   getSnapshotObservations,
   normalizeTelemetryTags,
   probeTelemetryEndpoint,
+  resolveSnapshotTelemetrySettings,
   setSnapshotObservations,
 } from './telemetry-snapshot.helper';
 
@@ -36,18 +37,12 @@ import {
  * Mirrors the OpenCTI model: DELTA temporality, hardcoded collector
  * endpoints, and a startup connectivity probe that self-disables gauge
  * telemetry when the collector is unreachable.
+ *
+ * Gauge telemetry only runs in production and staging, at a fixed
+ * 1h-refresh / 6h-export cadence (see resolveSnapshotTelemetrySettings for
+ * the incident that motivated this): feature environments, dev/prerelease,
+ * CI and laptops never export.
  */
-
-const PRODUCTION_ENDPOINT = 'https://telemetry.hub.filigran.io/v1/metrics';
-const STAGING_ENDPOINT = 'https://telemetry.hub.staging.filigran.io/v1/metrics';
-
-const HOUR_MS = 60 * 60 * 1000;
-// Snapshot refresh (DB counts) and export cadences. Tighter outside
-// production so the pipeline can be exercised without waiting hours.
-const PROD_REFRESH_INTERVAL_MS = HOUR_MS;
-const PROD_EXPORT_INTERVAL_MS = 6 * HOUR_MS;
-const DEV_REFRESH_INTERVAL_MS = 60 * 1000;
-const DEV_EXPORT_INTERVAL_MS = 2 * 60 * 1000;
 
 type Meter = ReturnType<MeterProvider['getMeter']>;
 
@@ -81,8 +76,17 @@ const registerGauges = (meter: Meter): void => {
 };
 
 const startSnapshotTelemetry = async (): Promise<void> => {
-  const isProduction = portalConfig.environment === 'production';
-  const endpoint = isProduction ? PRODUCTION_ENDPOINT : STAGING_ENDPOINT;
+  const { enabled, endpoint, refreshIntervalMillis, exportIntervalMillis } =
+    resolveSnapshotTelemetrySettings(
+      portalConfig.environment,
+      process.env.TELEMETRY_GAUGE_DEBUG
+    );
+  if (!enabled) {
+    logApp.info('Gauge telemetry is disabled in this environment', {
+      environment: portalConfig.environment,
+    });
+    return;
+  }
 
   const reachable = await probeTelemetryEndpoint(endpoint);
   if (!reachable) {
@@ -112,13 +116,6 @@ const startSnapshotTelemetry = async (): Promise<void> => {
     // landed as a `tags` column on every metric row by the warehouse.
     attributes['filigran.telemetry.tags'] = tags.join(',');
   }
-
-  const exportIntervalMillis = isProduction
-    ? PROD_EXPORT_INTERVAL_MS
-    : DEV_EXPORT_INTERVAL_MS;
-  const refreshIntervalMillis = isProduction
-    ? PROD_REFRESH_INTERVAL_MS
-    : DEV_REFRESH_INTERVAL_MS;
 
   meterProvider = new MeterProvider({
     resource: resourceFromAttributes(attributes),

--- a/apps/backend/src/modules/telemetry/telemetry-snapshot.helper.test.ts
+++ b/apps/backend/src/modules/telemetry/telemetry-snapshot.helper.test.ts
@@ -4,8 +4,54 @@ import {
   getSnapshotObservations,
   normalizeTelemetryTags,
   probeTelemetryEndpoint,
+  resolveSnapshotTelemetrySettings,
   setSnapshotObservations,
 } from './telemetry-snapshot.helper';
+
+const HOUR_MS = 60 * 60 * 1000;
+const PROD_URL = 'https://telemetry.hub.filigran.io/v1/metrics';
+const STAGING_URL = 'https://telemetry.hub.staging.filigran.io/v1/metrics';
+
+describe('resolveSnapshotTelemetrySettings', () => {
+  it.each([
+    { environment: 'production', enabled: true, endpoint: PROD_URL },
+    { environment: 'staging', enabled: true, endpoint: STAGING_URL },
+    { environment: 'development', enabled: false, endpoint: STAGING_URL },
+    { environment: 'test', enabled: false, endpoint: STAGING_URL },
+    { environment: '', enabled: false, endpoint: STAGING_URL },
+  ])(
+    'is enabled=$enabled towards $endpoint in $environment',
+    ({ environment, enabled, endpoint }) => {
+      const settings = resolveSnapshotTelemetrySettings(environment, undefined);
+      expect(settings.enabled).toBe(enabled);
+      expect(settings.endpoint).toBe(endpoint);
+    }
+  );
+
+  it('always uses the fixed 1h refresh / 6h export cadence outside debug', () => {
+    for (const environment of ['production', 'staging', 'development']) {
+      const settings = resolveSnapshotTelemetrySettings(environment, undefined);
+      expect(settings.refreshIntervalMillis).toBe(HOUR_MS);
+      expect(settings.exportIntervalMillis).toBe(6 * HOUR_MS);
+    }
+  });
+
+  it('enables telemetry with the tight cadence only on explicit debug opt-in', () => {
+    const settings = resolveSnapshotTelemetrySettings('development', 'true');
+    expect(settings.enabled).toBe(true);
+    expect(settings.endpoint).toBe(STAGING_URL);
+    expect(settings.refreshIntervalMillis).toBe(60 * 1000);
+    expect(settings.exportIntervalMillis).toBe(2 * 60 * 1000);
+  });
+
+  it('ignores non-"true" debug flag values', () => {
+    for (const flag of ['1', 'TRUE', 'yes', '']) {
+      expect(
+        resolveSnapshotTelemetrySettings('development', flag).enabled
+      ).toBe(false);
+    }
+  });
+});
 
 describe('normalizeTelemetryTags', () => {
   it.each([

--- a/apps/backend/src/modules/telemetry/telemetry-snapshot.helper.ts
+++ b/apps/backend/src/modules/telemetry/telemetry-snapshot.helper.ts
@@ -3,6 +3,57 @@
  * and OpenTelemetry imports so they stay trivially unit-testable.
  */
 
+const PRODUCTION_ENDPOINT = 'https://telemetry.hub.filigran.io/v1/metrics';
+const STAGING_ENDPOINT = 'https://telemetry.hub.staging.filigran.io/v1/metrics';
+
+const HOUR_MS = 60 * 60 * 1000;
+// Fixed cadence for EVERY environment: DB counts hourly, export every 6h
+// (the shared Filigran contract). The debug cadence below exists only for
+// explicitly opted-in pipeline testing.
+const REFRESH_INTERVAL_MS = HOUR_MS;
+const EXPORT_INTERVAL_MS = 6 * HOUR_MS;
+const DEBUG_REFRESH_INTERVAL_MS = 60 * 1000;
+const DEBUG_EXPORT_INTERVAL_MS = 2 * 60 * 1000;
+
+export interface SnapshotTelemetrySettings {
+  enabled: boolean;
+  endpoint: string;
+  refreshIntervalMillis: number;
+  exportIntervalMillis: number;
+}
+
+/**
+ * Resolve whether and how gauge telemetry runs for a given environment.
+ *
+ * Gauge telemetry only starts in `production` and `staging`. Unlike the
+ * sibling products where "dev mode" means a developer laptop, the hub's
+ * infrastructure deploys long-lived environments with NODE_ENV=development
+ * (per-PR feature envs, dev, prerelease): letting those export - especially
+ * at a tighter dev cadence - flooded the staging collector with one upload
+ * every 2 minutes per environment and minted a fresh instance identity for
+ * every CI run. Hence: disabled everywhere else, fixed 1h-refresh /
+ * 6h-export cadence for everyone.
+ *
+ * `TELEMETRY_GAUGE_DEBUG=true` is the explicit opt-in for exercising the
+ * pipeline end-to-end (any environment, tight cadence, staging collector
+ * unless production).
+ */
+export const resolveSnapshotTelemetrySettings = (
+  environment: string,
+  debugFlag: string | undefined
+): SnapshotTelemetrySettings => {
+  const debug = debugFlag === 'true';
+  return {
+    enabled: debug || environment === 'production' || environment === 'staging',
+    endpoint:
+      environment === 'production' ? PRODUCTION_ENDPOINT : STAGING_ENDPOINT,
+    refreshIntervalMillis: debug
+      ? DEBUG_REFRESH_INTERVAL_MS
+      : REFRESH_INTERVAL_MS,
+    exportIntervalMillis: debug ? DEBUG_EXPORT_INTERVAL_MS : EXPORT_INTERVAL_MS,
+  };
+};
+
 /** One gauge observation: a value plus optional low-cardinality dimensions. */
 export interface GaugeObservation {
   value: number;


### PR DESCRIPTION
## Summary

Fixes the staging-collector flood caused by the gauge telemetry merged in #2760. Closes #2761.

The merged code copied the sibling products' "tighter cadence in dev" pattern (2-minute exports outside production). In OpenCTI/OpenGRC/XTM One, dev mode means a developer laptop; the hub's infrastructure however deploys long-lived environments with `NODE_ENV=development` (per-PR feature envs, dev, prerelease). Within an hour of the merge, 6 environments (dev hub + 5 renovate feature envs rebuilt from the post-merge merge-ref) were each uploading one S3 object every 2 minutes (~180 objects/hour), each CI/feature-env boot also minting a throwaway instance identity.

### Changes

- **Fixed 1h-refresh / 6h-export cadence for every environment** - no more environment-dependent export interval.
- **Gauge telemetry only starts in `production` and `staging`**: feature environments, dev, prerelease, CI and developer machines never export.
- **`TELEMETRY_GAUGE_DEBUG=true`** is the explicit opt-in for end-to-end pipeline testing (any environment, 1 min refresh / 2 min export, staging collector).
- Cadence/endpoint/gating resolution extracted to a pure `resolveSnapshotTelemetrySettings` helper with table-driven unit tests; `USAGE_TELEMETRY.md` updated.

### Rollout notes

- Merging this triggers the automatic Development + Prerelease deploys, muting the dev hub immediately.
- The 5 noisy feature envs (pr-2754...2758) go quiet as soon as their PRs' CI rebuilds their images from the post-merge merge-ref (next renovate sync), or on env deletion.
- Companion PRs widen the *dev-mode* export window from 2 minutes to 3 hours in OpenCTI, XTM One and OpenGRC so their laptop dev installs cannot reproduce this pattern against their staging collectors.

## Test plan

- [x] `yarn check-ts` - clean
- [x] `yarn lint` - clean
- [x] `yarn vitest run src/modules/telemetry` - 46 tests green (incl. new resolver suite)
- [x] Prettier clean on all touched files
