### PR TITLE
feat(homepage): Restructure layout private/public of the app (#2876)

### DIFF
--- a/apps/frontend/app/(application)/app/layout.tsx
+++ b/apps/frontend/app/(application)/app/layout.tsx
@@ -8,11 +8,11 @@ import { AdminBanner } from '@/components/admin/AdminBanner';
 import { TestEnvBanner } from '@/components/admin/TestEnvBanner';
 import { ContentLayout } from '@/components/ContentLayout';
 import HeaderComponent from '@/components/Header';
+import { AppShell } from '@/components/layout/AppShell';
 import Menu from '@/components/menu/Menu';
 import PrivateMenu from '@/components/menu/PrivateMenu';
 import { ReactQueryProvider } from '@/components/ReactQueryProvider';
 import { TryFiligranProductsBanner } from '@/components/service/trial-instances/banner/TryFiligranProductsBanner';
-import { cn } from '@/lib/utils';
 import { RelayProvider } from '@/relay/relay-provider';
 import { getMetadataBase } from '@/utils/metadata';
 import { APP_PATH } from '@/utils/path/constant';
@@ -67,32 +67,41 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
     );
   }
 
+  const banners = (
+    <>
+      <TestEnvBanner />
+      <AdminBanner />
+      <TryFiligranProductsBanner />
+    </>
+  );
+
   return (
     <RelayProvider>
       <ReactQueryProvider>
         <div className="flex min-h-screen">
           <PageLoader>
-            <div
-              id="app-shell"
-              className={cn(
-                'flex flex-col w-full h-screen min-h-0',
-                isHomePageV2Enabled && 'overflow-y-auto'
-              )}>
-              <TestEnvBanner />
-              <AdminBanner />
-              <TryFiligranProductsBanner />
-              <div className="flex flex-row grow min-h-0">
-                {isHomePageV2Enabled ? <PrivateMenu /> : <Menu />}
-                <div
-                  className={cn(
-                    'flex flex-col w-full h-full min-h-0 min-w-0',
-                    isHomePageV2Enabled && 'overflow-y-auto'
-                  )}>
-                  <HeaderComponent />
-                  <ContentLayout>{children}</ContentLayout>
+            {isHomePageV2Enabled ? (
+              <AppShell
+                banners={banners}
+                menu={<PrivateMenu />}
+                headerContent={<HeaderComponent />}
+                contentClassName="p-3 sm:p-6">
+                {children}
+              </AppShell>
+            ) : (
+              <div
+                id="app-shell"
+                className="flex flex-col w-full h-screen min-h-0">
+                {banners}
+                <div className="flex flex-row grow min-h-0">
+                  <Menu />
+                  <div className="flex flex-col w-full h-full min-h-0 min-w-0">
+                    <HeaderComponent />
+                    <ContentLayout>{children}</ContentLayout>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </PageLoader>
         </div>
       </ReactQueryProvider>

--- a/apps/frontend/app/(embed)/layout.tsx
+++ b/apps/frontend/app/(embed)/layout.tsx
@@ -91,7 +91,7 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
       <PageLoader>
         <div className="flex flex-col items-center justify-center min-h-screen">
           <div className="w-1/3">
-            <ContentLayout showFooter={false}>
+            <ContentLayout>
               <LogoXTMDark className="pb-6" />
 
               <Card className="p-l bg-page-background">{children}</Card>

--- a/apps/frontend/app/(public)/[locale]/layout.tsx
+++ b/apps/frontend/app/(public)/[locale]/layout.tsx
@@ -1,21 +1,17 @@
-import { AppFooter } from '@/components/AppFooter';
 import Copilot from '@/components/external/Copilot';
-import { PublicMobileMenuButton } from '@/components/menu/navigation/public/PublicMobileMenuButton';
+import { AppShell } from '@/components/layout/AppShell';
+import { PublicHeaderContent } from '@/components/layout/PublicHeaderContent';
 import PublicMenu from '@/components/menu/PublicMenu';
 import { ReactQueryProvider } from '@/components/ReactQueryProvider';
 import { PublicTryFiligranProductsBanner } from '@/components/service/trial-instances/banner/PublicTryFiligranProductsBanner';
 import { publicLocales, type PublicLocale } from '@/i18n/config';
-import { cn } from '@/lib/utils';
 import { getDefaultMetadata } from '@/utils/generate-metadata';
 import { isFeatureEnabled } from '@/utils/settings.service';
-import { Button } from '@filigran/ui/servers';
 import '@filigran/ui/theme.css';
 import { FeatureFlag } from '@graphql/generated';
-import LogoXTMDark from '@public/logo_xtm_hub_dark.svg';
 import '@styles/globals.css';
 import { Metadata } from 'next';
-import { getTranslations, setRequestLocale } from 'next-intl/server';
-import Link from 'next/link';
+import { setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import * as React from 'react';
 
@@ -44,74 +40,35 @@ const RootLayout = async ({
     notFound();
   }
   setRequestLocale(locale);
-  const t = await getTranslations();
   const isHomePageV2Enabled = await isFeatureEnabled(FeatureFlag.HomePageV2);
+
+  if (isHomePageV2Enabled) {
+    return (
+      <ReactQueryProvider>
+        <AppShell
+          banners={<PublicTryFiligranProductsBanner />}
+          menu={<PublicMenu />}
+          headerContent={<PublicHeaderContent locale={locale} />}
+          contentClassName="container pt-l">
+          {children}
+        </AppShell>
+        <Copilot />
+      </ReactQueryProvider>
+    );
+  }
 
   return (
     <ReactQueryProvider>
       <div className="md:flex md:flex-col md:h-screen">
         <PublicTryFiligranProductsBanner />
         <div className="flex grow min-h-0">
-          {isHomePageV2Enabled && <PublicMenu />}
-          <div
-            className={cn(
-              'flex flex-col flex-1 min-h-0 min-w-0',
-              !isHomePageV2Enabled && 'bg-gradient-background',
-              isHomePageV2Enabled && 'md:overflow-y-auto'
-            )}>
-            <header
-              className={cn(
-                'sticky flex h-16 w-full shrink-0 items-center border-b border-elevation-border-strong px-4 justify-between',
-                isHomePageV2Enabled &&
-                  "backdrop-blur-sm top-0 z-20 before:content-[''] before:absolute before:inset-0 before:bg-gradient-background before:opacity-50 before:-z-1",
-                !isHomePageV2Enabled &&
-                  'bg-gradient-background max-md:top-0 max-md:z-20'
-              )}>
-              <Link
-                href={`/${locale}`}
-                className={isHomePageV2Enabled ? 'md:hidden' : undefined}>
-                <LogoXTMDark className="text-primary mr-2 h-8 w-auto" />
-                <span className="sr-only">XTM Hub by Filigran</span>
-              </Link>
-              {isHomePageV2Enabled ? (
-                <div className="flex items-center gap-s ml-auto">
-                  <Button
-                    asChild
-                    variant="outline-primary"
-                    className="whitespace-nowrap border-elevation-border-strong">
-                    <Link href="/auth/oidc">{t('PublicLayout.Login')}</Link>
-                  </Button>
-                  <Button
-                    asChild
-                    className="whitespace-nowrap">
-                    <Link href={`/sign-up`}>{t('PublicLayout.SignUp')}</Link>
-                  </Button>
-                  <div className="md:hidden flex items-center">
-                    <PublicMobileMenuButton />
-                  </div>
-                </div>
-              ) : (
-                <Button
-                  asChild
-                  className="whitespace-nowrap">
-                  <Link href={`/login`}>{t('PublicLayout.SignIn')}</Link>
-                </Button>
-              )}
+          <div className="flex flex-col flex-1 min-h-0 min-w-0 bg-gradient-background">
+            <header className="sticky flex h-16 w-full shrink-0 items-center border-b border-elevation-border-strong px-4 justify-between bg-gradient-background max-md:top-0 max-md:z-20">
+              <PublicHeaderContent locale={locale} />
             </header>
-            <main
-              className={cn('grow', !isHomePageV2Enabled && 'overflow-y-auto')}>
-              <div
-                className={cn(
-                  'container pt-l',
-                  isHomePageV2Enabled && 'pt-xxl'
-                )}>
-                {children}
-              </div>
+            <main className="grow overflow-y-auto">
+              <div className="container pt-l">{children}</div>
             </main>
-            <AppFooter
-              className="max-md:mt-xxl px-6"
-              isHomePageV2Enabled={isHomePageV2Enabled}
-            />
           </div>
         </div>
         <Copilot />

--- a/apps/frontend/src/components/AppFooter.tsx
+++ b/apps/frontend/src/components/AppFooter.tsx
@@ -24,7 +24,11 @@ export const AppFooter = ({
     isHomePageV2EnabledProp ?? isHomePageV2EnabledFromHook;
 
   return (
-    <footer className={cn('text-muted-foreground pt-6 px-0', className)}>
+    <footer
+      className={cn(
+        'text-text-default-primary content-body-compact bg-elevation-bg-layer-0 pt-6 px-0',
+        className
+      )}>
       <div className="items-center justify-between flex flex-col md:flex-row w-full px-4 py-2 gap-l text-center">
         <span className="text-content-body-compact-link">
           <Link

--- a/apps/frontend/src/components/AppFooter.tsx
+++ b/apps/frontend/src/components/AppFooter.tsx
@@ -24,8 +24,7 @@ export const AppFooter = ({
     isHomePageV2EnabledProp ?? isHomePageV2EnabledFromHook;
 
   return (
-    <footer
-      className={cn('container text-muted-foreground pt-6 px-0', className)}>
+    <footer className={cn('text-muted-foreground pt-6 px-0', className)}>
       <div className="items-center justify-between flex flex-col md:flex-row w-full px-4 py-2 gap-l text-center">
         <span className="text-content-body-compact-link">
           <Link

--- a/apps/frontend/src/components/ContentLayout.tsx
+++ b/apps/frontend/src/components/ContentLayout.tsx
@@ -1,32 +1,33 @@
 'use client';
 
-import { AppFooter } from '@/components/AppFooter';
+import { SharedContent } from '@/components/layout/SharedContent';
 import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
-import { cn } from '@/lib/utils';
 import { FeatureFlag } from '@graphql/generated';
 import { ReactNode } from 'react';
 
 interface ContentLayoutProps {
   children: ReactNode;
-  showFooter?: boolean;
 }
 
-export const ContentLayout = ({
-  children,
-  showFooter = true,
-}: ContentLayoutProps) => {
+// TODO: once FeatureFlag.HomePageV2 is removed, this component becomes a
+// pure passthrough (always the SharedContent branch) and can be deleted.
+// Its only remaining caller (app/(embed)/layout.tsx) should import
+// SharedContent directly instead, the same way AppShell already does.
+export const ContentLayout = ({ children }: ContentLayoutProps) => {
   const isHomePageV2Enabled = useIsFeatureEnabled(FeatureFlag.HomePageV2);
+
+  if (isHomePageV2Enabled) {
+    return (
+      <SharedContent className="flex flex-col bg-gradient-background px-3 pt-3 sm:px-6 sm:p-6">
+        {children}
+      </SharedContent>
+    );
+  }
+
   return (
     <div className="relative flex-1 min-h-0">
-      <main
-        className={cn(
-          'h-full w-full overflow-y-auto flex flex-col',
-          isHomePageV2Enabled
-            ? 'bg-gradient-background px-3 pt-3 sm:px-6 sm:pt-6'
-            : 'bg-background p-6'
-        )}>
+      <main className="h-full w-full overflow-y-auto flex flex-col bg-background p-6">
         <div className="flex-1">{children}</div>
-        {isHomePageV2Enabled && showFooter && <AppFooter />}
       </main>
     </div>
   );

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -57,16 +57,8 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
     ) ||
       hasOrganizationCapability(OrganizationCapability.ManageAccess));
 
-  return (
-    <header
-      id="app-header"
-      className={cn(
-        'sticky top-0 z-20 flex h-16 w-full shrink-0 items-center border-b border-elevation-border-strong px-4 justify-between',
-        !displayLogo && !isHomePageV2Enabled && 'sm:justify-end',
-        !isHomePageV2Enabled && 'bg-gradient-background',
-        isHomePageV2Enabled &&
-          "backdrop-blur-sm before:content-[''] before:absolute before:inset-0 before:bg-gradient-background before:opacity-50 before:-z-1"
-      )}>
+  const headerContent = (
+    <>
       <div className="mobile:hidden flex items-center gap-s">
         <DisplayLogo
           className={cn(
@@ -188,6 +180,21 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
           </SheetContent>
         </Sheet>
       </div>
+    </>
+  );
+
+  if (isHomePageV2Enabled) {
+    return headerContent;
+  }
+
+  return (
+    <header
+      id="app-header"
+      className={cn(
+        'sticky top-0 z-20 flex h-16 w-full shrink-0 items-center border-b border-elevation-border-strong px-4 justify-between bg-gradient-background',
+        !displayLogo && 'sm:justify-end'
+      )}>
+      {headerContent}
     </header>
   );
 };

--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,40 @@
+import { AppFooter } from '@/components/AppFooter';
+import { SharedContent } from '@/components/layout/SharedContent';
+import { ReactNode } from 'react';
+
+interface AppShellProps {
+  banners?: ReactNode;
+  menu: ReactNode;
+  headerContent: ReactNode;
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+export const AppShell = ({
+  banners,
+  menu,
+  headerContent,
+  contentClassName,
+  children,
+}: AppShellProps) => {
+  return (
+    <div className="flex flex-col w-full h-dvh min-h-0">
+      {banners}
+      <div className="flex flex-row grow min-h-0">
+        {menu}
+        <div className="flex flex-col w-full h-full min-h-0 min-w-0">
+          <header className="sticky top-0 z-20 flex h-16 w-full shrink-0 items-center border-b border-elevation-border-strong px-4 justify-between backdrop-blur-sm before:content-[''] before:absolute before:inset-0 before:bg-gradient-background before:opacity-50 before:-z-1">
+            {headerContent}
+          </header>
+          <SharedContent className={contentClassName}>
+            {children}
+            <AppFooter
+              isHomePageV2Enabled
+              className="max-md:mt-xxl mx-0"
+            />
+          </SharedContent>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/layout/PublicHeaderContent.tsx
+++ b/apps/frontend/src/components/layout/PublicHeaderContent.tsx
@@ -1,0 +1,53 @@
+import { PublicMobileMenuButton } from '@/components/menu/navigation/public/PublicMobileMenuButton';
+import { isFeatureEnabled } from '@/utils/settings.service';
+import { Button } from '@filigran/ui/servers';
+import { FeatureFlag } from '@graphql/generated';
+import LogoXTMDark from '@public/logo_xtm_hub_dark.svg';
+import { getTranslations } from 'next-intl/server';
+import Link from 'next/link';
+
+interface PublicHeaderContentProps {
+  locale: string;
+}
+
+export const PublicHeaderContent = async ({
+  locale,
+}: PublicHeaderContentProps) => {
+  const t = await getTranslations();
+  const isHomePageV2Enabled = await isFeatureEnabled(FeatureFlag.HomePageV2);
+
+  return (
+    <>
+      <Link
+        href={`/${locale}`}
+        className={isHomePageV2Enabled ? 'md:hidden' : undefined}>
+        <LogoXTMDark className="text-primary mr-2 h-8 w-auto" />
+        <span className="sr-only">{t('Metadata.SiteName')}</span>
+      </Link>
+      {isHomePageV2Enabled ? (
+        <div className="flex items-center gap-s ml-auto">
+          <Button
+            asChild
+            variant="outline-primary"
+            className="whitespace-nowrap border-elevation-border-strong">
+            <Link href="/auth/oidc">{t('PublicLayout.Login')}</Link>
+          </Button>
+          <Button
+            asChild
+            className="whitespace-nowrap">
+            <Link href={`/sign-up`}>{t('PublicLayout.SignUp')}</Link>
+          </Button>
+          <div className="md:hidden flex items-center">
+            <PublicMobileMenuButton />
+          </div>
+        </div>
+      ) : (
+        <Button
+          asChild
+          className="whitespace-nowrap">
+          <Link href={`/login`}>{t('PublicLayout.SignIn')}</Link>
+        </Button>
+      )}
+    </>
+  );
+};

--- a/apps/frontend/src/components/layout/SharedContent.tsx
+++ b/apps/frontend/src/components/layout/SharedContent.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { ReactNode } from 'react';
+
+interface SharedContentProps {
+  children: ReactNode;
+  className?: string;
+  mainClassName?: string;
+}
+
+export const SharedContent = ({
+  children,
+  className,
+  mainClassName = 'h-full w-full overflow-y-auto',
+}: SharedContentProps) => (
+  <div className="flex-1 min-h-0">
+    <main className={mainClassName}>
+      <div className={className}>{children}</div>
+    </main>
+  </div>
+);

--- a/apps/frontend/src/components/menu/PublicMenu.tsx
+++ b/apps/frontend/src/components/menu/PublicMenu.tsx
@@ -15,8 +15,8 @@ const PublicMenu = () => {
   return (
     <aside
       className={cn(
-        'max-md:hidden z-20 flex h-full flex-col overflow-x-hidden bg-gradient-layer-0-white duration-300',
-        open ? 'w-45' : 'w-14'
+        'max-md:hidden z-20 sticky shrink-0 top-0 left-0 flex h-full flex-col overflow-y-auto overflow-x-hidden bg-gradient-layer-0-white duration-300 ease-in-out',
+        open ? 'w-48' : 'w-14'
       )}>
       <MenuLogo
         href={`/${locale}`}


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

- Mutualize layout of private and public pages
- fix issue with private and public menus having different width
- fix issue with gradient background on mobile on public homepage


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- test layout of public and private pages, it must be similar, especially for scrolling. No regression, no scroll issue, no background issues especially on mobile (gradient background to the bottom of the page)


## Related issues

- Related to #2876

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.