### PR TITLE
fix(registration): Accept directly organizationId if not encoded (#2828)

### DIFF
--- a/apps/backend/src/modules/registration/registration.resolver.ts
+++ b/apps/backend/src/modules/registration/registration.resolver.ts
@@ -94,10 +94,23 @@ const resolvers: Resolvers = {
   Mutation: {
     registerPlatform: async (_, { input }) => {
       try {
+        const { id: decodedId, type: decodedType } = fromGlobalId(
+          input.organizationId
+        );
+
+        const ALLOWED_TYPES = [
+          'Organization',
+          'IsPlatformRegisteredOrganization',
+        ];
+
+        const organizationId = ALLOWED_TYPES.includes(decodedType)
+          ? decodedId
+          : input.organizationId;
+
         const payload = {
           ...input,
           // type may not be an OrganizationId, but can be a IsPlatformRegisteredOrganization
-          organizationId: fromGlobalId(input.organizationId).id,
+          organizationId,
         };
         const token = await RegistrationApp.registerPlatform(payload);
         return { token };

--- a/apps/backend/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
+++ b/apps/backend/src/modules/registration/test/resolver/registration.resolver.registerPlatform.test.ts
@@ -17,10 +17,53 @@ import { RegistrationApp } from '../../registration.app';
 import registrationResolver from '../../registration.resolver';
 
 describe('mutation.registerPlatform', () => {
-  it('should decode organizationId from global ID before calling registrationApp and return the token', async () => {
+  it.each`
+    organizationType                      | description
+    ${'Organization'}                     | ${'standard Organization global id'}
+    ${'IsPlatformRegisteredOrganization'} | ${'isPlatformRegistered organization global id'}
+  `(
+    'should decode $description before calling registrationApp and return the token',
+    async ({ organizationType }) => {
+      // Given
+      const rawOrgId = TEST_ORGANIZATIONS.FILIGRAN.ID;
+      const globalOrgId = toGlobalId(organizationType, rawOrgId);
+      const generatedToken = uuidv4();
+      const platformInput = {
+        id: uuidv4(),
+        url: 'http://example.com',
+        title: 'My Platform',
+        contract: PlatformContract.Ee,
+        version: '1.0.0',
+      };
+      const input: RegisterPlatformInput = {
+        organizationId: globalOrgId,
+        platform: platformInput,
+        identifier: PlatformIdentifier.Opencti,
+      };
+      vi.spyOn(RegistrationApp, 'registerPlatform').mockResolvedValue(
+        generatedToken
+      );
+
+      // When
+      const result = await registrationResolver.Mutation!.registerPlatform!(
+        {},
+        { input },
+        contextSimpleUserFiligran2,
+        GRAPHQL_RESOLVE_INFO
+      );
+
+      // Then
+      expect(RegistrationApp.registerPlatform).toHaveBeenCalledWith({
+        ...input,
+        organizationId: rawOrgId,
+      });
+      expect(result).toMatchObject({ token: generatedToken });
+    }
+  );
+
+  it('should keep organizationId unchanged when is not encoded', async () => {
     // Given
     const rawOrgId = TEST_ORGANIZATIONS.FILIGRAN.ID;
-    const globalOrgId = toGlobalId('Organization', rawOrgId);
     const generatedToken = uuidv4();
     const platformInput = {
       id: uuidv4(),
@@ -30,7 +73,7 @@ describe('mutation.registerPlatform', () => {
       version: '1.0.0',
     };
     const input: RegisterPlatformInput = {
-      organizationId: globalOrgId,
+      organizationId: rawOrgId,
       platform: platformInput,
       identifier: PlatformIdentifier.Opencti,
     };
@@ -47,10 +90,7 @@ describe('mutation.registerPlatform', () => {
     );
 
     // Then
-    expect(RegistrationApp.registerPlatform).toHaveBeenCalledWith({
-      ...input,
-      organizationId: rawOrgId,
-    });
+    expect(RegistrationApp.registerPlatform).toHaveBeenCalledWith(input);
     expect(result).toMatchObject({ token: generatedToken });
   });
 


### PR DESCRIPTION
# Context
> One user had the problem on production and I had the problem on the local dev, while registration, the organizationId can be sent already decoded. Then, if we decode > We have an error. 
> This PR takes the param organizationId if the decoded organizationId is null. 

## How to test
- You should see no regression on registration. 

## Related issues

- Related to #2828

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [X] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
- [X] Hope