### PR TITLE
fix(banner): make free trial learn more button visible on brand surface (#2935)

### DIFF
--- a/apps/frontend/src/components/service/trial-instances/banner/LearnMoreBannerButton.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/LearnMoreBannerButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
+import { IconActionContext } from '@/components/ui/IconActions';
+import { KeyboardArrowRightIcon } from '@filigran/icon';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@filigran/ui';
+import { Button } from '@filigran/ui/servers';
+import { PlatformIdentifier } from '@graphql/generated';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+
+interface LearnMoreBannerButtonProps {
+  getHref: (product: PlatformIdentifier) => string;
+}
+
+export const LearnMoreBannerButton = ({
+  getHref,
+}: LearnMoreBannerButtonProps) => {
+  const t = useTranslations();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const getLink = (product: PlatformIdentifier) => (
+    <Link
+      onClick={() => setMenuOpen(false)}
+      href={getHref(product)}>
+      <div className="flex flex-row h-9 px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring hover:bg-hover">
+        <Image
+          width="25"
+          height="25"
+          alt={'Product Logo'}
+          src={PlatformMetadataMapping[product].logoUrl}
+          className="mr-s object-contain"
+        />
+        {PlatformMetadataMapping[product].name}
+      </div>
+    </Link>
+  );
+
+  return (
+    <DropdownMenu
+      open={menuOpen}
+      onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className="ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70"
+          variant="secondary">
+          {t('Service.Trials.LearnMore.Link')}
+          <div
+            className={`ml-s inline-flex transition-transform ${
+              menuOpen ? 'rotate-90' : 'rotate-0'
+            }`}>
+            <KeyboardArrowRightIcon className="h-3 w-3" />
+          </div>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-full flex flex-col">
+        <IconActionContext.Provider value={{ setMenuOpen }}>
+          {getLink(PlatformIdentifier.Opencti)}
+          {getLink(PlatformIdentifier.Openaev)}
+        </IconActionContext.Provider>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/frontend/src/components/service/trial-instances/banner/LearnMoreBannerLink.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/LearnMoreBannerLink.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@filigran/ui/servers';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+
+interface LearnMoreBannerLinkProps {
+  href: string;
+}
+
+export const LearnMoreBannerLink = ({ href }: LearnMoreBannerLinkProps) => {
+  const t = useTranslations();
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        buttonVariants({ variant: 'secondary' }),
+        'ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70'
+      )}>
+      {t('Service.Trials.LearnMore.Link')}
+    </Link>
+  );
+};

