### PR TITLE
refactor(register): split components and improve steps handling (#923)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -797,7 +797,7 @@
         "Description": "This tab will be closed soon",
         "Title": "OpenCTI product connected successfully"
       },
-      "TooMuchOrganization": {
+      "TooManyOrganizations": {
         "Description1": "Your OpenCTI product {platformTitle} will be re-connected under the same organization due to capability restrictions.",
         "Description2": "If you wish to request a change, please contact your organization's administrator.",
         "Title": "Product Re-connection Notice"
@@ -827,7 +827,7 @@
       "Description": "This tab will be closed soon",
       "Title": "{platformIdentifier} product connected successfully"
     },
-    "TooMuchOrganization": {
+    "TooManyOrganizations": {
       "Description1": "Your {platformIdentifier} product {platformTitle} will be re-connected under the same organization due to capability restrictions.",
       "Description2": "If you wish to request a change, please contact your organization's administrator.",
       "Title": "Product Re-connection Notice"

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -797,7 +797,7 @@
         "Description": "Cet onglet sera bientôt fermé.",
         "Title": "Le produit OpenCTI a été connecté avec succès"
       },
-      "TooMuchOrganization": {
+      "TooManyOrganizations": {
         "Description1": "Votre produit OpenCTI {platformTitle} sera reconnecté sous la même organisation en raison de restrictions de capacité.",
         "Description2": "Si vous souhaitez demander un changement, veuillez contacter l'administrateur de votre organisation.",
         "Title": "Avis de reconnexion du produit"
@@ -827,7 +827,7 @@
       "Description": "Cet onglet sera bientôt fermé",
       "Title": "Le produit {platformIdentifier} a été connecté avec succès"
     },
-    "TooMuchOrganization": {
+    "TooManyOrganizations": {
       "Description1": "Votre produit {platformIdentifier} {platformTitle} sera reconnecté sous la même organisation en raison de restrictions de capacité.",
       "Description2": "Si vous souhaitez demander un changement, veuillez contacter l'administrateur de votre organisation.",
       "Title": "Avis de reconnexion du produit"

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -797,7 +797,7 @@
         "Description": "このタブはすぐに閉じられます",
         "Title": "OpenCTI製品が正常に接続されました"
       },
-      "TooMuchOrganization": {
+      "TooManyOrganizations": {
         "Description1": "OpenCTI 製品 {platformTitle} は権限制限のため、同じ組織で再接続されます。",
         "Description2": "変更を希望する場合は、組織の管理者に連絡してください。",
         "Title": "製品再接続のお知らせ"
@@ -827,7 +827,7 @@
       "Description": "このタブはすぐに閉じられます",
       "Title": "{platformIdentifier} 製品が正常に接続されました"
     },
-    "TooMuchOrganization": {
+    "TooManyOrganizations": {
       "Description1": "あなたの {platformIdentifier} 製品 {platformTitle} は、権限制限のため同じ組織で再接続されます。",
       "Description2": "変更を希望する場合は、組織の管理者に連絡してください。",
       "Title": "製品再接続のお知らせ"

--- a/apps/frontend/src/components/registration/register/Failed.tsx
+++ b/apps/frontend/src/components/registration/register/Failed.tsx
@@ -1,0 +1,16 @@
+import { RegistrationLayout } from '@/components/registration/Layout';
+import { useTranslations } from 'next-intl';
+
+interface RegisterStateFailedProps {
+  cancel: () => void;
+}
+
+export const RegisterStateFailed = ({ cancel }: RegisterStateFailedProps) => {
+  const t = useTranslations();
+  return (
+    <RegistrationLayout cancel={cancel}>
+      <h1>{t(`Register.Failed.Title`)}</h1>
+      <p>{t(`Register.Failed.Description`)}</p>
+    </RegistrationLayout>
+  );
+};

--- a/apps/frontend/src/components/registration/register/Register.test.tsx
+++ b/apps/frontend/src/components/registration/register/Register.test.tsx
@@ -186,13 +186,13 @@ describe('Register', () => {
     ];
     const { user } = renderRegister();
     expect(
-      screen.getByText('Register.TooMuchOrganization.Title')
+      screen.getByText('Register.TooManyOrganizations.Title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Register.TooMuchOrganization.Description1/)
+      screen.getByText(/Register.TooManyOrganizations.Description1/)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Register.TooMuchOrganization.Description2/)
+      screen.getByText(/Register.TooManyOrganizations.Description2/)
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Utils.Confirm' }));

--- a/apps/frontend/src/components/registration/register/Register.test.tsx
+++ b/apps/frontend/src/components/registration/register/Register.test.tsx
@@ -1,0 +1,347 @@
+import { RegistrationContext } from '@/components/registration/Context';
+import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
+import { Register } from '@/components/registration/register';
+import testRender from '@/utils/test/test-render';
+import * as FiligranUI from '@filigran/ui/clients';
+import { organizationListUserOrganizationsQuery$data } from '@generated/organizationListUserOrganizationsQuery.graphql';
+import { registerIsPlatformRegisteredFragment$data } from '@generated/registerIsPlatformRegisteredFragment.graphql';
+import { registerIsPlatformRegisteredQuery } from '@generated/registerIsPlatformRegisteredQuery.graphql';
+import { PlatformInput } from '@generated/registerPlatformMutation.graphql';
+import {
+  PlatformIdentifier,
+  PlatformRegistrationStatus,
+} from '@graphql/generated';
+import { screen, waitFor } from '@testing-library/react';
+import { PreloadedQuery } from 'react-relay';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  isPlatformRegistered: {
+    status: 'never_registered',
+    platformTitle: null,
+    organization: null,
+  } as registerIsPlatformRegisteredFragment$data,
+  userOrganizations: [
+    { id: 'org-1', name: 'Org One', personal_space: false },
+    { id: 'org-2', name: 'Org Two', personal_space: true },
+  ] as organizationListUserOrganizationsQuery$data['userOrganizations'],
+  mutationMode: 'success' as 'success' | 'missing-capability' | 'error',
+  token: 'a-token',
+  errorMessage: 'SOME_ERROR',
+  lastRegisterVariables: null as Record<string, unknown> | null,
+}));
+
+vi.mock('react-relay', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-relay')>()),
+  usePreloadedQuery: () => ({
+    isPlatformRegistered: testState.isPlatformRegistered,
+  }),
+  useLazyLoadQuery: () => ({
+    userOrganizations: testState.userOrganizations,
+  }),
+  useFragment: (_doc: unknown, ref: unknown) => ref,
+  useMutation: () => [
+    (opts: {
+      variables: Record<string, unknown>;
+      onCompleted?: (data: unknown) => void;
+      onError?: (error: Error) => void;
+    }) => {
+      testState.lastRegisterVariables = opts.variables;
+      if (testState.mutationMode === 'missing-capability') {
+        opts.onError?.(new Error('MISSING_CAPABILITY_ON_ORGANIZATION'));
+        return;
+      }
+      if (testState.mutationMode === 'error') {
+        opts.onError?.(new Error(testState.errorMessage));
+        return;
+      }
+      opts.onCompleted?.({ registerPlatform: { token: testState.token } });
+    },
+    {},
+  ],
+}));
+
+vi.mock('@/components/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+}));
+
+vi.mock('@/components/registration/register/MissingCapability', () => ({
+  RegisterStateMissingCapability: ({
+    organizationId,
+    cancel,
+  }: {
+    organizationId: string;
+    cancel: () => void;
+  }) => (
+    <div data-testid="missing-capability">
+      <span>{organizationId}</span>
+      <button onClick={cancel}>mock-cancel</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/registration/register/OrganizationForm', () => ({
+  RegisterOrganizationForm: ({
+    userOrganizationsQueryData,
+    cancel,
+    confirm,
+  }: {
+    userOrganizationsQueryData: organizationListUserOrganizationsQuery$data;
+    cancel: () => void;
+    confirm: (organizationId: string) => void;
+  }) => (
+    <div data-testid="organization-form">
+      <span>{userOrganizationsQueryData.userOrganizations.length}</span>
+      <button onClick={cancel}>mock-cancel</button>
+      <button onClick={() => confirm('org-1')}>mock-confirm</button>
+    </div>
+  ),
+}));
+
+const mockQueryRef = {} as PreloadedQuery<registerIsPlatformRegisteredQuery>;
+const mockPlatform: PlatformInput = {
+  url: 'https://opencti.example.com',
+};
+
+const renderRegister = () =>
+  testRender(
+    <RegistrationContext.Provider
+      value={{
+        identifier: PlatformIdentifier.Opencti,
+        displayedIdentifier:
+          PlatformMetadataMapping[PlatformIdentifier.Opencti].name,
+      }}>
+      <Register
+        queryRef={mockQueryRef}
+        platform={mockPlatform}
+      />
+    </RegistrationContext.Provider>
+  );
+
+describe('Register', () => {
+  beforeEach(() => {
+    testState.isPlatformRegistered = {
+      status: 'never_registered',
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.userOrganizations = [
+      { id: 'org-1', name: 'Org One', personal_space: false },
+      { id: 'org-2', name: 'Org Two', personal_space: true },
+    ];
+    testState.mutationMode = 'success';
+    testState.token = 'a-token';
+    testState.errorMessage = 'SOME_ERROR';
+    testState.lastRegisterVariables = null;
+    vi.spyOn(FiligranUI, 'toast').mockImplementation(() => undefined);
+  });
+
+  it('renders the organization form when the platform was never registered', () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    renderRegister();
+    expect(screen.getByTestId('organization-form')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders the organization form when the platform is unregistered with two or fewer organizations', () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.Unregistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    renderRegister();
+    expect(screen.getByTestId('organization-form')).toBeInTheDocument();
+  });
+
+  it('calls window.opener postMessage with cancel action when cancel is triggered', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    const postMessage = vi.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      writable: true,
+    });
+    const { user } = renderRegister();
+    await user.click(screen.getByRole('button', { name: 'mock-cancel' }));
+    expect(postMessage).toHaveBeenCalledWith({ action: 'cancel' }, '*');
+  });
+
+  it('renders the "too much organization" screen when unregistered with more than two organizations', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.Unregistered,
+      platformTitle: 'My Platform',
+      organization: { id: 'org-3' },
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.userOrganizations = [
+      { id: 'org-1', name: 'Org One', personal_space: false },
+      { id: 'org-2', name: 'Org Two', personal_space: false },
+      { id: 'org-3', name: 'Org Three', personal_space: true },
+    ];
+    const { user } = renderRegister();
+    expect(
+      screen.getByText('Register.TooMuchOrganization.Title')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Register.TooMuchOrganization.Description1/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Register.TooMuchOrganization.Description2/)
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Utils.Confirm' }));
+    await waitFor(() => {
+      expect(testState.lastRegisterVariables).toEqual({
+        input: {
+          organizationId: 'org-3',
+          platform: mockPlatform,
+          identifier: PlatformIdentifier.Opencti,
+        },
+      });
+    });
+  });
+
+  it('posts a register message to window.opener once the mutation resolves with a token', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.mutationMode = 'success';
+    testState.token = 'my-token';
+    const postMessage = vi.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      writable: true,
+    });
+    const { user } = renderRegister();
+
+    await user.click(screen.getByRole('button', { name: 'mock-confirm' }));
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        { action: 'register', token: 'my-token' },
+        '*'
+      );
+    });
+  });
+
+  it('automatically registers when the platform is already registered with an organization', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.Registered,
+      platformTitle: 'My Platform',
+      organization: { id: 'org-auto' },
+    } as registerIsPlatformRegisteredFragment$data;
+    const postMessage = vi.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      writable: true,
+    });
+    renderRegister();
+
+    await waitFor(() => {
+      expect(testState.lastRegisterVariables).toEqual({
+        input: {
+          organizationId: 'org-auto',
+          platform: mockPlatform,
+          identifier: PlatformIdentifier.Opencti,
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        { action: 'register', token: testState.token },
+        '*'
+      );
+    });
+    expect(
+      screen.getByRole('heading', { name: 'Register.Succeeded.Title' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls the error toast when the mutation errors out', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.mutationMode = 'error';
+    testState.errorMessage = 'SOME_ERROR';
+    const { user } = renderRegister();
+
+    await user.click(screen.getByRole('button', { name: 'mock-confirm' }));
+
+    await waitFor(() => {
+      expect(FiligranUI.toast).toHaveBeenCalledWith({
+        variant: 'destructive',
+        title: 'Utils.Error',
+        description: 'Error.Server.SOME_ERROR',
+      });
+    });
+    expect(
+      screen.getByRole('heading', { name: 'Register.Failed.Title' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the missing-capability state when the mutation errors with MISSING_CAPABILITY_ON_ORGANIZATION', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.mutationMode = 'missing-capability';
+    const { user } = renderRegister();
+
+    await user.click(screen.getByRole('button', { name: 'mock-confirm' }));
+
+    await waitFor(() => {
+      expect(testState.lastRegisterVariables).toEqual({
+        input: {
+          organizationId: 'org-1',
+          platform: mockPlatform,
+          identifier: PlatformIdentifier.Opencti,
+        },
+      });
+    });
+    expect(screen.getByTestId('missing-capability')).toBeInTheDocument();
+  });
+
+  it('calls window.opener postMessage with cancel action after a missing capability error', async () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.NeverRegistered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    testState.mutationMode = 'missing-capability';
+    const postMessage = vi.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      writable: true,
+    });
+    const { user } = renderRegister();
+
+    await user.click(screen.getByRole('button', { name: 'mock-confirm' }));
+    await waitFor(() => {
+      expect(testState.lastRegisterVariables).not.toBeNull();
+    });
+    expect(screen.getByTestId('missing-capability')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'mock-cancel' }));
+    expect(postMessage).toHaveBeenCalledWith({ action: 'cancel' }, '*');
+  });
+
+  it('renders a loader as a fallback for any other status', () => {
+    testState.isPlatformRegistered = {
+      status: PlatformRegistrationStatus.Registered,
+      platformTitle: null,
+      organization: null,
+    } as registerIsPlatformRegisteredFragment$data;
+    renderRegister();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/registration/register/Succeeded.tsx
+++ b/apps/frontend/src/components/registration/register/Succeeded.tsx
@@ -1,0 +1,22 @@
+import { RegistrationLayout } from '@/components/registration/Layout';
+import { useTranslations } from 'next-intl';
+
+interface RegisterStateSucceededProps {
+  displayedIdentifier: string;
+}
+
+export const RegisterStateSucceeded = ({
+  displayedIdentifier,
+}: RegisterStateSucceededProps) => {
+  const t = useTranslations();
+  return (
+    <RegistrationLayout>
+      <h1>
+        {t(`Register.Succeeded.Title`, {
+          platformIdentifier: displayedIdentifier,
+        })}
+      </h1>
+      <p>{t(`Register.Succeeded.Description`)}</p>
+    </RegistrationLayout>
+  );
+};

--- a/apps/frontend/src/components/registration/register/TooManyOrganizations.tsx
+++ b/apps/frontend/src/components/registration/register/TooManyOrganizations.tsx
@@ -1,32 +1,32 @@
 import { RegistrationLayout } from '@/components/registration/Layout';
 import { useTranslations } from 'next-intl';
 
-interface RegisterStateTooMuchOrganizationProps {
+interface RegisterStateTooManyOrganizationsProps {
   cancel: () => void;
   confirm: () => void;
   displayedIdentifier: string;
   platformTitle: string;
 }
 
-export const RegisterStateTooMuchOrganization = ({
+export const RegisterStateTooManyOrganizations = ({
   cancel,
   confirm,
   displayedIdentifier,
   platformTitle,
-}: RegisterStateTooMuchOrganizationProps) => {
+}: RegisterStateTooManyOrganizationsProps) => {
   const t = useTranslations();
   return (
     <RegistrationLayout
       cancel={cancel}
       confirm={confirm}>
-      <h1>{t(`Register.TooMuchOrganization.Title`)}</h1>
+      <h1>{t(`Register.TooManyOrganizations.Title`)}</h1>
       <p>
-        {t(`Register.TooMuchOrganization.Description1`, {
+        {t(`Register.TooManyOrganizations.Description1`, {
           platformIdentifier: displayedIdentifier,
           platformTitle,
         })}
         <br />
-        {t(`Register.TooMuchOrganization.Description2`)}
+        {t(`Register.TooManyOrganizations.Description2`)}
       </p>
     </RegistrationLayout>
   );

--- a/apps/frontend/src/components/registration/register/TooMuchOrganization.tsx
+++ b/apps/frontend/src/components/registration/register/TooMuchOrganization.tsx
@@ -1,0 +1,33 @@
+import { RegistrationLayout } from '@/components/registration/Layout';
+import { useTranslations } from 'next-intl';
+
+interface RegisterStateTooMuchOrganizationProps {
+  cancel: () => void;
+  confirm: () => void;
+  displayedIdentifier: string;
+  platformTitle: string;
+}
+
+export const RegisterStateTooMuchOrganization = ({
+  cancel,
+  confirm,
+  displayedIdentifier,
+  platformTitle,
+}: RegisterStateTooMuchOrganizationProps) => {
+  const t = useTranslations();
+  return (
+    <RegistrationLayout
+      cancel={cancel}
+      confirm={confirm}>
+      <h1>{t(`Register.TooMuchOrganization.Title`)}</h1>
+      <p>
+        {t(`Register.TooMuchOrganization.Description1`, {
+          platformIdentifier: displayedIdentifier,
+          platformTitle,
+        })}
+        <br />
+        {t(`Register.TooMuchOrganization.Description2`)}
+      </p>
+    </RegistrationLayout>
+  );
+};

--- a/apps/frontend/src/components/registration/register/index.tsx
+++ b/apps/frontend/src/components/registration/register/index.tsx
@@ -5,7 +5,7 @@ import { RegisterStateMissingCapability } from '@/components/registration/regist
 import { RegisterOrganizationForm } from '@/components/registration/register/OrganizationForm';
 import { RegisterPlatform } from '@/components/registration/register/register.graphql';
 import { RegisterStateSucceeded } from '@/components/registration/register/Succeeded';
-import { RegisterStateTooMuchOrganization } from '@/components/registration/register/TooMuchOrganization';
+import { RegisterStateTooManyOrganizations } from '@/components/registration/register/TooManyOrganizations';
 import { toast } from '@filigran/ui/clients';
 import OrganizationListUserOrganizationsQueryGraphql, {
   organizationListUserOrganizationsQuery,
@@ -217,7 +217,7 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
       userOrganizationsQueryData.userOrganizations.length > 2;
     if (shouldRegisterOnSameOrganization) {
       return (
-        <RegisterStateTooMuchOrganization
+        <RegisterStateTooManyOrganizations
           cancel={cancel}
           confirm={() => register(isPlatformRegistered.organization?.id ?? '')}
           displayedIdentifier={displayedIdentifier}

--- a/apps/frontend/src/components/registration/register/index.tsx
+++ b/apps/frontend/src/components/registration/register/index.tsx
@@ -1,9 +1,11 @@
 import Loader from '@/components/Loader';
 import { RegistrationContext } from '@/components/registration/Context';
-import { RegistrationLayout } from '@/components/registration/Layout';
+import { RegisterStateFailed } from '@/components/registration/register/Failed';
 import { RegisterStateMissingCapability } from '@/components/registration/register/MissingCapability';
 import { RegisterOrganizationForm } from '@/components/registration/register/OrganizationForm';
 import { RegisterPlatform } from '@/components/registration/register/register.graphql';
+import { RegisterStateSucceeded } from '@/components/registration/register/Succeeded';
+import { RegisterStateTooMuchOrganization } from '@/components/registration/register/TooMuchOrganization';
 import { toast } from '@filigran/ui/clients';
 import OrganizationListUserOrganizationsQueryGraphql, {
   organizationListUserOrganizationsQuery,
@@ -192,25 +194,11 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
   }
 
   if (state.registrationRequestStatus === 'succeeded') {
-    return (
-      <RegistrationLayout>
-        <h1>
-          {t(`Register.Succeeded.Title`, {
-            platformIdentifier: displayedIdentifier,
-          })}
-        </h1>
-        <p>{t(`Register.Succeeded.Description`)}</p>
-      </RegistrationLayout>
-    );
+    return <RegisterStateSucceeded displayedIdentifier={displayedIdentifier} />;
   }
 
   if (state.registrationRequestStatus === 'failed') {
-    return (
-      <RegistrationLayout cancel={cancel}>
-        <h1>{t(`Register.Failed.Title`)}</h1>
-        <p>{t(`Register.Failed.Description`)}</p>
-      </RegistrationLayout>
-    );
+    return <RegisterStateFailed cancel={cancel} />;
   }
 
   const shouldRegisterOnSameOrganization =
@@ -218,19 +206,12 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
     userOrganizationsQueryData.userOrganizations.length > 2;
   if (shouldRegisterOnSameOrganization) {
     return (
-      <RegistrationLayout
+      <RegisterStateTooMuchOrganization
         cancel={cancel}
-        confirm={() => register(isPlatformRegistered.organization?.id ?? '')}>
-        <h1>{t(`Register.TooMuchOrganization.Title`)}</h1>
-        <p>
-          {t(`Register.TooMuchOrganization.Description1`, {
-            platformIdentifier: displayedIdentifier,
-            platformTitle: isPlatformRegistered.platformTitle ?? '',
-          })}
-          <br />
-          {t(`Register.TooMuchOrganization.Description2`)}
-        </p>
-      </RegistrationLayout>
+        confirm={() => register(isPlatformRegistered.organization?.id ?? '')}
+        displayedIdentifier={displayedIdentifier}
+        platformTitle={isPlatformRegistered.platformTitle ?? ''}
+      />
     );
   }
 

--- a/apps/frontend/src/components/registration/register/index.tsx
+++ b/apps/frontend/src/components/registration/register/index.tsx
@@ -185,7 +185,7 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
   }, [isPlatformRegistered, register]);
 
   return useMemo(() => {
-    const renderers = new Map<RegistrationRequestStatus, ReactNode>([
+    const renderers = new Map<RegistrationRequestStatus, () => ReactNode>([
       [
         'missed-capability',
         () =>
@@ -207,8 +207,9 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
       ['failed', () => <RegisterStateFailed cancel={cancel} />],
     ]);
 
-    if (renderers[state.registrationRequestStatus]) {
-      return renderers[state.registrationRequestStatus];
+    const renderer = renderers.get(state.registrationRequestStatus);
+    if (renderer) {
+      return renderer();
     }
 
     const shouldRegisterOnSameOrganization =
@@ -248,6 +249,7 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
     platform.title,
     displayedIdentifier,
     isPlatformRegistered,
+    register,
     userOrganizationsQueryData,
   ]);
 };

--- a/apps/frontend/src/components/registration/register/index.tsx
+++ b/apps/frontend/src/components/registration/register/index.tsx
@@ -26,9 +26,11 @@ import {
 import { PlatformRegistrationStatus } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
 import {
+  ReactNode,
   useCallback,
   useContext,
   useLayoutEffect,
+  useMemo,
   useReducer,
   useRef,
 } from 'react';
@@ -182,53 +184,70 @@ export const Register = ({ queryRef, platform }: RegisterProps) => {
     }
   }, [isPlatformRegistered, register]);
 
-  if (state.registrationRequestStatus === 'missed-capability') {
-    return state.chosenOrganizationId ? (
-      <RegisterStateMissingCapability
-        organizationId={state.chosenOrganizationId}
-        cancel={cancel}
-      />
-    ) : (
-      <Loader />
-    );
-  }
+  return useMemo(() => {
+    const renderers = new Map<RegistrationRequestStatus, ReactNode>([
+      [
+        'missed-capability',
+        () =>
+          state.chosenOrganizationId ? (
+            <RegisterStateMissingCapability
+              organizationId={state.chosenOrganizationId}
+              cancel={cancel}
+            />
+          ) : (
+            <Loader />
+          ),
+      ],
+      [
+        'succeeded',
+        () => (
+          <RegisterStateSucceeded displayedIdentifier={displayedIdentifier} />
+        ),
+      ],
+      ['failed', () => <RegisterStateFailed cancel={cancel} />],
+    ]);
 
-  if (state.registrationRequestStatus === 'succeeded') {
-    return <RegisterStateSucceeded displayedIdentifier={displayedIdentifier} />;
-  }
+    if (renderers[state.registrationRequestStatus]) {
+      return renderers[state.registrationRequestStatus];
+    }
 
-  if (state.registrationRequestStatus === 'failed') {
-    return <RegisterStateFailed cancel={cancel} />;
-  }
+    const shouldRegisterOnSameOrganization =
+      isPlatformRegistered.status === PlatformRegistrationStatus.Unregistered &&
+      userOrganizationsQueryData.userOrganizations.length > 2;
+    if (shouldRegisterOnSameOrganization) {
+      return (
+        <RegisterStateTooMuchOrganization
+          cancel={cancel}
+          confirm={() => register(isPlatformRegistered.organization?.id ?? '')}
+          displayedIdentifier={displayedIdentifier}
+          platformTitle={isPlatformRegistered.platformTitle ?? ''}
+        />
+      );
+    }
 
-  const shouldRegisterOnSameOrganization =
-    isPlatformRegistered.status === PlatformRegistrationStatus.Unregistered &&
-    userOrganizationsQueryData.userOrganizations.length > 2;
-  if (shouldRegisterOnSameOrganization) {
-    return (
-      <RegisterStateTooMuchOrganization
-        cancel={cancel}
-        confirm={() => register(isPlatformRegistered.organization?.id ?? '')}
-        displayedIdentifier={displayedIdentifier}
-        platformTitle={isPlatformRegistered.platformTitle ?? ''}
-      />
-    );
-  }
+    if (
+      isPlatformRegistered.status ===
+        PlatformRegistrationStatus.NeverRegistered ||
+      isPlatformRegistered.status === PlatformRegistrationStatus.Unregistered
+    ) {
+      return (
+        <RegisterOrganizationForm
+          userOrganizationsQueryData={userOrganizationsQueryData}
+          defaultPlatformName={platform.title}
+          cancel={cancel}
+          confirm={register}
+        />
+      );
+    }
 
-  if (
-    isPlatformRegistered.status ===
-      PlatformRegistrationStatus.NeverRegistered ||
-    isPlatformRegistered.status === PlatformRegistrationStatus.Unregistered
-  ) {
-    return (
-      <RegisterOrganizationForm
-        userOrganizationsQueryData={userOrganizationsQueryData}
-        defaultPlatformName={platform.title}
-        cancel={cancel}
-        confirm={register}
-      />
-    );
-  }
-
-  return <Loader />;
+    return <Loader />;
+  }, [
+    cancel,
+    state.chosenOrganizationId,
+    state.registrationRequestStatus,
+    platform.title,
+    displayedIdentifier,
+    isPlatformRegistered,
+    userOrganizationsQueryData,
+  ]);
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

This PR refactors the frontend registration “Register” flow to split state-specific UI into dedicated components and centralize step/status rendering logic, aligning with issue #923’s goal of moving away from large conditional blocks.

**Changes:**
- Extracts register state screens into separate components (`Succeeded`, `Failed`, `TooMuchOrganization`).
- Refactors `Register` to select the rendered step/state in a single place (now via a memoized renderer).
- Adds/updates unit tests for the register flow scenarios.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #923 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.