### PR TITLE
fix(document): newest document should not return images (#2768)

### DIFF
--- a/apps/backend/src/modules/document/document.app.test.ts
+++ b/apps/backend/src/modules/document/document.app.test.ts
@@ -1285,6 +1285,28 @@ describe('documentApp', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('should not include service_picture documents when no platformIdentifiers are given', async () => {
+      // Given — a service picture (logo) document alongside the shareable ones created in beforeEach
+      await DocumentApp.createDocumentWithChildrenAndMetadata(
+        {
+          name: 'Service logo',
+          description: 'description',
+          service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+          type: 'service_picture',
+          active: true,
+        },
+        []
+      );
+
+      // When — no platform filter provided (homepage / unauthenticated caller scenario)
+      const result = await DocumentApp.loadNewestDocuments(10);
+
+      // Then — only the 2 shareable docs from beforeEach should be returned;
+      // the service_picture document must not leak through the unfiltered query
+      expect(result.map((d) => d.name)).not.toContain('Service logo');
+      expect(result).toHaveLength(2);
+    });
+
     it('should enforce the 20-document cap when limit exceeds maximum', async () => {
       // Given
       const domainSpy = vi

--- a/apps/backend/src/modules/document/document.app.ts
+++ b/apps/backend/src/modules/document/document.app.ts
@@ -30,6 +30,7 @@ import {
   BOOLEAN_METADATA,
   DOCUMENT_TYPE,
   DocumentHelper,
+  DocumentTypeMappedByServiceDefinition,
   ManageableServiceDefinitionIdentifier,
   ServiceDefinitionIdentifiersByPlatformIdentifier,
 } from './document.helper';
@@ -642,7 +643,8 @@ export const DocumentApp = {
     const NEWEST_DOCUMENTS_MAX_LIMIT = 20;
 
     // Default to all shareable service definitions so that non-shareable
-    // types (e.g. vault) are never exposed when no platform filter is provided.
+    // types (e.g. vault, service_picture) are never exposed when no platform
+    // filter is provided.
     const allShareableIdentifiers = [
       ...ServiceDefinitionIdentifiersByPlatformIdentifier.values(),
     ].flat();
@@ -653,10 +655,14 @@ export const DocumentApp = {
         )
       : allShareableIdentifiers;
 
+    const documentTypes = serviceDefinitionIdentifiers.map(
+      (identifier) => DocumentTypeMappedByServiceDefinition[identifier]
+    );
+
     return DocumentDomain.loadNewestDocuments(
       Math.min(limit, NEWEST_DOCUMENTS_MAX_LIMIT),
       ALL_METADATA_KEYS,
-      serviceDefinitionIdentifiers
+      documentTypes
     );
   },
 

--- a/apps/backend/src/modules/document/document.helper.ts
+++ b/apps/backend/src/modules/document/document.helper.ts
@@ -84,7 +84,7 @@ export const ALL_METADATA_KEYS: DocumentMetadataKeyCode[] = Array.from(
 
 export const ServiceDefinitionIdentifiersByPlatformIdentifier = new Map<
   PlatformIdentifier,
-  ServiceDefinitionIdentifier[]
+  ManageableServiceDefinitionIdentifier[]
 >([
   [
     PlatformIdentifier.Opencti,
@@ -116,7 +116,7 @@ export type DOCUMENT_TYPE =
   | typeof OPENCTI_PLAYBOOK_DOCUMENT_TYPE
   | typeof VAULT_DOCUMENT_TYPE;
 
-const DocumentTypeMappedByServiceDefinition: Record<
+export const DocumentTypeMappedByServiceDefinition: Record<
   ManageableServiceDefinitionIdentifier,
   DOCUMENT_TYPE
 > = {

--- a/apps/backend/src/modules/document/domain/document.domain.test.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.test.ts
@@ -18,7 +18,6 @@ import {
   IntegrationType,
   LogicalOperator,
   OrderingMode,
-  ServiceDefinitionIdentifier,
 } from '../../../__generated__/resolvers-types';
 import type { DocumentMetadataKey } from '../../../model/kanel/public/DocumentMetadata';
 import { OPENAEV_SCENARIO_DOCUMENT_TYPE } from '../../shareable-resource/openaev/scenario/scenario.model';
@@ -1063,7 +1062,7 @@ describe('document domain', () => {
       expect(result[0]?.id).toBe(activeDoc.id);
     });
 
-    it('should filter documents by serviceDefinitionIdentifiers', async () => {
+    it('should filter documents by documentTypes', async () => {
       // Given
       const integrationDoc = await TestHelper.document.create({
         name: 'Integration document',
@@ -1088,7 +1087,40 @@ describe('document domain', () => {
       const result = await DocumentDomain.loadNewestDocuments(
         10,
         [],
-        [ServiceDefinitionIdentifier.OpenctiIntegrations]
+        [OPENCTI_INTEGRATION_DOCUMENT_TYPE]
+      );
+
+      // Then
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe(integrationDoc.id);
+    });
+
+    it('should exclude service_picture documents when documentTypes filter does not include it', async () => {
+      // Given
+      const integrationDoc = await TestHelper.document.create({
+        name: 'Integration document',
+        type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
+        slug: 'integration-document',
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        active: true,
+      });
+      await TestHelper.document.create({
+        name: 'Service logo',
+        type: 'service_picture',
+        slug: 'service-logo',
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        active: true,
+      });
+
+      // When
+      const result = await DocumentDomain.loadNewestDocuments(
+        10,
+        [],
+        [OPENCTI_INTEGRATION_DOCUMENT_TYPE]
       );
 
       // Then

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -6,7 +6,6 @@ import {
   IntegrationType,
   Organization,
   QueryDocumentsArgs,
-  ServiceDefinitionIdentifier,
   UpdateDocumentInput,
 } from '../../../__generated__/resolvers-types';
 import {
@@ -25,7 +24,7 @@ import {
   ConnectorV2,
   INTEGRATION_CONNECTOR_V2_METADATA_KEYS,
 } from '../../shareable-resource/opencti/integration/integration.model';
-import { Document, WithDocumentId } from '../document.helper';
+import { Document, DOCUMENT_TYPE, WithDocumentId } from '../document.helper';
 
 import { requestContext } from '../../../context/request.context';
 import { OrganizationId } from '../../../model/kanel/public/Organization';
@@ -495,20 +494,10 @@ export const DocumentDomain = {
   loadNewestDocuments: async (
     limit: number,
     include_metadata: DocumentMetadataKeyCode[] = [],
-    serviceDefinitionIdentifiers?: ServiceDefinitionIdentifier[]
+    documentTypes?: DOCUMENT_TYPE[]
   ): Promise<Document[]> => {
     const query = db<Document>('Document')
       .select('Document.*')
-      .join(
-        'ServiceInstance',
-        'Document.service_instance_id',
-        'ServiceInstance.id'
-      )
-      .join(
-        'ServiceDefinition',
-        'ServiceInstance.service_definition_id',
-        'ServiceDefinition.id'
-      )
       .where('Document.active', true)
       .whereNotExists(function () {
         this.select(dbRaw('1'))
@@ -518,11 +507,8 @@ export const DocumentDomain = {
           );
       })
       .modify((qb) => {
-        if (serviceDefinitionIdentifiers?.length) {
-          qb.whereIn(
-            'ServiceDefinition.identifier',
-            serviceDefinitionIdentifiers
-          );
+        if (documentTypes?.length) {
+          qb.whereIn('Document.type', documentTypes);
         }
       })
       .orderBy('Document.created_at', 'desc')


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

The query retrieving the newest documents also retrieve images, leading to displaying the wrong number of documents in the new homepage, when there are orphaned documents


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Test there is no regression on the newest documents display. Then only on dev we can check all 8 resources are displayed.
Alignment is tracked in another issue.

## Related issues

- Related to #2768

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.