### PR TITLE
feat(connectionfromhub): Modale when has rights (#2808)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -714,7 +714,9 @@
       "ConnectedProductSentence": "To deploy a resource you must have a connected product",
       "NotAllowedMessage": "You do not have permission to connect a product. \nPlease contact your product {count, plural, =1 {administrator} other {administrators}} to connect the product on your behalf.",
       "Administrators": "{count, plural, =1 {Administrator} other {Administrators}}",
-      "ReachAdmin": "Reach your admin"
+      "ReachAdmin": "Reach your admin",
+      "ConnectProduct": "Connect your product",
+      "RedirectionMessage": "You will be redirected to your product in a new tab to authorize the connection with XTM Hub."
     },
     "Back": "Back to {platformIdentifier}",
     "Confirm": "Connect",
@@ -728,6 +730,7 @@
       },
       "Description": "Click here to access your Private Product.",
       "ProductName": "Product name",
+      "Product": "Product",
       "ProductURL": "Product URL",
       "StartDate": "Start date",
       "EndDate": "End date",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -714,7 +714,9 @@
       "ConnectedProductSentence": "Pour déployer une ressource, vous devez disposer d'un produit connecté",
       "NotAllowedMessage": "Vous ne disposez pas des autorisations nécessaires pour connecter un produit. \nVeuillez contacter votre {count, plural, =1 {administrateur} other {administrateurs}} afin qu'il se charge de connecter le produit en votre nom.",
       "Administrators": "{count, plural, =1 {Administrator} other {Administrators}}",
-      "ReachAdmin": "Contactez votre administrateur"
+      "ReachAdmin": "Contactez votre administrateur",
+      "ConnectProduct": "Connectez votre produit",
+      "RedirectionMessage": "Vous serez redirigé vers votre produit dans un nouvel onglet afin d'autoriser la connexion avec XTM Hub."
     },
     "Back": "Retour à {platformIdentifier}",
     "Confirm": "Connecter",
@@ -728,6 +730,7 @@
       },
       "Description": "Cliquez ici pour accéder à votre produit privé.",
       "ProductName": "Nom du produit",
+      "Product": "Produit",
       "ProductURL": "URL du produit",
       "StartDate": "Date de début",
       "EndDate": "Date de fin",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -714,7 +714,9 @@
       "ConnectedProductSentence": "リソースをデプロイするには、接続された製品が必要です。",
       "NotAllowedMessage": "製品を接続するために必要な権限がありません。\n代わりに製品を接続してもらうよう、{count, plural, =1 {管理者} other {管理者}} に連絡してください",
       "Administrators": "{count, plural, =1 {管理者} other {管理者}}",
-      "ReachAdmin": "管理者にお問い合わせください"
+      "ReachAdmin": "管理者にお問い合わせください",
+      "ConnectProduct": "製品を接続する",
+      "RedirectionMessage": "XTM Hub との接続を承認するため、新しいタブで製品ページにリダイレクトされます。"
     },
     "Back": "{platformIdentifier} に戻る",
     "Confirm": "接続する",
@@ -728,6 +730,7 @@
       },
       "Description": "プライベート・プラットフォームへのアクセスはこちらをクリックしてください。",
       "ProductName": "製品名",
+      "Product": "製品",
       "ProductURL": "商品URL",
       "StartDate": "開始日",
       "EndDate": "終了日",

--- a/apps/frontend/src/components/connected-products/ConnectProductButton.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectProductButton.tsx
@@ -4,7 +4,9 @@ import { AddIcon } from '@filigran/icon';
 import { Button } from '@filigran/ui';
 import { useState } from 'react';
 
-import ConnectProductFromHubModal from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
+import ConnectProductFromHubModal, {
+  ConnectProductOrigin,
+} from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
 import { useTranslations } from 'next-intl';
 
 interface ConnectProductButtonProps {
@@ -43,6 +45,7 @@ export const ConnectProductButton = ({
             onCloseDropdown?.();
           }
         }}
+        origin={ConnectProductOrigin.homepage}
       />
     </>
   );