--- a/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
@@ -14,6 +14,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
+import { BANNER_ACTION_CLASSES } from './banner-styles';
 
 export const PublicTryFiligranProductsBanner = () => {
   const t = useTranslations();
@@ -59,9 +60,8 @@ export const PublicTryFiligranProductsBanner = () => {
         <DropdownMenuTrigger asChild>
           <div className="flex flex-row items-center mr-xl">
             <Button
-              className="ml-s mr-s text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70"
+              className={BANNER_ACTION_CLASSES}
               variant="secondary"
-              size="sm"
               aria-expanded={menuOpen}>
               {t('Service.Trials.LearnMore.Link')}
               <div

--- a/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
@@ -1,51 +1,20 @@
 'use client';
+
 import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
-import { IconActionContext } from '@/components/ui/IconActions';
-import { KeyboardArrowRightIcon } from '@filigran/icon';
-import {
-  Callout,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@filigran/ui';
-import { Button } from '@filigran/ui/servers';
-import { PlatformIdentifier } from '@graphql/generated';
+import { Callout } from '@filigran/ui';
 import { useLocale, useTranslations } from 'next-intl';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useState } from 'react';
-import { BANNER_ACTION_CLASSES } from './banner-styles';
+import { LearnMoreBannerButton } from './LearnMoreBannerButton';
 
 export const PublicTryFiligranProductsBanner = () => {
   const t = useTranslations();
   const locale = useLocale();
-  const [menuOpen, setMenuOpen] = useState(false);
+
   const bannerText = (
     <span>
       {t('Service.Trials.ExploreProducts')}{' '}
       <span className="font-bold">{t('Service.Trials.ExploreBold')}</span>
     </span>
   );
-
-  const getLink = (product: PlatformIdentifier) => {
-    return (
-      <Link
-        onClick={() => setMenuOpen(false)}
-        href={`/${locale}${PlatformMetadataMapping[product].learnMorePublicUrl}`}>
-        <div className="flex flex-row h-9 px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring hover:bg-hover">
-          <Image
-            width="25"
-            height="25"
-            alt={'Product Logo'}
-            src={PlatformMetadataMapping[product].logoUrl}
-            className="mr-s"
-          />
-          {PlatformMetadataMapping[product].name}
-        </div>
-      </Link>
-    );
-  };
-
   return (
     <Callout
       className="rounded-none text-black justify-center"
@@ -54,34 +23,11 @@ export const PublicTryFiligranProductsBanner = () => {
           'linear-gradient(to right, hsl(var(--blue-default)), hsl(var(--turquoise-300)))',
       }}>
       {bannerText}
-      <DropdownMenu
-        open={menuOpen}
-        onOpenChange={setMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <div className="flex flex-row items-center mr-xl">
-            <Button
-              className={BANNER_ACTION_CLASSES}
-              variant="secondary"
-              aria-expanded={menuOpen}>
-              {t('Service.Trials.LearnMore.Link')}
-              <div
-                className={`ml-s inline-flex transition-transform ${
-                  menuOpen ? 'rotate-90' : 'rotate-0'
-                }`}>
-                <KeyboardArrowRightIcon className="h-3 w-3" />
-              </div>
-            </Button>
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="w-full flex flex-col">
-          <IconActionContext.Provider value={{ setMenuOpen }}>
-            {getLink(PlatformIdentifier.Opencti)}
-            {getLink(PlatformIdentifier.Openaev)}
-          </IconActionContext.Provider>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <LearnMoreBannerButton
+        getHref={(product) =>
+          `/${locale}${PlatformMetadataMapping[product].learnMorePublicUrl}`
+        }
+      />
     </Callout>
   );
 };

--- a/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/PublicTryFiligranProductsBanner.tsx
@@ -59,10 +59,10 @@ export const PublicTryFiligranProductsBanner = () => {
         <DropdownMenuTrigger asChild>
           <div className="flex flex-row items-center mr-xl">
             <Button
-              className="ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto"
+              className="ml-s mr-s text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70"
               variant="secondary"
-              aria-expanded={menuOpen}
-              onClick={() => setMenuOpen}>
+              size="sm"
+              aria-expanded={menuOpen}>
               {t('Service.Trials.LearnMore.Link')}
               <div
                 className={`ml-s inline-flex transition-transform ${

--- a/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.tsx
@@ -4,12 +4,15 @@ import { useTranslations } from 'next-intl';
 
 import GuardCapacityComponent from '@/components/AdminGuard';
 import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
+import { BANNER_ACTION_CLASSES } from '@/components/service/trial-instances/banner/banner-styles';
 import { StartTrialBannerButton } from '@/components/service/trial-instances/banner/StartTrialBannerButton';
 import { useOrgaFreeTrial } from '@/components/service/trial-instances/useOrgaFreeTrials';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
 import { IconActionContext } from '@/components/ui/IconActions';
+import { cn } from '@/lib/utils';
 import { KeyboardArrowRightIcon } from '@filigran/icon';
 import {
+  buttonVariants,
   Callout,
   DropdownMenu,
   DropdownMenuContent,
@@ -73,9 +76,9 @@ export const TryFiligranProductsBanner = () => {
           <DropdownMenuTrigger asChild>
             <div className="ml-xs mr-xs flex flex-row items-center">
               <Button
-                className="ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto"
+                className={BANNER_ACTION_CLASSES}
                 variant="secondary"
-                onClick={() => setMenuOpen}>
+                aria-expanded={menuOpen}>
                 {t('Service.Trials.LearnMore.Link')}
                 <div
                   className={`ml-s inline-flex transition-transform ${
@@ -110,7 +113,10 @@ export const TryFiligranProductsBanner = () => {
       learnMore: (
         <Link
           href={`${settings!.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Openaev].learnMorePrivateUrl}`}
-          className="ml-xs mr-s underline font-bold">
+          className={cn(
+            buttonVariants({ variant: 'secondary' }),
+            BANNER_ACTION_CLASSES
+          )}>
           {t('Service.Trials.LearnMore.Link')}
         </Link>
       ),
@@ -128,7 +134,10 @@ export const TryFiligranProductsBanner = () => {
       learnMore: (
         <Link
           href={`${settings!.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Opencti].learnMorePrivateUrl}`}
-          className="ml-xs mr-s underline font-bold">
+          className={cn(
+            buttonVariants({ variant: 'secondary' }),
+            BANNER_ACTION_CLASSES
+          )}>
           {t('Service.Trials.LearnMore.Link')}
         </Link>
       ),

--- a/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.tsx
+++ b/apps/frontend/src/components/service/trial-instances/banner/TryFiligranProductsBanner.tsx
@@ -4,25 +4,14 @@ import { useTranslations } from 'next-intl';
 
 import GuardCapacityComponent from '@/components/AdminGuard';
 import { PlatformMetadataMapping } from '@/components/registration/PlatformIdentifierMapping';
-import { BANNER_ACTION_CLASSES } from '@/components/service/trial-instances/banner/banner-styles';
+import { LearnMoreBannerButton } from '@/components/service/trial-instances/banner/LearnMoreBannerButton';
+import { LearnMoreBannerLink } from '@/components/service/trial-instances/banner/LearnMoreBannerLink';
 import { StartTrialBannerButton } from '@/components/service/trial-instances/banner/StartTrialBannerButton';
 import { useOrgaFreeTrial } from '@/components/service/trial-instances/useOrgaFreeTrials';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
-import { IconActionContext } from '@/components/ui/IconActions';
-import { cn } from '@/lib/utils';
-import { KeyboardArrowRightIcon } from '@filigran/icon';
-import {
-  buttonVariants,
-  Callout,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@filigran/ui';
-import { Button } from '@filigran/ui/servers';
+import { Callout } from '@filigran/ui';
 import { OrganizationCapability, PlatformIdentifier } from '@graphql/generated';
-import Image from 'next/image'; // Component
-import Link from 'next/link';
-import { ReactNode, useContext, useState } from 'react';
+import { ReactNode, useContext } from 'react';
 
 export const PRODUCTS_AVAILABLE_ON_TRIAL = 2;
 type BannerConfig = {
@@ -36,30 +25,9 @@ export const TryFiligranProductsBanner = () => {
   const { settings } = useContext(SettingsContext);
   const { availableTrials } = useOrgaFreeTrial();
 
-  const [menuOpen, setMenuOpen] = useState(false);
-
   if (!settings) return null;
 
   if (availableTrials.length === 0) return null; // Dont display the banner if user already has the 2 products in trial
-
-  const getLink = (product: PlatformIdentifier) => {
-    return (
-      <Link
-        onClick={() => setMenuOpen(false)}
-        href={`${settings!.base_url_front}${PlatformMetadataMapping[product].learnMorePrivateUrl}`}>
-        <div className="flex flex-row h-9 px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring hover:bg-hover">
-          <Image
-            width="25"
-            height="25"
-            alt={'Product Logo'}
-            src={PlatformMetadataMapping[product].logoUrl}
-            className="mr-s object-contain"
-          />
-          {PlatformMetadataMapping[product].name}
-        </div>
-      </Link>
-    );
-  };
 
   const BANNER_TEXTS: Record<string, BannerConfig> = {
     default: {
@@ -70,34 +38,11 @@ export const TryFiligranProductsBanner = () => {
         </span>
       ),
       learnMore: (
-        <DropdownMenu
-          open={menuOpen}
-          onOpenChange={setMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <div className="ml-xs mr-xs flex flex-row items-center">
-              <Button
-                className={BANNER_ACTION_CLASSES}
-                variant="secondary"
-                aria-expanded={menuOpen}>
-                {t('Service.Trials.LearnMore.Link')}
-                <div
-                  className={`ml-s inline-flex transition-transform ${
-                    menuOpen ? 'rotate-90' : 'rotate-0'
-                  }`}>
-                  <KeyboardArrowRightIcon className="h-3 w-3" />
-                </div>
-              </Button>
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            className="w-full flex flex-col">
-            <IconActionContext.Provider value={{ setMenuOpen }}>
-              {getLink(PlatformIdentifier.Opencti)}
-              {getLink(PlatformIdentifier.Openaev)}
-            </IconActionContext.Provider>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <LearnMoreBannerButton
+          getHref={(product) =>
+            `${settings.base_url_front}${PlatformMetadataMapping[product].learnMorePrivateUrl}`
+          }
+        />
       ),
     },
     openaev: {
@@ -111,14 +56,9 @@ export const TryFiligranProductsBanner = () => {
         </span>
       ),
       learnMore: (
-        <Link
-          href={`${settings!.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Openaev].learnMorePrivateUrl}`}
-          className={cn(
-            buttonVariants({ variant: 'secondary' }),
-            BANNER_ACTION_CLASSES
-          )}>
-          {t('Service.Trials.LearnMore.Link')}
-        </Link>
+        <LearnMoreBannerLink
+          href={`${settings.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Openaev].learnMorePrivateUrl}`}
+        />
       ),
     },
     opencti: {
@@ -132,14 +72,9 @@ export const TryFiligranProductsBanner = () => {
         </span>
       ),
       learnMore: (
-        <Link
-          href={`${settings!.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Opencti].learnMorePrivateUrl}`}
-          className={cn(
-            buttonVariants({ variant: 'secondary' }),
-            BANNER_ACTION_CLASSES
-          )}>
-          {t('Service.Trials.LearnMore.Link')}
-        </Link>
+        <LearnMoreBannerLink
+          href={`${settings.base_url_front}${PlatformMetadataMapping[PlatformIdentifier.Opencti].learnMorePrivateUrl}`}
+        />
       ),
     },
   };

--- a/apps/frontend/src/components/service/trial-instances/banner/banner-styles.ts
+++ b/apps/frontend/src/components/service/trial-instances/banner/banner-styles.ts
@@ -1,0 +1,2 @@
+export const BANNER_ACTION_CLASSES =
+  'ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70';

--- a/apps/frontend/src/components/service/trial-instances/banner/banner-styles.ts
+++ b/apps/frontend/src/components/service/trial-instances/banner/banner-styles.ts
@@ -1,2 +1,0 @@
-export const BANNER_ACTION_CLASSES =
-  'ml-s mr-s text-[12px] px-2 py-0.5 min-h-0 h-auto text-inherit border-current hover:bg-current/10 focus-visible:ring-current/70';


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

<img width="1915" height="698" alt="image" src="https://github.com/user-attachments/assets/3448c850-9646-4920-baf1-d46f56ef1b98" />


## Related issues

- Related to #2935

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.