### PR TITLE
feat(homepage): display preferences in profile on all env (#2929)

### DIFF
--- a/apps/frontend/src/components/profile/form/Preferences.tsx
+++ b/apps/frontend/src/components/profile/form/Preferences.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { MeEditUserMutation } from '@/components/me/me.graphql';
-import { SettingsContext } from '@/components/settings/EnvPortalContext';
 import { Locale, locales } from '@/i18n/config';
 import { setUserLocale } from '@/i18n/locale';
 import {
@@ -17,14 +16,10 @@ import {
 } from '@filigran/ui';
 import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useContext } from 'react';
 import { useMutation } from 'react-relay';
 
 export const ProfileFormPreferences = () => {
   const t = useTranslations();
-  const { settings } = useContext(SettingsContext);
-  const isDevelopmentEnvSetting =
-    settings?.environment && settings.environment !== 'production';
   const locale = useLocale();
   const { theme, setTheme } = useTheme();
   const [commitEditMeUserMutation] = useMutation(MeEditUserMutation);
@@ -35,10 +30,6 @@ export const ProfileFormPreferences = () => {
   };
 
   const currentTheme = theme ?? 'dark';
-
-  if (!isDevelopmentEnvSetting) {
-    return null;
-  }
 
   return (
     <Card>


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

remove condition to display preferences in profile and allow language and theme change.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

test preferences is displayed on prerelease (after merge)

## Related issues

- Related to #2929

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.