### PR TITLE
feat(homepage): exclude decoupling connectors from new resources  (#2953)

### DIFF
--- a/apps/backend/src/modules/document/domain/document.domain.test.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.test.ts
@@ -1127,6 +1127,37 @@ describe('document domain', () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.id).toBe(integrationDoc.id);
     });
+
+    it('should exclude documents tagged with decoupling', async () => {
+      // Given
+      const normalDoc = await TestHelper.document.create({
+        name: 'Normal document',
+        type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
+        slug: 'normal-document',
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        active: true,
+        tags: [],
+      });
+      await TestHelper.document.create({
+        name: 'Decoupling document',
+        type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
+        slug: 'decoupling-document',
+        uploader_id: ADMIN_UUID,
+        uploader_organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        active: true,
+        tags: ['decoupling'],
+      });
+
+      // When
+      const result = await DocumentDomain.loadNewestDocuments(10);
+
+      // Then
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe(normalDoc.id);
+    });
   });
 
   describe('search by use case name', () => {

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -520,6 +520,7 @@ export const DocumentDomain = {
             '"Document_Children"."child_document_id" = "Document"."id"'
           );
       })
+      .modify(excludeDecouplingTag)
       .modify((qb) => {
         if (documentTypes?.length) {
           qb.whereIn('Document.type', documentTypes);


### PR DESCRIPTION

# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

new resources on homepage should not return decoupling connectors

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Check decoupling connectors are not displayed on the new resources (connectors created with ingestManifestFragments)


## Related issues

- Related to #2953

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.