### PR TITLE
feat(fetching): support conditional requests with ETag on manifest downloads (#2971)

### DIFF
--- a/apps/backend/src/server/endpoints/manifest-endpoint.errors.test.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.errors.test.ts
@@ -31,12 +31,13 @@ describe('sendManifestError', () => {
     expect(json).toHaveBeenCalledWith({ code: status, message: error.message });
   });
 
-  it('clears the cache directive before sending an error', () => {
+  it('clears representation headers before sending an error', () => {
     const { res, removeHeader } = buildResponse();
 
     sendManifestError(res, MANIFEST_ERRORS.ManifestNotFound);
 
     expect(removeHeader).toHaveBeenCalledWith('Cache-Control');
+    expect(removeHeader).toHaveBeenCalledWith('ETag');
   });
 });
 

--- a/apps/backend/src/server/endpoints/manifest-endpoint.errors.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.errors.ts
@@ -29,9 +29,8 @@ const sendError = (
   status: ManifestErrorStatus,
   message: string
 ): void => {
-  // Error responses must never inherit the long-lived cache directive
-  // set by the download routes.
   res.removeHeader('Cache-Control');
+  res.removeHeader('ETag');
   res.status(status).json({ code: status, message });
 };
 

--- a/apps/backend/src/server/endpoints/manifest-endpoint.test.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.test.ts
@@ -40,12 +40,14 @@ const buildResponse = () => ({
   status: vi.fn().mockReturnThis(),
   json: vi.fn().mockReturnThis(),
   destroy: vi.fn(),
+  end: vi.fn(),
 });
 
 const buildRequest = (
   params: Record<string, string>,
-  query: Record<string, unknown> = {}
-) => ({ params, query }) as unknown as Request;
+  query: Record<string, unknown> = {},
+  fresh = false
+) => ({ params, query, fresh }) as unknown as Request;
 
 const VALID = {
   product: PlatformIdentifier.Opencti,
@@ -106,6 +108,7 @@ describe('downloadLatestManifest', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(loadManifestsMock).not.toHaveBeenCalled();
   });
+
   it('returns 503 when the storage is unavailable', async () => {
     loadManifestsMock.mockResolvedValue([
       { name: VALID_NAME, created_at: new Date() },
@@ -159,6 +162,37 @@ describe('downloadLatestManifest', () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.destroy).not.toHaveBeenCalled();
+  });
+
+  it('sets a strong ETag built from the manifest name', async () => {
+    loadManifestsMock.mockResolvedValue([
+      { name: VALID_NAME, created_at: new Date() },
+    ]);
+    downloadFileMock.mockResolvedValue({ on: vi.fn(), pipe: vi.fn() });
+
+    const res = buildResponse();
+    await ManifestEndpoint.downloadLatestManifest(
+      buildRequest(VALID),
+      res as unknown as Response
+    );
+
+    expect(res.setHeader).toHaveBeenCalledWith('ETag', `"${VALID_NAME}"`);
+  });
+
+  it('returns 304 without reading from storage when the client is up to date', async () => {
+    loadManifestsMock.mockResolvedValue([
+      { name: VALID_NAME, created_at: new Date() },
+    ]);
+
+    const res = buildResponse();
+    await ManifestEndpoint.downloadLatestManifest(
+      buildRequest(VALID, {}, true),
+      res as unknown as Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(304);
+    expect(res.end).toHaveBeenCalled();
+    expect(downloadFileMock).not.toHaveBeenCalled();
   });
 });
 
@@ -217,6 +251,43 @@ describe('downloadManifestByName', () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.removeHeader).toHaveBeenCalledWith('Cache-Control');
+  });
+
+  it('sets a strong ETag built from the manifest name', async () => {
+    getManifestByNameMock.mockResolvedValue({
+      name: VALID_NAME,
+      created_at: new Date(),
+    });
+    downloadFileMock.mockResolvedValue({ on: vi.fn(), pipe: vi.fn() });
+
+    const res = buildResponse();
+    await ManifestEndpoint.downloadManifestByName(
+      buildRequest({ ...VALID, name: VALID_NAME }),
+      res as unknown as Response
+    );
+
+    expect(res.setHeader).toHaveBeenCalledWith('ETag', `"${VALID_NAME}"`);
+  });
+
+  it('returns 304 without reading from storage when the client is up to date', async () => {
+    getManifestByNameMock.mockResolvedValue({
+      name: VALID_NAME,
+      created_at: new Date(),
+    });
+
+    const res = buildResponse();
+    await ManifestEndpoint.downloadManifestByName(
+      buildRequest({ ...VALID, name: VALID_NAME }, {}, true),
+      res as unknown as Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(304);
+    expect(res.end).toHaveBeenCalled();
+    expect(downloadFileMock).not.toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'public, max-age=31536000, immutable'
+    );
   });
 });
 

