### PR TITLE
fix(filters): apply design system tokens to filter chips (#2887)

### DIFF
--- a/apps/frontend/src/components/ui/shareable-resource/logical-multi-select/SelectedValuesDisplay.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/logical-multi-select/SelectedValuesDisplay.tsx
@@ -33,7 +33,7 @@ export const AndSeparator = ({ className }: { className?: string }) => {
   return (
     <span
       className={cn(
-        'text-sm h-9 leading-9 px-s bg-gray-200/60 dark:bg-gray-700/60 text-foreground rounded',
+        'inline-flex items-center h-9 px-2 content-body-compact-medium bg-elevation-background-layer-2 text-text-default-primary rounded-lg',
         className
       )}>
       {t('Utils.And')}
@@ -49,11 +49,7 @@ export const FilterLabel = ({
   className?: string;
 }) => {
   return (
-    <span
-      className={cn(
-        'inline-block text-white dark:text-foreground whitespace-nowrap',
-        className
-      )}>
+    <span className={cn('inline-block whitespace-nowrap', className)}>
       {children}
     </span>
   );
@@ -63,7 +59,7 @@ export const OrSeparator = ({ className }: { className?: string }) => {
   return (
     <span
       className={cn(
-        'h-9 leading-9 px-s mx-s bg-gray-500/30 dark:bg-gray-50/30 text-white dark:text-foreground inline-block',
+        'inline-flex items-center h-8 px-2 mx-2 content-body-compact-medium bg-elevation-surface-heading-layer-3 text-text-default-primary rounded-lg',
         className
       )}>
       {t('Utils.Or')}
@@ -78,7 +74,11 @@ export const SelectionChip = ({
   children: ReactNode;
   className?: string;
 }) => (
-  <div className={cn('text-sm inline-block rounded max-w-[400px] ', className)}>
+  <div
+    className={cn(
+      'content-body-compact-medium inline-block rounded-lg max-w-[400px]',
+      className
+    )}>
     {children}
   </div>
 );
@@ -91,7 +91,7 @@ export const ChildrenLabels = ({
   <>
     {items.map((child, index) => (
       <Fragment key={child.value}>
-        {index > 0 && <OrSeparator className="text-foreground" />}
+        {index > 0 && <OrSeparator />}
         {child.label}
       </Fragment>
     ))}
@@ -112,7 +112,7 @@ const RemoveFilterButton = ({ onRemove }: RemoveFilterButtonProps) => {
       aria-label="Remove filter"
       asChild>
       <div>
-        <CancelIcon className="h-6 w-6 text-muted-foreground ml-xs pr-xs" />
+        <CancelIcon className="h-6 w-6 text-text-default-secondary ml-1 pr-1" />
       </div>
     </Button>
   );
@@ -126,9 +126,9 @@ export const SelectedValuesDisplay = ({
 }: SelectedValuesDisplayProps) => {
   if (groupedSelections.length === 0) {
     return (
-      <div className="h-9 flex items-center justify-between border rounded">
+      <div className="h-9 flex items-center justify-between pl-4 pr-2 bg-elevation-background-layer-3 rounded-lg">
         <span
-          className="mx-3 text-sm text-foreground normal-case"
+          className="content-body-compact-medium text-text-default-primary normal-case"
           role="textbox"
           aria-readonly="true">
           {placeholder}
@@ -150,14 +150,14 @@ export const SelectedValuesDisplay = ({
         <TooltipTrigger
           style={{ cursor: 'unset' }}
           asChild>
-          <div className="flex items-center bg-gray-200/60 dark:bg-gray-700/60 text-foreground hover:bg-hover rounded">
+          <div className="h-9 flex items-center pl-4 pr-2 bg-elevation-background-layer-3 text-text-default-primary hover:bg-hover rounded-lg">
             <SelectionChip className="truncate">
-              <FilterLabel className="text-foreground pl-s py-s mr-s font-semibold">
+              <FilterLabel className="mr-2 font-semibold">
                 {optionLabel} =
               </FilterLabel>
               {groupedSelections.map((group, index) => (
                 <Fragment key={group.parentValue}>
-                  {index > 0 && <OrSeparator className="text-foreground" />}
+                  {index > 0 && <OrSeparator />}
                   {group.children.length > 0 ? (
                     <ChildrenLabels items={group.children} />
                   ) : (


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Aligns the filter chips (`SelectedValuesDisplay`) with the Design System 2026:
semantic colour tokens, radius and spacing. No functional change — filter logic
is untouched.

<img width="1687" height="137" alt="image" src="https://github.com/user-attachments/assets/134bef1d-11b0-435e-b586-c2683e209f7a" />

<img width="1687" height="137" alt="image" src="https://github.com/user-attachments/assets/8a86bc54-3877-4be3-b265-64b839953633" />


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #2887

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.