### PR TITLE
chore(profile): enable japanese selector in production (#2981)

### DIFF
--- a/apps/frontend/src/components/profile/form/Preferences.test.tsx
+++ b/apps/frontend/src/components/profile/form/Preferences.test.tsx
@@ -1,0 +1,118 @@
+import { ProfileFormPreferences } from '@/components/profile/form/Preferences';
+import testRender from '@/utils/test/test-render';
+import { screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setTheme: vi.fn(),
+  commitEditMeUserMutation: vi.fn(),
+  setUserLocale: vi.fn(),
+}));
+
+vi.mock('@/i18n/locale', () => ({
+  setUserLocale: mocks.setUserLocale,
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    theme: undefined,
+    setTheme: mocks.setTheme,
+  }),
+}));
+
+vi.mock('react-relay', () => ({
+  useMutation: () => [mocks.commitEditMeUserMutation],
+}));
+
+vi.mock('@filigran/ui', async () => {
+  const actual =
+    await vi.importActual<typeof import('@filigran/ui')>('@filigran/ui');
+
+  return {
+    ...actual,
+    Select: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value: string;
+      onValueChange: (nextValue: string) => void;
+      children: ReactNode;
+    }) => (
+      <select
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}>
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: { children: ReactNode }) => children,
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: ReactNode;
+    }) => <option value={value}>{children}</option>,
+    SelectTrigger: ({ children }: { children: ReactNode }) => children,
+    SelectValue: () => null,
+  };
+});
+
+describe('ProfileFormPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.setUserLocale.mockResolvedValue(undefined);
+  });
+
+  it('should render the preference sections', () => {
+    testRender(<ProfileFormPreferences />);
+
+    expect(
+      screen.getByText('ProfilePage.Preferences.Title')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('ProfilePage.Preferences.Theme')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('ProfilePage.Preferences.Language')
+    ).toBeInTheDocument();
+  });
+
+  it('should use dark theme by default when theme is undefined', () => {
+    testRender(<ProfileFormPreferences />);
+
+    expect(screen.getByText('ThemeToggle.Dark')).toBeInTheDocument();
+  });
+
+  it('should call setTheme when changing the theme', async () => {
+    const { user } = testRender(<ProfileFormPreferences />);
+
+    const [themeSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(themeSelect, 'light');
+
+    expect(mocks.setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('should update locale and persist selected language on locale change', async () => {
+    const { user } = testRender(<ProfileFormPreferences />);
+
+    const [, localeSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(localeSelect, 'ja');
+
+    expect(mocks.setUserLocale).toHaveBeenCalledWith('ja');
+    expect(mocks.commitEditMeUserMutation).toHaveBeenCalledWith({
+      variables: { selected_language: 'ja' },
+    });
+  });
+
+  it('should display fr locale when environment is development', () => {
+    testRender(<ProfileFormPreferences />, {
+      settings: { environment: 'development' },
+    });
+
+    expect(
+      screen.getByRole('option', { name: 'LocaleSwitcher.fr' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/profile/form/Preferences.tsx
+++ b/apps/frontend/src/components/profile/form/Preferences.tsx
@@ -2,7 +2,7 @@
 
 import { MeEditUserMutation } from '@/components/me/me.graphql';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
-import { Locale, locales } from '@/i18n/config';
+import { Locale, locales, publicLocales } from '@/i18n/config';
 import { setUserLocale } from '@/i18n/locale';
 import {
   Card,
@@ -23,11 +23,11 @@ import { useMutation } from 'react-relay';
 export const ProfileFormPreferences = () => {
   const t = useTranslations();
   const { settings } = useContext(SettingsContext);
-  const isDevelopmentEnvSetting =
-    settings?.environment && settings.environment !== 'production';
+  const isDevelopmentEnvSetting = settings?.environment === 'development';
   const locale = useLocale();
   const { theme, setTheme } = useTheme();
   const [commitEditMeUserMutation] = useMutation(MeEditUserMutation);
+  const availableLocales = isDevelopmentEnvSetting ? locales : publicLocales;
 
   const onLocaleChange = (value: string) => {
     void setUserLocale(value as Locale);
@@ -64,29 +64,27 @@ export const ProfileFormPreferences = () => {
           </Select>
         </div>
 
-        {isDevelopmentEnvSetting && (
-          <div className="grid gap-s">
-            <span className="txt-default">
-              {t('ProfilePage.Preferences.Language')}
-            </span>
-            <Select
-              value={locale}
-              onValueChange={onLocaleChange}>
-              <SelectTrigger aria-label={t('LocaleSwitcher.Label')}>
-                <SelectValue placeholder={t('LocaleSwitcher.Label')} />
-              </SelectTrigger>
-              <SelectContent>
-                {locales.map((loc) => (
-                  <SelectItem
-                    key={loc}
-                    value={loc}>
-                    {t(`LocaleSwitcher.${loc}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+        <div className="grid gap-s">
+          <span className="txt-default">
+            {t('ProfilePage.Preferences.Language')}
+          </span>
+          <Select
+            value={locale}
+            onValueChange={onLocaleChange}>
+            <SelectTrigger aria-label={t('LocaleSwitcher.Label')}>
+              <SelectValue placeholder={t('LocaleSwitcher.Label')} />
+            </SelectTrigger>
+            <SelectContent>
+              {availableLocales.map((loc) => (
+                <SelectItem
+                  key={loc}
+                  value={loc}>
+                  {t(`LocaleSwitcher.${loc}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Nothing to test on feature env because it's only available on production.

Local screenshot with production settings enabled (production label won't be displayed in production):

<img width="1706" height="726" alt="image" src="https://github.com/user-attachments/assets/e1067037-9f3e-4ab6-a492-9a0077f30ce1" />

## Related issues

- Related to #2981 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.