### PR TITLE
feat(telemetry): stamp events with the emitting hub instance identity (#2805)

### DIFF
--- a/apps/backend/src/es-migrations/1783668792737-add-hub-instance-id.ts
+++ b/apps/backend/src/es-migrations/1783668792737-add-hub-instance-id.ts
@@ -1,0 +1,105 @@
+'use strict';
+
+import { esDbClient } from '../thirdparty/elasticsearch/client.js';
+
+const FULL_TEMPLATE_PROPERTIES = {
+  event_type: { type: 'keyword' },
+  organization_id: { type: 'keyword' },
+  organization_name: { type: 'keyword' },
+  user_id: { type: 'keyword' },
+  '@timestamp': { type: 'date', format: 'strict_date_time' },
+  source: { type: 'keyword' },
+  service: { type: 'keyword' },
+  service_type: { type: 'keyword' },
+  resource_id: { type: 'keyword' },
+  resource_title: { type: 'text' },
+  status: { type: 'keyword' },
+  target_product: { type: 'keyword' },
+  platform_id: { type: 'keyword' },
+  organization_type: { type: 'keyword' },
+  platform_contract: { type: 'keyword' },
+  platform_version: { type: 'keyword' },
+  domains: { type: 'keyword' },
+  activity_sector: { type: 'keyword' },
+  deployment_id: { type: 'keyword' },
+  deployment_type: { type: 'keyword' },
+  email: { type: 'keyword' },
+  job_title: { type: 'keyword' },
+  region: { type: 'keyword' },
+  use_case: { type: 'keyword' },
+  cancellation_reason: {
+    type: 'text',
+    fields: {
+      keyword: { type: 'keyword', ignore_above: 256 },
+    },
+  },
+  platform_url: { type: 'keyword' },
+  existing_users_count: { type: 'integer' },
+  tenant_id: { type: 'keyword' },
+} as const;
+
+// The durable anonymous identity of the EMITTING hub instance (same
+// PlatformMetadata id as the gauge telemetry's service.instance.id) plus its
+// environment. Lets the warehouse attribute every event to the production
+// hub vs staging/dev deployments; note platform_id is the REGISTERED
+// OpenCTI/OpenAEV platform, not the hub itself.
+const NEW_PROPERTIES = {
+  hub_instance_id: { type: 'keyword' },
+  hub_environment: { type: 'keyword' },
+} as const;
+
+const TEMPLATE_CONFIG = {
+  aliases: { telemetry: {} },
+  priority: 100,
+  version: 1,
+  _meta: {
+    description: 'Template for telemetry indices',
+    created_by: 'migration',
+  },
+};
+
+export const up = async function (next: () => void) {
+  await esDbClient.getIndices().putIndexTemplate({
+    name: 'telemetry-template',
+    index_patterns: ['telemetry_v*'],
+    template: {
+      mappings: {
+        properties: {
+          ...FULL_TEMPLATE_PROPERTIES,
+          ...NEW_PROPERTIES,
+        },
+      },
+      aliases: TEMPLATE_CONFIG.aliases,
+    },
+    priority: TEMPLATE_CONFIG.priority,
+    version: TEMPLATE_CONFIG.version,
+    _meta: TEMPLATE_CONFIG._meta,
+  });
+
+  await esDbClient.getIndices().putMapping({
+    index: 'telemetry_v1',
+    body: {
+      properties: NEW_PROPERTIES,
+    },
+  });
+
+  next();
+};
+
+export const down = async function (next: () => void) {
+  await esDbClient.getIndices().putIndexTemplate({
+    name: 'telemetry-template',
+    index_patterns: ['telemetry_v*'],
+    template: {
+      mappings: {
+        properties: FULL_TEMPLATE_PROPERTIES,
+      },
+      aliases: TEMPLATE_CONFIG.aliases,
+    },
+    priority: TEMPLATE_CONFIG.priority,
+    version: TEMPLATE_CONFIG.version,
+    _meta: TEMPLATE_CONFIG._meta,
+  });
+
+  next();
+};

--- a/apps/backend/src/modules/telemetry/USAGE_TELEMETRY.md
+++ b/apps/backend/src/modules/telemetry/USAGE_TELEMETRY.md
@@ -2,7 +2,7 @@
 
 The hub has two complementary telemetry pipelines:
 
-1. **Events** (existing) — user/business events (`login`, `register`, `unregister`, `create_deployment`, `download`, ...) indexed into the hub's Elasticsearch (`telemetry` alias) via the pg-boss queue, replicated to the Filigran data warehouse. Events answer _"what happened"_ (funnels, activity).
+1. **Events** (existing) — user/business events (`login`, `register`, `unregister`, `create_deployment`, `download`, ...) indexed into the hub's Elasticsearch (`telemetry` alias) via the pg-boss queue, replicated to the Filigran data warehouse. Events answer _"what happened"_ (funnels, activity). Every event is stamped by `TelemetryApp.sendTelemetryEvent` with `hub_instance_id` (the same durable PlatformMetadata identity the gauges export as `service.instance.id`) and `hub_environment` (`production` / `staging` / ...), so the warehouse can attribute events to the production hub vs staging/dev deployments. Note the pre-existing `platform_id` event field identifies the _registered OpenCTI/OpenAEV platform_, not the hub instance.
 2. **Gauges** (this document) — periodic snapshots of aggregate counts exported over OTLP/HTTP to the dedicated Filigran collector, exactly like OpenCTI / OpenAEV / XTM One / OpenGRC. Gauges answer _"what is the current state"_, which the event stream fundamentally cannot (e.g. a platform that unregisters and re-registers inflates event counts forever, while the registered-platforms gauge always reports the truth from the database).
 
 ## Transport

--- a/apps/backend/src/modules/telemetry/telemetry.app.test.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.app.test.ts
@@ -9,6 +9,7 @@ import {
   it,
   vi,
 } from 'vitest';
+import portalConfig from '../../config';
 import { esDbClient } from '../../thirdparty/elasticsearch/client';
 import { PgBossProducer } from '../../thirdparty/pgboss/producer';
 import { TELEMETRY_QUEUES } from '../../thirdparty/pgboss/telemetry.jobs';
@@ -51,6 +52,20 @@ vi.mock('config', async (importOriginal) => {
       get: vi.fn(mod.default.get.bind(mod.default)),
       has: mod.default.has.bind(mod.default),
     },
+  };
+});
+
+// The event pipeline stamps the durable hub instance identity on every
+// event; pin it so assertions do not depend on the test database contents.
+vi.mock('./telemetry-snapshot.domain', async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import('./telemetry-snapshot.domain')>();
+  return {
+    ...mod,
+    loadInstanceIdentity: vi.fn().mockResolvedValue({
+      instanceId: 'test-hub-instance-id',
+      instanceCreation: '2026-01-01T00:00:00.000Z',
+    }),
   };
 });
 