--- a/apps/backend/src/server/endpoints/manifest-endpoint.test.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.test.ts
@@ -194,6 +194,22 @@ describe('downloadLatestManifest', () => {
     expect(res.end).toHaveBeenCalled();
     expect(downloadFileMock).not.toHaveBeenCalled();
   });
+
+  it('returns 404 when the stored manifest name is malformed', async () => {
+    loadManifestsMock.mockResolvedValue([
+      { name: 'not-a-manifest-name', created_at: new Date() },
+    ]);
+
+    const res = buildResponse();
+    await ManifestEndpoint.downloadLatestManifest(
+      buildRequest(VALID),
+      res as unknown as Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.setHeader).not.toHaveBeenCalledWith('ETag', expect.anything());
+    expect(downloadFileMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('downloadManifestByName', () => {

--- a/apps/backend/src/server/endpoints/manifest-endpoint.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.ts
@@ -86,6 +86,14 @@ export const ManifestEndpoint = {
         return;
       }
 
+      if (!isValidManifestName(latest.name)) {
+        logApp.error('Manifest name failed validation before MinIO lookup', {
+          name: latest.name,
+        });
+        sendManifestError(res, MANIFEST_ERRORS.ManifestNotFound);
+        return;
+      }
+
       res.setHeader('ETag', buildManifestETag(latest.name));
       res.setHeader('Cache-Control', 'no-cache');
       if (req.fresh) {
@@ -205,14 +213,6 @@ const streamManifestByName = async (
   version: string,
   name: string
 ): Promise<void> => {
-  if (!isValidManifestName(name)) {
-    logApp.error('Manifest name failed validation before MinIO lookup', {
-      name,
-    });
-    sendManifestError(res, MANIFEST_ERRORS.ManifestNotFound);
-    return;
-  }
-
   const key = ManifestHelper.buildManifestObjectKey(product, version, name);
   const body = await MinIOClient.downloadFile(key);
   if (!body) {

--- a/apps/backend/src/server/endpoints/manifest-endpoint.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.ts
@@ -16,6 +16,7 @@ import {
 } from './manifest-endpoint.errors';
 import { buildManifestRateLimiterOptions } from './manifest-endpoint.rate-limit';
 import {
+  buildManifestETag,
   isValidManifestName,
   parseCount,
   validateManifestParams,
@@ -85,7 +86,13 @@ export const ManifestEndpoint = {
         return;
       }
 
+      res.setHeader('ETag', buildManifestETag(latest.name));
       res.setHeader('Cache-Control', 'no-cache');
+      if (req.fresh) {
+        res.status(304).end();
+        return;
+      }
+
       await streamManifestByName(res, product, version, latest.name);
     } catch (error) {
       if (res.headersSent) {
@@ -142,7 +149,13 @@ export const ManifestEndpoint = {
         return;
       }
 
+      res.setHeader('ETag', buildManifestETag(manifest.name));
       res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      if (req.fresh) {
+        res.status(304).end();
+        return;
+      }
+
       await streamManifestByName(res, product, version, manifest.name);
     } catch (error) {
       if (res.headersSent) {
@@ -164,6 +177,7 @@ export const ManifestEndpoint = {
     }
   },
 };
+
 export const manifestEndpoint = (app: Express) => {
   app.get(
     '/:product/:version/:integrationType/manifests',

--- a/apps/backend/src/server/endpoints/manifest-endpoint.utils.test.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.utils.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../__generated__/resolvers-types';
 import { MANIFEST_LIST_DEFAULT_COUNT } from '../../modules/shareable-resource/manifest/manifest.consts';
 import {
+  buildManifestETag,
   isIntegrationType,
   isProduct,
   isValidManifestName,
@@ -93,5 +94,13 @@ describe('validateManifestParams', () => {
     ${{ ...VALID, version: 'not-a-version' }} | ${'Invalid version format'}  | ${'malformed version'}
   `('rejects $description', ({ params, message }) => {
     expect(validateManifestParams(params)).toEqual({ ok: false, message });
+  });
+});
+
+describe('buildManifestETag', () => {
+  const VALID_NAME = 'connector-manifest-7.260604.0-260526113805';
+
+  it('wraps the manifest name in a strong ETag', () => {
+    expect(buildManifestETag(VALID_NAME)).toBe(`"${VALID_NAME}"`);
   });
 });

--- a/apps/backend/src/server/endpoints/manifest-endpoint.utils.ts
+++ b/apps/backend/src/server/endpoints/manifest-endpoint.utils.ts
@@ -14,6 +14,8 @@ const MANIFEST_NAME_PATTERN = new RegExp(
   'i'
 );
 
+export const buildManifestETag = (name: string): string => `"${name}"`;
+
 export const isProduct = (value: unknown): value is PlatformIdentifier =>
   typeof value === 'string' &&
   (Object.values(PlatformIdentifier) as string[]).includes(value);


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

The manifest download routes now support conditional
requests: they expose an `ETag` and answer `304 Not Modified` when the client
already holds the current manifest.

The value isn't bandwidth. The 304 is decided right after the database lookup
that resolves the manifest name, **before** the object is read from MinIO — so a
revalidation costs one small query instead of an 18 MB storage read. That also
makes it the main lever on per-request server cost, which is what we said we'd
need before tuning the rate limit introduced in #2955.

Three design notes:

- **The list route is out of scope.** Express already computes a weak ETag on
  buffered JSON responses and answers 304 through `req.fresh`. Verified with
  curl; nothing to add there. Only the two streamed routes needed work, since
  `stream.pipe(res)` bypasses that mechanism.
- **No hashing.** The `name` column is already unique per snapshot
  (`connector-manifest-{version}-{YYMMDDhhmmss}`), so it *is* the identifier —
  hashing 18 MB to produce one we already have would be wasteful. The ETag is
  strong, since the bytes are identical for a given name.
- **`If-None-Match` is handled by `req.fresh`**, which already implements the
  RFC's weak comparison, lists and `*`. No custom comparator.

`sendManifestError` now also clears the `ETag`, for the same reason it clears
`Cache-Control`: an error response must not carry the identifier of a
representation it didn't serve.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

The manifest download routes now support conditional
requests: they expose an `ETag` and answer `304 Not Modified` when the client
already holds the current manifest.

The value isn't bandwidth. The 304 is decided right after the database lookup
that resolves the manifest name, **before** the object is read from MinIO — so a
revalidation costs one small query instead of an 18 MB storage read. That also
makes it the main lever on per-request server cost, which is what we said we'd
need before tuning the rate limit introduced in #2955.

Three design notes:

- **The list route is out of scope.** Express already computes a weak ETag on
  buffered JSON responses and answers 304 through `req.fresh`. Verified with
  curl; nothing to add there. Only the two streamed routes needed work, since
  `stream.pipe(res)` bypasses that mechanism.
- **No hashing.** The `name` column is already unique per snapshot
  (`connector-manifest-{version}-{YYMMDDhhmmss}`), so it *is* the identifier —
  hashing 18 MB to produce one we already have would be wasteful. The ETag is
  strong, since the bytes are identical for a given name.
- **`If-None-Match` is handled by `req.fresh`**, which already implements the
  RFC's weak comparison, lists and `*`. No custom comparator.

`sendManifestError` now also clears the `ETag`, for the same reason it clears
`Cache-Control`: an error response must not carry the identifier of a
representation it didn't serve.

## Related issues

- Related to #2971

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.