### PR TITLE
fix(ui): footer layout && dropdown color (#2933)

### DIFF
--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -30,7 +30,7 @@ export const AppShell = ({
             {children}
             <AppFooter
               isHomePageV2Enabled
-              className="mt-auto max-md:mt-xxl mx-0"
+              className="mt-auto mx-0"
             />
           </SharedContent>
         </div>

--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -30,7 +30,7 @@ export const AppShell = ({
             {children}
             <AppFooter
               isHomePageV2Enabled
-              className="max-md:mt-xxl mx-0"
+              className="mt-auto max-md:mt-xxl mx-0"
             />
           </SharedContent>
         </div>

--- a/apps/frontend/src/components/layout/SharedContent.tsx
+++ b/apps/frontend/src/components/layout/SharedContent.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/lib/utils';
 import { ReactNode } from 'react';
 

--- a/apps/frontend/src/components/layout/SharedContent.tsx
+++ b/apps/frontend/src/components/layout/SharedContent.tsx
@@ -1,4 +1,4 @@
-'use client';
+import { cn } from '@/lib/utils';
 import { ReactNode } from 'react';
 
 interface SharedContentProps {
@@ -14,7 +14,9 @@ export const SharedContent = ({
 }: SharedContentProps) => (
   <div className="flex-1 min-h-0">
     <main className={mainClassName}>
-      <div className={className}>{children}</div>
+      <div className={cn('flex flex-col min-h-full', className)}>
+        {children}
+      </div>
     </main>
   </div>
 );

--- a/apps/frontend/src/components/menu/organization-switcher/HeaderOrganizationSwitcher.tsx
+++ b/apps/frontend/src/components/menu/organization-switcher/HeaderOrganizationSwitcher.tsx
@@ -94,7 +94,7 @@ const HeaderOrganizationSwitcher = () => {
             aria-controls={listboxId}
             aria-expanded={openPopover}
             aria-haspopup="listbox"
-            className="w-full justify-between border-none dark:bg-grayblue-800 bg-gray-150 sm:w-55 text-text-default-primary">
+            className="w-full justify-between border-none bg-elevation-surface-highlight sm:w-55 text-text-default-primary">
             <span className="truncate">{selectedOrganization?.label}</span>
             <ArrowDropDownIcon
               aria-hidden={true}

--- a/apps/frontend/src/components/menu/organization-switcher/HeaderOrganizationSwitcher.tsx
+++ b/apps/frontend/src/components/menu/organization-switcher/HeaderOrganizationSwitcher.tsx
@@ -79,7 +79,7 @@ const HeaderOrganizationSwitcher = () => {
   };
 
   return (
-    <div className="flex flex-col gap-xs sm:flex-row sm:items-center sm:gap-m">
+    <div className="flex flex-col gap-xs sm:flex-row sm:items-center sm:gap-m text-text-default-primary">
       <span className="content-body-base sm:whitespace-nowrap">
         {t('OrganizationSwitcher.Workspace')}
       </span>
@@ -94,12 +94,12 @@ const HeaderOrganizationSwitcher = () => {
             aria-controls={listboxId}
             aria-expanded={openPopover}
             aria-haspopup="listbox"
-            className="w-full justify-between border-none dark:bg-grayblue-800 bg-gray-150 sm:w-55">
+            className="w-full justify-between border-none dark:bg-grayblue-800 bg-gray-150 sm:w-55 text-text-default-primary">
             <span className="truncate">{selectedOrganization?.label}</span>
             <ArrowDropDownIcon
               aria-hidden={true}
               focusable={false}
-              className="ml-s h-4 w-4 shrink-0 opacity-70"
+              className="ml-s h-4 w-4 shrink-0 text-text-default-primary"
             />
           </Button>
         </PopoverTrigger>
@@ -123,7 +123,7 @@ const HeaderOrganizationSwitcher = () => {
                     role="option"
                     aria-selected={isSelected}
                     onClick={() => handleOnValueChange(organization)}
-                    className="w-full justify-start truncate normal-case">
+                    className="w-full justify-start truncate normal-case text-text-default-primary">
                     {organization.label}
                   </Button>
                 </li>


### PR DESCRIPTION
# Context
- footer need to be at bottom by default 
- organization dropdown had the wrong color (the default one), not the primary 

## How to test
- check that the footer stays at the bottom of the page even when body content is short
<img width="1317" height="652" alt="Capture d’écran 2026-07-24 à 09 33 09" src="https://github.com/user-attachments/assets/98175235-3092-4059-81a7-857f7a2d957f" />

- check that organization dropdown has the right color (selected org, arrow icon, org options)
<img width="323" height="158" alt="Capture d’écran 2026-07-24 à 09 33 31" src="https://github.com/user-attachments/assets/40d35385-0fe2-4735-9d44-be825b8180ef" />


## Related issues

- Related to #2933

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.