### PR TITLE
fix(email): point library docs CTA to the Hub instead of OpenCTI/OpenAEV (#2975)

### DIFF
--- a/apps/backend/src/server/mail-template/openaev_scenarios.html
+++ b/apps/backend/src/server/mail-template/openaev_scenarios.html
@@ -216,7 +216,7 @@
                     <p style="margin: 24px 0 0; line-height: 24px">
                       To learn more about all available features,
                       <a
-                        href="https://docs.openaev.io/latest/"
+                        href="https://docs.hub.filigran.io/latest/libraries/openaev-scenarios/"
                         style="color: #001bdb"
                         >click here</a
                       >.

--- a/apps/backend/src/server/mail-template/opencti_custom_dashboards.html
+++ b/apps/backend/src/server/mail-template/opencti_custom_dashboards.html
@@ -215,7 +215,7 @@
                     <p style="margin: 24px 0 0; line-height: 24px">
                       To learn more about all available features,
                       <a
-                        href="https://docs.opencti.io/latest/"
+                        href="https://docs.hub.filigran.io/latest/libraries/custom-dashboards/"
                         style="color: #001bdb"
                         >click here</a
                       >.

--- a/apps/backend/src/server/mail-template/opencti_custom_views.html
+++ b/apps/backend/src/server/mail-template/opencti_custom_views.html
@@ -216,7 +216,7 @@
                     <p style="margin: 24px 0 0; line-height: 24px">
                       To learn more about all available features,
                       <a
-                        href="https://docs.opencti.io/latest/"
+                        href="https://docs.hub.filigran.io/latest/libraries/opencti-custom-views/"
                         style="color: #001bdb"
                         >click here</a
                       >.

--- a/apps/backend/src/server/mail-template/opencti_integrations.html
+++ b/apps/backend/src/server/mail-template/opencti_integrations.html
@@ -220,7 +220,7 @@
                     <p style="margin: 24px 0 0; line-height: 24px">
                       To learn more about all available features,
                       <a
-                        href="https://docs.opencti.io/latest/"
+                        href="https://docs.hub.filigran.io/latest/libraries/integrations/"
                         style="color: #001bdb"
                         >click here</a
                       >.

--- a/apps/backend/src/server/mail-template/opencti_playbooks.html
+++ b/apps/backend/src/server/mail-template/opencti_playbooks.html
@@ -211,7 +211,7 @@
                     <p style="margin: 24px 0 0; line-height: 24px">
                       To learn more about all available features,
                       <a
-                        href="https://docs.opencti.io/latest/"
+                        href="https://docs.hub.filigran.io/latest/libraries/opencti-playbooks/"
                         style="color: #001bdb"
                         >click here</a
                       >.


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #2975 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.