--- a/apps/frontend/src/components/registration/registerFromHub/Administratorslist.test.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/Administratorslist.test.tsx
@@ -1,0 +1,57 @@
+import { Administratorslist } from '@/components/registration/registerFromHub/Administratorslist';
+import testRender from '@/utils/test/test-render';
+import { ConnectProductOrganizationAdminsQuery } from '@graphql/generated';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('Administratorslist', () => {
+  it('renders administrators label and all administrator emails', () => {
+    const admins: ConnectProductOrganizationAdminsQuery = {
+      usersWithCapabilitiesInOrganization: [
+        {
+          id: 'admin-1',
+          email: 'admin1@example.com',
+          first_name: 'Admin',
+          last_name: 'One',
+        },
+        {
+          id: 'admin-2',
+          email: 'admin2@example.com',
+          first_name: 'Admin',
+          last_name: 'Two',
+        },
+      ],
+    };
+
+    testRender(<Administratorslist admins={admins} />);
+
+    expect(
+      screen.getByText(/Register\.ConnectFromHub\.Administrators/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('admin1@example.com')).toBeInTheDocument();
+    expect(screen.getByText('admin2@example.com')).toBeInTheDocument();
+  });
+
+  it('renders only administrators label when there are no administrators', () => {
+    const admins: ConnectProductOrganizationAdminsQuery = {
+      usersWithCapabilitiesInOrganization: [],
+    };
+
+    testRender(<Administratorslist admins={admins} />);
+
+    expect(
+      screen.getByText(/Register\.ConnectFromHub\.Administrators/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('@example.com')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when admins is not provided', () => {
+    const { container } = testRender(
+      <Administratorslist
+        admins={undefined as unknown as ConnectProductOrganizationAdminsQuery}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/frontend/src/components/registration/registerFromHub/Administratorslist.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/Administratorslist.tsx
@@ -1,0 +1,33 @@
+import { ConnectProductOrganizationAdminsQuery } from '@graphql/generated';
+import { useTranslations } from 'next-intl';
+
+interface AdministratorslistProps {
+  admins?: ConnectProductOrganizationAdminsQuery;
+}
+
+export const Administratorslist = ({ admins }: AdministratorslistProps) => {
+  const t = useTranslations();
+
+  if (!admins) {
+    return null;
+  }
+  return (
+    <div className="space-y-1">
+      <div className="content-body-base">
+        {t('Register.ConnectFromHub.Administrators', {
+          count: admins.usersWithCapabilitiesInOrganization?.length ?? 0,
+        })}
+        :
+      </div>
+      {admins.usersWithCapabilitiesInOrganization?.map((user) => {
+        return (
+          <div
+            className="content-body-base"
+            key={user.id}>
+            {user.email}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/registration/registerFromHub/ConnectFromHubForm.test.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/ConnectFromHubForm.test.tsx
@@ -1,0 +1,45 @@
+import ConnectFromHubForm, {
+  CONNECTABLE_PRODUCTS,
+} from '@/components/registration/registerFromHub/ConnectFromHubForm';
+import testRender from '@/utils/test/test-render';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('ConnectFromHubForm', () => {
+  it('renders product combobox and url input', () => {
+    testRender(<ConnectFromHubForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('combobox')).toHaveTextContent(
+      CONNECTABLE_PRODUCTS.OpenCTI
+    );
+    expect(
+      screen.getByPlaceholderText('Register.Details.ProductURL')
+    ).toBeInTheDocument();
+  });
+
+  it('submits selected product and URL', async () => {
+    const onSubmit = vi.fn();
+    const { user } = testRender(<ConnectFromHubForm onSubmit={onSubmit} />);
+
+    const productSelect = document.querySelector(
+      'select[name="product"]'
+    ) as HTMLSelectElement | null;
+    expect(productSelect).not.toBeNull();
+    fireEvent.change(productSelect!, {
+      target: { value: CONNECTABLE_PRODUCTS.OpenAEV },
+    });
+    await user.type(
+      screen.getByPlaceholderText('Register.Details.ProductURL'),
+      'https://openaev.example.com'
+    );
+    await user.click(screen.getByRole('button', { name: 'Utils.Continue' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+        product: CONNECTABLE_PRODUCTS.OpenAEV,
+        productUrl: 'https://openaev.example.com',
+      });
+    });
+  });
+});

--- a/apps/frontend/src/components/registration/registerFromHub/ConnectFromHubForm.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/ConnectFromHubForm.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { AutoForm, Button } from '@filigran/ui';
+import { useTranslations } from 'next-intl';
+import { z } from 'zod';
+
+export enum CONNECTABLE_PRODUCTS {
+  OpenCTI = 'OpenCTI',
+  OpenAEV = 'OpenAEV',
+}
+export const connectFromHubFormSchema = z.object({
+  product: z.enum(CONNECTABLE_PRODUCTS),
+  productUrl: z.url({ error: 'Product URL must be a valid URL' }),
+});
+
+interface ConnectFromHubFormProps {
+  onSubmit: (values: z.infer<typeof connectFromHubFormSchema>) => void;
+}
+
+const ConnectFromHubForm = ({ onSubmit }: ConnectFromHubFormProps) => {
+  const t = useTranslations();
+
+  return (
+    <AutoForm
+      formSchema={connectFromHubFormSchema}
+      onSubmit={onSubmit}
+      fieldConfig={{
+        product: {
+          label: t('Register.Details.Product'),
+          inputProps: {
+            placeholder: CONNECTABLE_PRODUCTS.OpenCTI,
+          },
+        },
+        productUrl: {
+          label: t('Register.Details.ProductURL'),
+          inputProps: {
+            placeholder: t('Register.Details.ProductURL'),
+          },
+        },
+      }}>
+      <div className="flex justify-end">
+        <Button type="submit">{t('Utils.Continue')}</Button>
+      </div>
+    </AutoForm>
+  );
+};
+
+export default ConnectFromHubForm;

--- a/apps/frontend/src/components/registration/registerFromHub/ConnectProductFromHubModal.test.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/ConnectProductFromHubModal.test.tsx
@@ -1,8 +1,10 @@
-import ConnectProductFromHubModal from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
+import ConnectProductFromHubModal, {
+  ConnectProductOrigin,
+} from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
 import testRender from '@/utils/test/test-render';
-import { PlatformIdentifier } from '@graphql/generated';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CONNECTABLE_PRODUCTS } from './ConnectFromHubForm';
 
 const { mockUseGranted, mockUseConnectProductOrganizationAdminsQuery } =
   vi.hoisted(() => ({
@@ -21,7 +23,10 @@ vi.mock('@graphql/generated', async (importOriginal) => ({
 }));
 
 describe('ConnectProductFromHubModal', () => {
+  const onOpenChange = vi.fn();
+
   beforeEach(() => {
+    onOpenChange.mockReset();
     mockUseGranted.mockReset();
     mockUseConnectProductOrganizationAdminsQuery.mockReset();
     mockUseConnectProductOrganizationAdminsQuery.mockReturnValue({
@@ -39,8 +44,8 @@ describe('ConnectProductFromHubModal', () => {
     testRender(
       <ConnectProductFromHubModal
         isOpen={true}
-        onOpenChange={vi.fn()}
-        product={PlatformIdentifier.Opencti}
+        onOpenChange={onOpenChange}
+        origin={ConnectProductOrigin.library}
       />
     );
 
@@ -48,7 +53,7 @@ describe('ConnectProductFromHubModal', () => {
       screen.getByText('Register.ConnectFromHub.PermissionRequired')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Register.ConnectFromHub.NotAllowedMessage')
+      screen.getByText(/Register\.ConnectFromHub\.NotAllowedMessage/)
     ).toBeInTheDocument();
     expect(screen.getByText('admin1@example.com')).toBeInTheDocument();
     expect(screen.getByText('admin2@example.com')).toBeInTheDocument();
@@ -65,20 +70,71 @@ describe('ConnectProductFromHubModal', () => {
     testRender(
       <ConnectProductFromHubModal
         isOpen={true}
-        onOpenChange={vi.fn()}
-        product={PlatformIdentifier.Opencti}
+        onOpenChange={onOpenChange}
+        origin={ConnectProductOrigin.library}
       />
     );
 
-    expect(screen.getAllByText('allowedMessage')).toHaveLength(2);
+    expect(
+      screen.getByText('Register.ConnectFromHub.ConnectProduct')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveTextContent(
+      CONNECTABLE_PRODUCTS.OpenCTI
+    );
+    expect(
+      screen.getByPlaceholderText('Register.Details.ProductURL')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Utils.Continue' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Register.ConnectFromHub.ReachAdmin',
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('submits form and opens redirect URL when user can manage organization', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    mockUseGranted.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const { user } = testRender(
+      <ConnectProductFromHubModal
+        isOpen={true}
+        onOpenChange={onOpenChange}
+        origin={ConnectProductOrigin.homepage}
+      />
+    );
+
+    const productSelect = document.querySelector(
+      'select[name="product"]'
+    ) as HTMLSelectElement | null;
+    expect(productSelect).not.toBeNull();
+    fireEvent.change(productSelect!, {
+      target: { value: CONNECTABLE_PRODUCTS.OpenCTI },
+    });
+    await user.type(
+      screen.getByPlaceholderText('Register.Details.ProductURL'),
+      'https://opencti.example.com'
+    );
+    await user.click(screen.getByRole('button', { name: 'Utils.Continue' }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://opencti.example.com/redirect/connect-xtm-hub?from=xtmhub_homepage',
+        '_blank',
+        'noopener,noreferrer'
+      );
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
   });
 
   it('disables administrators query when modal is closed', () => {
     testRender(
       <ConnectProductFromHubModal
         isOpen={false}
-        onOpenChange={vi.fn()}
-        product={PlatformIdentifier.Opencti}
+        onOpenChange={onOpenChange}
+        origin={ConnectProductOrigin.library}
       />
     );
 

--- a/apps/frontend/src/components/registration/registerFromHub/ConnectProductFromHubModal.tsx
+++ b/apps/frontend/src/components/registration/registerFromHub/ConnectProductFromHubModal.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { PortalContext } from '@/components/me/AppPortalContext';
+import { Administratorslist } from '@/components/registration/registerFromHub/Administratorslist';
+import ConnectFromHubForm, {
+  connectFromHubFormSchema,
+} from '@/components/registration/registerFromHub/ConnectFromHubForm';
 import { DialogInformative } from '@/components/ui/Dialog';
 import useGranted from '@/hooks/use-granted';
 import { portalGraphqlClient } from '@/lib/graphql-client';
@@ -9,13 +13,20 @@ import {
   useConnectProductOrganizationAdminsQuery,
 } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
+import { z } from 'zod';
+
 import { useRouter } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 
+export enum ConnectProductOrigin {
+  library = 'library',
+  homepage = 'homepage',
+}
+
 interface ConnectProductProps {
   isOpen: boolean;
-  displayConnectedProductSentence?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
+  origin: ConnectProductOrigin;
 }
 
 const DEFAULT_EMAIL_BODY = () => `Hello,
@@ -30,8 +41,8 @@ Thank you!`;
 
 const ConnectProductFromHubModal = ({
   isOpen,
-  displayConnectedProductSentence = false,
   onOpenChange,
+  origin,
 }: ConnectProductProps) => {
   const t = useTranslations();
   const { me } = useContext(PortalContext);
@@ -62,14 +73,20 @@ const ConnectProductFromHubModal = ({
     }
   }, [isOpen, me, router]);
 
-  const allowedMessage = t('allowedMessage'); // TO Be done in the next chunk
+  const allowedMessageTitle = t('Register.ConnectFromHub.ConnectProduct');
+  const allowedMessage = t('Register.ConnectFromHub.RedirectionMessage');
+  const allowedMessageDescription =
+    origin === ConnectProductOrigin.library
+      ? `${t('Register.ConnectFromHub.ConnectedProductSentence')}. \n\n ${allowedMessage}`
+      : allowedMessage;
   const deniedMessage = t('Register.ConnectFromHub.PermissionRequired');
   const notAllowedMessage = t('Register.ConnectFromHub.NotAllowedMessage', {
     count: data?.usersWithCapabilitiesInOrganization?.length ?? 0,
   });
-  const deniedMessageDescription = displayConnectedProductSentence
-    ? `${t('Register.ConnectFromHub.ConnectedProductSentence')}. \n\n ${notAllowedMessage}`
-    : notAllowedMessage;
+  const deniedMessageDescription =
+    origin === ConnectProductOrigin.library
+      ? `${t('Register.ConnectFromHub.ConnectedProductSentence')}. \n\n ${notAllowedMessage}`
+      : notAllowedMessage;
   const administratorsEmails =
     data?.usersWithCapabilitiesInOrganization?.map((user) => user.email) ?? [];
   const [mainRecipientEmail, ...ccRecipientsEmails] = administratorsEmails;
@@ -90,34 +107,36 @@ const ConnectProductFromHubModal = ({
     window.location.href = `mailto:${to}?${params.join('&')}`;
   };
 
+  const handleConnectFromHub = ({
+    productUrl,
+  }: z.infer<typeof connectFromHubFormSchema>) => {
+    window.open(
+      `${productUrl}/redirect/connect-xtm-hub?from=xtmhub_${origin}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    onOpenChange?.(false);
+  };
+
   return (
     <DialogInformative
       isOpen={isOpen}
       onClose={handleClose}
-      onButtonClick={handleReachAdmin}
+      onButtonClick={canManageOrganization ? undefined : handleReachAdmin}
       variant={'default'}
       buttonText={'Register.ConnectFromHub.ReachAdmin'}
-      title={canManageOrganization ? allowedMessage : deniedMessage}
+      title={canManageOrganization ? allowedMessageTitle : deniedMessage}
       description={
-        canManageOrganization ? allowedMessage : deniedMessageDescription
-      }>
-      <div className="space-y-1">
-        <div className="content-body-base">
-          {t('Register.ConnectFromHub.Administrators', {
-            count: data?.usersWithCapabilitiesInOrganization?.length ?? 0,
-          })}
-          :
-        </div>
-        {data?.usersWithCapabilitiesInOrganization?.map((user) => {
-          return (
-            <div
-              className="text-sm text-muted-foreground"
-              key={user.email}>
-              {user.email}
-            </div>
-          );
-        })}
-      </div>
+        canManageOrganization
+          ? allowedMessageDescription
+          : deniedMessageDescription
+      }
+      showFooter={!canManageOrganization}>
+      {canManageOrganization ? (
+        <ConnectFromHubForm onSubmit={handleConnectFromHub} />
+      ) : (
+        <Administratorslist admins={data} />
+      )}
     </DialogInformative>
   );
 };

--- a/apps/frontend/src/components/service/document/one-click-deploy/OneClickDeploy.tsx
+++ b/apps/frontend/src/components/service/document/one-click-deploy/OneClickDeploy.tsx
@@ -1,5 +1,7 @@
 import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
-import ConnectProductFromHubModal from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
+import ConnectProductFromHubModal, {
+  ConnectProductOrigin,
+} from '@/components/registration/registerFromHub/ConnectProductFromHubModal';
 import ChoosePlatformForm from '@/components/service/document/one-click-deploy/ChoosePlatformForm';
 import EeBadge from '@/components/service/document/one-click-deploy/EeBadge';
 import EeLearnMoreSheet from '@/components/service/document/one-click-deploy/EeLearnMoreSheet';
@@ -167,10 +169,10 @@ const OneClickDeploy = ({
         {isFeatureEnabled ? (
           <ConnectProductFromHubModal
             isOpen={isOpen}
-            displayConnectedProductSentence
             onOpenChange={(isOpen) => {
               setIsOpen(isOpen);
             }}
+            origin={ConnectProductOrigin.library}
           />
         ) : (
           <NoPlatformDisplay

--- a/apps/frontend/src/components/ui/Dialog.tsx
+++ b/apps/frontend/src/components/ui/Dialog.tsx
@@ -20,6 +20,7 @@ interface DialogInformativeProps {
   children: ReactNode;
   variant?: 'default' | 'secondary';
   buttonText?: string;
+  showFooter?: boolean;
 }
 
 export const DialogInformative = ({
@@ -31,6 +32,7 @@ export const DialogInformative = ({
   children,
   variant = 'secondary',
   buttonText = 'Utils.Close',
+  showFooter = true,
 }: DialogInformativeProps) => {
   const t = useTranslations();
 
@@ -52,17 +54,19 @@ export const DialogInformative = ({
           )}
         </DialogHeader>
         {children}
-        <DialogFooter className="justify-end">
-          <DialogClose asChild>
-            <Button
-              className="mt-2 hover:cursor-pointer"
-              type="button"
-              variant={variant}
-              onClick={onButtonClick ?? onClose}>
-              {t(buttonText)}
-            </Button>
-          </DialogClose>
-        </DialogFooter>
+        {showFooter && (
+          <DialogFooter className="justify-end">
+            <DialogClose asChild>
+              <Button
+                className="mt-2 hover:cursor-pointer"
+                type="button"
+                variant={variant}
+                onClick={onButtonClick ?? onClose}>
+                {t(buttonText)}
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
# Context
> This PR contnues the workflow on registering from Hub when the user has the correct capabilities. It displays a form to fill productName and productURL and then redirects to the correct product.

## How to test
Connect as a user ADMIN_ORGA or MANAGE_REGISTRATION
Click on Connect Your product in the header
You should see a form with product and productURL. Fill it. Click on continue
You should be redirected in a new tab to your URL + /redirect/connect-xtm-hub?from=xtmhub_${origin} (for now, it's only the redirection, the work On OpenCTI and OpenAEV is in progress...)
Try it from libraries
Try it from the homepage as well :)

## Related issues

- Related to #2808

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [X] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [X] Integration tests
- [ ] E2E tests
- [X] Local manual tests
