### PR TITLE
fix(connectionredirection): redirection on sign up  (#2873)

### DIFF
--- a/apps/frontend/src/components/login/LoginLayout.tsx
+++ b/apps/frontend/src/components/login/LoginLayout.tsx
@@ -53,7 +53,7 @@ export const LoginLayout = ({}) => {
       <div className="flex flex-col items-center p-xl sm:p-0">
         <LoginTitleForm />
         <div className="space-y-l mt-l w-full flex flex-col items-center">
-          <LoginMessage />
+          <LoginMessage isHomePageV2Enabled={isHomePageV2Enabled} />
           {isHomePageV2Enabled
             ? localProvider && <LoginForm />
             : settings?.platform_providers?.map((platformProvider) =>

--- a/apps/frontend/src/components/login/LoginMessage.tsx
+++ b/apps/frontend/src/components/login/LoginMessage.tsx
@@ -1,14 +1,23 @@
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
-const LoginMessage = () => {
+interface LoginMessageProps {
+  isHomePageV2Enabled: boolean;
+}
+
+const LoginMessage = ({ isHomePageV2Enabled }: LoginMessageProps) => {
   const t = useTranslations();
+
   return (
     <div className="bg-page-background border border-border-light rounded w-full p-xl text-sm text-center">
       {t('LoginPage.DontHaveAccount')}{' '}
       <Link
         className="text-primary"
-        href="/sign-up">
+        href={
+          isHomePageV2Enabled
+            ? '/sign-up'
+            : 'https://filigran.io/filigran-account-creation/?form_origin=xtmhub'
+        }>
         {t('LoginPage.SignUp')}
       </Link>
     </div>


### PR DESCRIPTION
# Context
> The redirection does not use the FF HomePage V2

## How to test
- Remove the FF > The redirection on sign up should redirect to filigran.io 
- Add the FF > The user can sign up directly from the Hub

## Related issues

- Related to #2873

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to imp

https://github.com/user-attachments/assets/515d12f3-e2f7-4655-afd6-a87c0614a539

rove quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [X] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