@@ -527,6 +542,14 @@ describe('telemetryApp', () => {
       service: TelemetryEventService.INTEGRATIONS_LIBRARY,
     };
 
+    // sendTelemetryEvent stamps the hub identity before enqueueing/indexing.
+    const hubIdentity = {
+      hub_instance_id: 'test-hub-instance-id',
+      hub_environment: portalConfig.environment,
+    };
+    const enrichedLoginEvent = { ...loginEvent, ...hubIdentity };
+    const enrichedSubscribeEvent = { ...subscribeEvent, ...hubIdentity };
+
     describe('when queue processing is disabled', () => {
       beforeEach(() => {
         indexSpy = vi
@@ -547,7 +570,7 @@ describe('telemetryApp', () => {
 
         expect(indexSpy).toHaveBeenCalledExactlyOnceWith({
           index: 'telemetry',
-          document: loginEvent,
+          document: enrichedLoginEvent,
         });
         expect(pgBossSendSpy).not.toHaveBeenCalled();
       });
@@ -584,7 +607,7 @@ describe('telemetryApp', () => {
 
         expect(pgBossSendSpy).toHaveBeenCalledExactlyOnceWith(
           TELEMETRY_QUEUES.EVENTS,
-          { event: loginEvent }
+          { event: enrichedLoginEvent }
         );
         expect(indexSpy).not.toHaveBeenCalled();
       });
@@ -594,7 +617,7 @@ describe('telemetryApp', () => {
 
         expect(pgBossSendSpy).toHaveBeenCalledExactlyOnceWith(
           TELEMETRY_QUEUES.EVENTS,
-          { event: subscribeEvent }
+          { event: enrichedSubscribeEvent }
         );
         expect(indexSpy).not.toHaveBeenCalled();
       });
@@ -607,7 +630,7 @@ describe('telemetryApp', () => {
 
         expect(logSpy).toHaveBeenCalledWith(
           'Failed to enqueue telemetry event',
-          { event: loginEvent, error: sendError }
+          { event: enrichedLoginEvent, error: sendError }
         );
         expect(indexSpy).not.toHaveBeenCalled();
       });
@@ -634,7 +657,7 @@ describe('telemetryApp', () => {
 
         expect(pgBossSendSpy).toHaveBeenCalledExactlyOnceWith(
           TELEMETRY_QUEUES.EVENTS,
-          { event: loginEvent }
+          { event: enrichedLoginEvent }
         );
         expect(indexSpy).not.toHaveBeenCalled();
       });
@@ -644,7 +667,7 @@ describe('telemetryApp', () => {
 
         expect(indexSpy).toHaveBeenCalledExactlyOnceWith({
           index: 'telemetry',
-          document: subscribeEvent,
+          document: enrichedSubscribeEvent,
         });
         expect(pgBossSendSpy).not.toHaveBeenCalled();
       });

--- a/apps/backend/src/modules/telemetry/telemetry.app.test.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.app.test.ts
@@ -14,7 +14,8 @@ import { esDbClient } from '../../thirdparty/elasticsearch/client';
 import { PgBossProducer } from '../../thirdparty/pgboss/producer';
 import { TELEMETRY_QUEUES } from '../../thirdparty/pgboss/telemetry.jobs';
 import { logApp } from '../../utils/app-logger.util';
-import { TelemetryApp } from './telemetry.app';
+import { loadInstanceIdentity } from './telemetry-snapshot.domain';
+import { resetHubIdentityCacheForTests, TelemetryApp } from './telemetry.app';
 import {
   TelemetryEventService,
   TelemetryEventServiceType,
@@ -670,6 +671,97 @@ describe('telemetryApp', () => {
           document: enrichedSubscribeEvent,
         });
         expect(pgBossSendSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('hub identity stamping', () => {
+      const identityLoadError = new Error('database is down');
+
+      beforeEach(() => {
+        resetHubIdentityCacheForTests();
+        indexSpy = vi
+          .spyOn(esDbClient, 'index')
+          .mockResolvedValue(mockWriteResponse);
+        pgBossSendSpy = vi
+          .spyOn(PgBossProducer, 'send')
+          .mockResolvedValue('job-id');
+        vi.mocked(config.get).mockImplementation((key: string) => {
+          if (key === 'telemetry_use_queue_processing') return false;
+          if (key === 'telemetry_queued_event_types') return [];
+          return realConfigGet(key);
+        });
+      });
+
+      afterEach(() => {
+        vi.mocked(loadInstanceIdentity).mockResolvedValue({
+          instanceId: 'test-hub-instance-id',
+          instanceCreation: '2026-01-01T00:00:00.000Z',
+        });
+        resetHubIdentityCacheForTests();
+      });
+
+      it('should load the identity once and reuse it for subsequent events', async () => {
+        await TelemetryApp.sendTelemetryEvent(loginEvent);
+        await TelemetryApp.sendTelemetryEvent(subscribeEvent);
+
+        expect(loadInstanceIdentity).toHaveBeenCalledOnce();
+        expect(indexSpy).toHaveBeenNthCalledWith(1, {
+          index: 'telemetry',
+          document: enrichedLoginEvent,
+        });
+        expect(indexSpy).toHaveBeenNthCalledWith(2, {
+          index: 'telemetry',
+          document: enrichedSubscribeEvent,
+        });
+      });
+
+      it('should stamp unknown on load failure and not retry within the backoff window', async () => {
+        vi.mocked(loadInstanceIdentity).mockRejectedValue(identityLoadError);
+        const logErrorSpy = vi.spyOn(logApp, 'error');
+
+        await TelemetryApp.sendTelemetryEvent(loginEvent);
+        await TelemetryApp.sendTelemetryEvent(loginEvent);
+
+        expect(loadInstanceIdentity).toHaveBeenCalledOnce();
+        expect(logErrorSpy).toHaveBeenCalledExactlyOnceWith(
+          'Failed to load hub instance identity for telemetry',
+          { error: identityLoadError }
+        );
+        expect(indexSpy).toHaveBeenCalledTimes(2);
+        expect(indexSpy).toHaveBeenLastCalledWith({
+          index: 'telemetry',
+          document: {
+            ...loginEvent,
+            hub_instance_id: 'unknown',
+            hub_environment: portalConfig.environment,
+          },
+        });
+      });
+
+      it('should retry the identity load after the backoff window', async () => {
+        vi.useFakeTimers();
+        vi.mocked(loadInstanceIdentity).mockRejectedValueOnce(
+          identityLoadError
+        );
+
+        await TelemetryApp.sendTelemetryEvent(loginEvent);
+        expect(indexSpy).toHaveBeenLastCalledWith({
+          index: 'telemetry',
+          document: {
+            ...loginEvent,
+            hub_instance_id: 'unknown',
+            hub_environment: portalConfig.environment,
+          },
+        });
+
+        vi.advanceTimersByTime(61_000);
+        await TelemetryApp.sendTelemetryEvent(loginEvent);
+
+        expect(loadInstanceIdentity).toHaveBeenCalledTimes(2);
+        expect(indexSpy).toHaveBeenLastCalledWith({
+          index: 'telemetry',
+          document: enrichedLoginEvent,
+        });
       });
     });
   });

--- a/apps/backend/src/modules/telemetry/telemetry.app.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.app.ts
@@ -3,6 +3,7 @@ import {
   OneClickDeployInput,
   PlatformIdentifier,
 } from '../../__generated__/resolvers-types';
+import portalConfig from '../../config';
 import { requestContext } from '../../context/request.context';
 import { OneClickDeploymentInitializer } from '../../model/kanel/public/OneClickDeployment';
 import { UserId } from '../../model/kanel/public/User';
@@ -12,7 +13,6 @@ import { TELEMETRY_QUEUES } from '../../thirdparty/pgboss/telemetry.jobs';
 import { logApp } from '../../utils/app-logger.util';
 import { ErrorCode } from '../../utils/error/error.code';
 import { extractId } from '../../utils/utils';
-import portalConfig from '../../config';
 import { OrganizationDomain } from '../organization-management/organization/organization.domain';
 import { ServiceInstanceDomain } from '../service/instance/service-instance.domain';
 import { OneClickDeploymentDomain } from './one-click-deployment.domain';

--- a/apps/backend/src/modules/telemetry/telemetry.app.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.app.ts
@@ -12,9 +12,11 @@ import { TELEMETRY_QUEUES } from '../../thirdparty/pgboss/telemetry.jobs';
 import { logApp } from '../../utils/app-logger.util';
 import { ErrorCode } from '../../utils/error/error.code';
 import { extractId } from '../../utils/utils';
+import portalConfig from '../../config';
 import { OrganizationDomain } from '../organization-management/organization/organization.domain';
 import { ServiceInstanceDomain } from '../service/instance/service-instance.domain';
 import { OneClickDeploymentDomain } from './one-click-deployment.domain';
+import { loadInstanceIdentity } from './telemetry-snapshot.domain';
 import {
   TelemetryHelper,
   TelemetryTargetProductMappedByPlatformIdentifier,
@@ -43,6 +45,41 @@ const useQueueProcessing = (): boolean =>
 const getQueuedEventTypes = (): string[] =>
   config.get<string[]>('telemetry_queued_event_types');
 
+// The durable instance identity is loaded once and cached for the process
+// lifetime (it is seeded by the add_platform_metadata migration and never
+// changes). A failed load resolves to 'unknown' for the in-flight event but
+// resets the cache so later events retry instead of being tagged 'unknown'
+// forever.
+let hubInstanceIdPromise: Promise<string> | undefined;
+
+const getHubInstanceId = (): Promise<string> => {
+  hubInstanceIdPromise ??= loadInstanceIdentity().then(
+    ({ instanceId }) => instanceId,
+    (error) => {
+      hubInstanceIdPromise = undefined;
+      logApp.error('Failed to load hub instance identity for telemetry', {
+        error,
+      });
+      return 'unknown';
+    }
+  );
+  return hubInstanceIdPromise;
+};
+
+/**
+ * Stamp the emitting hub instance on the event before it leaves the process
+ * (both the pg-boss and the synchronous ES paths go through this). Without
+ * it the warehouse cannot tell production events apart from staging/dev
+ * hubs replicating into the same pipeline.
+ */
+const withHubIdentity = async (
+  event: TelemetryEvent
+): Promise<TelemetryEvent> => ({
+  ...event,
+  hub_instance_id: await getHubInstanceId(),
+  hub_environment: portalConfig.environment,
+});
+
 export const TelemetryApp = {
   async indexTelemetryEvent(event: TelemetryEvent) {
     await esDbClient.index({
@@ -51,8 +88,9 @@ export const TelemetryApp = {
     });
   },
 
-  async sendTelemetryEvent(event: TelemetryEvent) {
+  async sendTelemetryEvent(rawEvent: TelemetryEvent) {
     try {
+      const event = await withHubIdentity(rawEvent);
       if (useQueueProcessing()) {
         const queuedTypes = getQueuedEventTypes();
         if (
@@ -74,7 +112,10 @@ export const TelemetryApp = {
         });
       });
     } catch (error) {
-      logApp.error('Error sending telemetry event ', { event, error });
+      logApp.error('Error sending telemetry event ', {
+        event: rawEvent,
+        error,
+      });
     }
   },
 

--- a/apps/backend/src/modules/telemetry/telemetry.app.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.app.ts
@@ -47,23 +47,45 @@ const getQueuedEventTypes = (): string[] =>
 
 // The durable instance identity is loaded once and cached for the process
 // lifetime (it is seeded by the add_platform_metadata migration and never
-// changes). A failed load resolves to 'unknown' for the in-flight event but
-// resets the cache so later events retry instead of being tagged 'unknown'
-// forever.
+// changes). A failed load resolves to 'unknown' for the in-flight events and
+// only retries after a backoff window, so a persistent database outage does
+// not trigger one identity query + one error log per emitted event.
+const UNKNOWN_HUB_INSTANCE_ID = 'unknown';
+const FAILED_IDENTITY_LOAD_BACKOFF_MS = 60_000;
+
 let hubInstanceIdPromise: Promise<string> | undefined;
+let lastFailedIdentityLoadAtMs: number | undefined;
 
 const getHubInstanceId = (): Promise<string> => {
-  hubInstanceIdPromise ??= loadInstanceIdentity().then(
-    ({ instanceId }) => instanceId,
-    (error) => {
-      hubInstanceIdPromise = undefined;
-      logApp.error('Failed to load hub instance identity for telemetry', {
-        error,
-      });
-      return 'unknown';
+  if (hubInstanceIdPromise === undefined) {
+    if (
+      lastFailedIdentityLoadAtMs !== undefined &&
+      Date.now() - lastFailedIdentityLoadAtMs < FAILED_IDENTITY_LOAD_BACKOFF_MS
+    ) {
+      return Promise.resolve(UNKNOWN_HUB_INSTANCE_ID);
     }
-  );
+    hubInstanceIdPromise = loadInstanceIdentity().then(
+      ({ instanceId }) => {
+        lastFailedIdentityLoadAtMs = undefined;
+        return instanceId;
+      },
+      (error) => {
+        hubInstanceIdPromise = undefined;
+        lastFailedIdentityLoadAtMs = Date.now();
+        logApp.error('Failed to load hub instance identity for telemetry', {
+          error,
+        });
+        return UNKNOWN_HUB_INSTANCE_ID;
+      }
+    );
+  }
   return hubInstanceIdPromise;
+};
+
+/** Test-only: reset the memoized hub identity between test cases. */
+export const resetHubIdentityCacheForTests = (): void => {
+  hubInstanceIdPromise = undefined;
+  lastFailedIdentityLoadAtMs = undefined;
 };
 
 /**

--- a/apps/backend/src/modules/telemetry/telemetry.types.ts
+++ b/apps/backend/src/modules/telemetry/telemetry.types.ts
@@ -37,6 +37,16 @@ export interface BaseTelemetryEvent {
   user_id?: string;
   '@timestamp': string;
   source: TelemetrySource;
+  /**
+   * Durable anonymous id of the hub instance that emitted the event (same
+   * PlatformMetadata identity as the gauge telemetry's service.instance.id).
+   * Set centrally by TelemetryApp.sendTelemetryEvent, never by builders:
+   * it lets the warehouse attribute events to the production hub vs
+   * staging/dev deployments, which the event payload otherwise cannot.
+   */
+  hub_instance_id?: string;
+  /** Hub environment (production / staging / ...), set with hub_instance_id. */
+  hub_environment?: string;
 }
 
 export interface LoginEvent extends BaseTelemetryEvent {


### PR DESCRIPTION
Closes #2805

## Summary

- Every telemetry EVENT is now stamped with the emitting hub's identity before it leaves the process: hub_instance_id (the durable anonymous PlatformMetadata id, the same identity the gauge pipeline exports as service.instance.id) and hub_environment (production / staging / ...).
- The stamping happens centrally in TelemetryApp.sendTelemetryEvent, the single funnel for both the pg-boss queue path and the synchronous Elasticsearch path, so builders stay untouched. The identity is loaded once and memoized for the process lifetime.
- A failed identity load resolves to 'unknown' for the in-flight events and retries only after a 60s backoff window, so a persistent database outage does not trigger one identity query and one error log per emitted event (addresses the Copilot review comment).
- New ES migration adds both fields as keyword to the telemetry-template and the live telemetry_v1 mapping (same pattern as the add-tenant-id migration).
- USAGE_TELEMETRY.md documents the new fields and clarifies that the pre-existing platform_id event field is the registered OpenCTI/OpenAEV platform, not the hub instance.

## Why

Once events are replicated to the Filigran data warehouse, there is no way to attribute them to the production hub vs staging/dev deployments - unlike the gauge telemetry, which carries service.instance.id. This blocks instance-grain filtering on the warehouse's event-based marts (active users, logins, registrations, trial launches). Counterpart warehouse work happens in FiligranHQ/enterprise-data-platform.

## Notes

- Historical events keep NULL for both fields; only events emitted after this release are stamped.
- Airbyte will pick the new columns up automatically on the next schema refresh of the Elasticsearch source.

## Test plan

- [x] tsc --noEmit passes
- [x] eslint + prettier pass on changed files
- [x] telemetry.app.test.ts updated for the enriched payloads, plus three new tests covering the identity memoization, the 'unknown' fallback + single error log within the backoff window, and the retry after the window elapses (runs in CI; the local machine has no test database configured)
- [ ] After deploy: new events in the telemetry index carry hub_instance_id matching the gauge service.instance.id
