### PR TITLE
fix(translation): capitalize resource in a translation (#2921)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -323,7 +323,7 @@
       "Title": "New Resources"
     },
     "XtmMostDeployedResources": {
-      "Title": "Most deployed resources"
+      "Title": "Most deployed Resources"
     },
     "LastDeployedResources": {
       "Title": "The last deployed resources",


### PR DESCRIPTION
eplace ‘Most deployed resource’s by ‘Most Deployed Resources’
<img width="763" height="319" alt="image" src="https://github.com/user-attachments/assets/2eb994e5-90d7-401a-94f6-57ea2d64bcc0" />

## Related issues

- Related to #2921 