### PR TITLE
refactor(service-instance): improve performances by using data loaders (#2880)

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -27,6 +27,7 @@ import { documentDownloadEndpoint } from './modules/document/document-download-e
 import { DocumentDataLoader } from './modules/document/document.dataloader';
 import { documentVisualizeEndpoint } from './modules/document/visualize-document-endpoint';
 import { initAuthPlatform } from './modules/security-management/authentication/auth-platform';
+import { ServiceInstanceDataLoader } from './modules/service/instance/service-instance.dataloader';
 import { TelemetrySnapshotApp } from './modules/telemetry/telemetry-snapshot.app';
 import { errorLoggingPlugin } from './server/apollo-plugins/log';
 import {
@@ -340,7 +341,10 @@ const middlewareExpress = expressMiddleware(server, {
       user: user as UserLoadUserBy,
       req,
       res,
-      dataLoaders: DocumentDataLoader.create(),
+      dataLoaders: {
+        document: DocumentDataLoader.create(),
+        serviceInstance: ServiceInstanceDataLoader.create(),
+      },
     };
 
     return portalContext;

--- a/apps/backend/src/migrations/20260806103000_add_subscription_and_user_service_indexes.js
+++ b/apps/backend/src/migrations/20260806103000_add_subscription_and_user_service_indexes.js
@@ -1,0 +1,32 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_subscription_organization_service_instance
+    ON "Subscription" ("organization_id", "service_instance_id")
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_subscription_service_instance_id
+    ON "Subscription" ("service_instance_id")
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_user_service_subscription_user
+    ON "User_Service" ("subscription_id", "user_id")
+  `);
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.raw(`DROP INDEX IF EXISTS idx_user_service_subscription_user`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_subscription_service_instance_id`);
+  await knex.raw(
+    `DROP INDEX IF EXISTS idx_subscription_organization_service_instance`
+  );
+}

--- a/apps/backend/src/model/portal-context.ts
+++ b/apps/backend/src/model/portal-context.ts
@@ -1,12 +1,18 @@
 import express from 'express';
 
 import type { DocumentDataLoaders } from '../modules/document/document.dataloader';
+import type { ServiceInstanceDataLoaders } from '../modules/service/instance/service-instance.dataloader';
 import { UserLoadUserBy } from './user';
+
+export type PortalDataLoaders = {
+  document: DocumentDataLoaders;
+  serviceInstance: ServiceInstanceDataLoaders;
+};
 
 export interface PortalContext {
   user: UserLoadUserBy;
   referer?: string;
   req: express.Request;
   res: express.Response;
-  dataLoaders: DocumentDataLoaders;
+  dataLoaders: PortalDataLoaders;
 }

--- a/apps/backend/src/modules/document/document.dataloader.ts
+++ b/apps/backend/src/modules/document/document.dataloader.ts
@@ -12,6 +12,10 @@ import ServiceInstance, {
 import Subscription from '../../model/kanel/public/Subscription';
 import UseCase from '../../model/kanel/public/UseCase';
 import User, { UserId } from '../../model/kanel/public/User';
+import {
+  CompositeKey,
+  defineCompositeKey,
+} from '../../utils/dataloader-key.util';
 import { UserDomain } from '../organization-management/user/user-domain/user.domain';
 import { ServiceInstanceDomain } from '../service/instance/service-instance.domain';
 import { solutionCategoryDomain } from '../solution-category/solution-category.domain';
@@ -23,35 +27,19 @@ import { DocumentChildrenDomain } from './domain/document.children.domain';
 import { DocumentDomain } from './domain/document.domain';
 import { DocumentMetadataDomain } from './domain/document.metadata.domain';
 
-const SUBSCRIPTION_KEY_SEPARATOR = ':';
+interface SubscriptionByServiceInstanceFields extends Record<string, string> {
+  organizationId: OrganizationId;
+  serviceInstanceId: ServiceInstanceId;
+}
+
 type SubscriptionByServiceInstanceLoaderKey =
-  `${OrganizationId}:${ServiceInstanceId}`;
+  CompositeKey<SubscriptionByServiceInstanceFields>;
 
-export const createSubscriptionByServiceInstanceLoaderKey = ({
-  organizationId,
-  serviceInstanceId,
-}: {
-  organizationId: OrganizationId;
-  serviceInstanceId: ServiceInstanceId;
-}): SubscriptionByServiceInstanceLoaderKey =>
-  `${organizationId}${SUBSCRIPTION_KEY_SEPARATOR}${serviceInstanceId}`;
-
-const parseSubscriptionByServiceInstanceLoaderKey = (
-  key: SubscriptionByServiceInstanceLoaderKey
-): {
-  organizationId: OrganizationId;
-  serviceInstanceId: ServiceInstanceId;
-} => {
-  const separatorIndex = key.indexOf(SUBSCRIPTION_KEY_SEPARATOR);
-  if (separatorIndex <= 0 || separatorIndex >= key.length - 1) {
-    throw new Error(`Invalid subscription loader key: ${key}`);
-  }
-
-  const organizationId = key.slice(0, separatorIndex) as OrganizationId;
-  const serviceInstanceId = key.slice(separatorIndex + 1) as ServiceInstanceId;
-
-  return { organizationId, serviceInstanceId };
-};
+export const subscriptionByServiceInstanceLoaderKey =
+  defineCompositeKey<SubscriptionByServiceInstanceFields>([
+    'organizationId',
+    'serviceInstanceId',
+  ]);
 
 export interface DocumentDataLoaders {
   userLoader: DataLoader<string, User | null>;
@@ -209,7 +197,7 @@ export const DocumentDataLoader = {
   batchLoadSubscriptionsByServiceInstance: async (
     keys: readonly SubscriptionByServiceInstanceLoaderKey[]
   ): Promise<(Subscription | null)[]> => {
-    const parsedKeys = keys.map(parseSubscriptionByServiceInstanceLoaderKey);
+    const parsedKeys = keys.map(subscriptionByServiceInstanceLoaderKey.parse);
     const organizationIds = [
       ...new Set(parsedKeys.map(({ organizationId }) => organizationId)),
     ];
@@ -227,7 +215,7 @@ export const DocumentDataLoader = {
 
     const map = new Map<string, Subscription>(
       subscriptions.map((subscription) => [
-        createSubscriptionByServiceInstanceLoaderKey({
+        subscriptionByServiceInstanceLoaderKey.create({
           organizationId: subscription.organization_id,
           serviceInstanceId: subscription.service_instance_id,
         }),
@@ -236,7 +224,7 @@ export const DocumentDataLoader = {
     );
 
     return parsedKeys.map(({ organizationId, serviceInstanceId }) => {
-      const key = createSubscriptionByServiceInstanceLoaderKey({
+      const key = subscriptionByServiceInstanceLoaderKey.create({
         organizationId,
         serviceInstanceId,
       });

--- a/apps/backend/src/modules/document/document.resolver.test.ts
+++ b/apps/backend/src/modules/document/document.resolver.test.ts
@@ -290,7 +290,7 @@ describe('document.__resolveType', () => {
         type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
       } as unknown as DocumentModel;
       vi.spyOn(
-        contextSimpleUserFiligran2.dataLoaders.integrationTypeLoader,
+        contextSimpleUserFiligran2.dataLoaders.document.integrationTypeLoader,
         'load'
       ).mockResolvedValue(integrationType);
 
@@ -319,12 +319,12 @@ describe('document field resolvers', () => {
     const id = uuidv4() as DocumentId;
     const expected = [{ id: uuidv4() }];
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader,
+      contextSimpleUserFiligran2.dataLoaders.document.childrenDocumentsLoader,
       'load'
     ).mockResolvedValue(
       expected as unknown as Awaited<
         ReturnType<
-          typeof contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader.load
+          typeof contextSimpleUserFiligran2.dataLoaders.document.childrenDocumentsLoader.load
         >
       >
     );
@@ -339,7 +339,8 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.childrenDocumentsLoader.load
+      contextSimpleUserFiligran2.dataLoaders.document.childrenDocumentsLoader
+        .load
     ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
@@ -348,7 +349,8 @@ describe('document field resolvers', () => {
     const id = uuidv4() as DocumentId;
     const expected = [{ id: uuidv4(), name: 'Use Case A' }];
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader,
+      contextSimpleUserFiligran2.dataLoaders.document
+        .useCasesByDocumentIdLoader,
       'load'
     ).mockResolvedValue(expected as unknown as UseCase[]);
 
@@ -362,7 +364,8 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.useCasesByDocumentIdLoader.load
+      contextSimpleUserFiligran2.dataLoaders.document.useCasesByDocumentIdLoader
+        .load
     ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
@@ -371,7 +374,7 @@ describe('document field resolvers', () => {
     const id = uuidv4() as DocumentId;
     const expected = { id: uuidv4() } as unknown as User | null;
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders.uploaderLoader,
+      contextSimpleUserFiligran2.dataLoaders.document.uploaderLoader,
       'load'
     ).mockResolvedValue(expected);
 
@@ -385,7 +388,7 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.uploaderLoader.load
+      contextSimpleUserFiligran2.dataLoaders.document.uploaderLoader.load
     ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
@@ -394,7 +397,8 @@ describe('document field resolvers', () => {
     const id = uuidv4() as DocumentId;
     const expected = { id: uuidv4() } as unknown as Organization | null;
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader,
+      contextSimpleUserFiligran2.dataLoaders.document
+        .uploaderOrganizationLoader,
       'load'
     ).mockResolvedValue(expected);
 
@@ -408,7 +412,8 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.uploaderOrganizationLoader.load
+      contextSimpleUserFiligran2.dataLoaders.document.uploaderOrganizationLoader
+        .load
     ).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
@@ -418,7 +423,7 @@ describe('document field resolvers', () => {
     const expected = { id: serviceInstanceId } as unknown as
       ServiceInstance | undefined;
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders.serviceInstanceByIdLoader,
+      contextSimpleUserFiligran2.dataLoaders.document.serviceInstanceByIdLoader,
       'load'
     ).mockResolvedValue(expected as ServiceInstance | undefined);
 
@@ -432,7 +437,8 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.serviceInstanceByIdLoader.load
+      contextSimpleUserFiligran2.dataLoaders.document.serviceInstanceByIdLoader
+        .load
     ).toHaveBeenCalledWith(serviceInstanceId);
     expect(result).toEqual(expected);
   });
@@ -441,7 +447,7 @@ describe('document field resolvers', () => {
     const serviceInstanceId = SERVICES.INSTANCES.CUSTOM_DASHBOARDS.ID;
     const expected = { id: uuidv4() } as unknown as SubscriptionModel;
     vi.spyOn(
-      contextSimpleUserFiligran2.dataLoaders
+      contextSimpleUserFiligran2.dataLoaders.document
         .subscriptionByServiceInstanceLoader,
       'load'
     ).mockResolvedValue(expected);
@@ -456,8 +462,8 @@ describe('document field resolvers', () => {
     );
 
     expect(
-      contextSimpleUserFiligran2.dataLoaders.subscriptionByServiceInstanceLoader
-        .load
+      contextSimpleUserFiligran2.dataLoaders.document
+        .subscriptionByServiceInstanceLoader.load
     ).toHaveBeenCalledWith(
       createSubscriptionByServiceInstanceLoaderKey({
         organizationId:

--- a/apps/backend/src/modules/document/document.resolver.test.ts
+++ b/apps/backend/src/modules/document/document.resolver.test.ts
@@ -31,7 +31,7 @@ import { OPENAEV_SCENARIO_DOCUMENT_TYPE } from '../shareable-resource/openaev/sc
 import { OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE } from '../shareable-resource/opencti/custom-dashboard/custom-dashboard.model';
 import { OPENCTI_INTEGRATION_DOCUMENT_TYPE } from '../shareable-resource/opencti/integration/integration.model';
 import { DocumentApp } from './document.app';
-import { createSubscriptionByServiceInstanceLoaderKey } from './document.dataloader';
+import { subscriptionByServiceInstanceLoaderKey } from './document.dataloader';
 import { DocumentHelper } from './document.helper';
 import documentResolver from './document.resolver';
 import { DocumentDomain } from './domain/document.domain';
@@ -465,7 +465,7 @@ describe('document field resolvers', () => {
       contextSimpleUserFiligran2.dataLoaders.document
         .subscriptionByServiceInstanceLoader.load
     ).toHaveBeenCalledWith(
-      createSubscriptionByServiceInstanceLoaderKey({
+      subscriptionByServiceInstanceLoaderKey.create({
         organizationId:
           contextSimpleUserFiligran2.user.selected_organization_id,
         serviceInstanceId,

--- a/apps/backend/src/modules/document/document.resolver.ts
+++ b/apps/backend/src/modules/document/document.resolver.ts
@@ -23,7 +23,7 @@ import { OPENCTI_PLAYBOOK_DOCUMENT_TYPE } from '../shareable-resource/opencti/pl
 import { TelemetryApp } from '../telemetry/telemetry.app';
 import { TelemetryHelper } from '../telemetry/telemetry.helper';
 import { DocumentApp } from './document.app';
-import { createSubscriptionByServiceInstanceLoaderKey } from './document.dataloader';
+import { subscriptionByServiceInstanceLoaderKey } from './document.dataloader';
 import { DocumentHelper } from './document.helper';
 import { DocumentDomain } from './domain/document.domain';
 
@@ -196,7 +196,7 @@ const resolvers: Resolvers = {
       if (!service_instance_id) return null;
       const subscription =
         await context.dataLoaders.document.subscriptionByServiceInstanceLoader.load(
-          createSubscriptionByServiceInstanceLoaderKey({
+          subscriptionByServiceInstanceLoaderKey.create({
             organizationId: context.user.selected_organization_id,
             serviceInstanceId: service_instance_id,
           })

--- a/apps/backend/src/modules/document/document.resolver.ts
+++ b/apps/backend/src/modules/document/document.resolver.ts
@@ -155,7 +155,9 @@ const resolvers: Resolvers = {
         return mappedType;
       } else if (document.type === OPENCTI_INTEGRATION_DOCUMENT_TYPE) {
         const integrationType =
-          await context.dataLoaders.integrationTypeLoader.load(document.id);
+          await context.dataLoaders.document.integrationTypeLoader.load(
+            document.id
+          );
         if (integrationType) {
           const responseType =
             INTEGRATION_MAPPINGS[
@@ -173,19 +175,19 @@ const resolvers: Resolvers = {
     },
 
     children_documents: async ({ id }, _, context) =>
-      (await context.dataLoaders.childrenDocumentsLoader.load(
+      (await context.dataLoaders.document.childrenDocumentsLoader.load(
         id
       )) as ShareableResource[],
     use_cases: ({ id }, _, context) =>
-      context.dataLoaders.useCasesByDocumentIdLoader.load(id),
+      context.dataLoaders.document.useCasesByDocumentIdLoader.load(id),
     uploader: ({ id }, _, context) =>
-      context.dataLoaders.uploaderLoader.load(id),
+      context.dataLoaders.document.uploaderLoader.load(id),
     uploader_organization: ({ id }, _, context) =>
-      context.dataLoaders.uploaderOrganizationLoader.load(id),
+      context.dataLoaders.document.uploaderOrganizationLoader.load(id),
     service_instance: async ({ service_instance_id }, _, context) => {
       if (!service_instance_id) return null;
       const serviceInstance =
-        await context.dataLoaders.serviceInstanceByIdLoader.load(
+        await context.dataLoaders.document.serviceInstanceByIdLoader.load(
           service_instance_id
         );
       return serviceInstance as unknown as ServiceInstanceModel;
@@ -193,7 +195,7 @@ const resolvers: Resolvers = {
     subscription: async ({ service_instance_id }, _, context) => {
       if (!service_instance_id) return null;
       const subscription =
-        await context.dataLoaders.subscriptionByServiceInstanceLoader.load(
+        await context.dataLoaders.document.subscriptionByServiceInstanceLoader.load(
           createSubscriptionByServiceInstanceLoaderKey({
             organizationId: context.user.selected_organization_id,
             serviceInstanceId: service_instance_id,
@@ -209,7 +211,7 @@ const resolvers: Resolvers = {
         deployedById: string | null;
       };
       return deployedById
-        ? context.dataLoaders.userLoader.load(deployedById)
+        ? context.dataLoaders.document.userLoader.load(deployedById)
         : null;
     },
   },

--- a/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.test.ts
+++ b/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.test.ts
@@ -138,4 +138,29 @@ describe('loadCapabilitiesByKeys', () => {
 
     expect(results).toEqual([[], ['MANAGE_ACCESS']]);
   });
+
+  it('should not match a key built from the cross product of the requested keys', async () => {
+    const results = await UserServiceCapabilityHelper.loadCapabilitiesByKeys([
+      {
+        serviceInstanceId: SERVICES.INSTANCES.VAULT.ID,
+        userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      },
+      {
+        serviceInstanceId: SERVICES.INSTANCES.VAULT.ID,
+        userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      },
+    ]);
+
+    expect(results).toEqual([[], []]);
+  });
+
+  it('should return an empty array when no key is provided', async () => {
+    const results = await UserServiceCapabilityHelper.loadCapabilitiesByKeys(
+      []
+    );
+
+    expect(results).toEqual([]);
+  });
 });

--- a/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.test.ts
+++ b/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.test.ts
@@ -81,3 +81,61 @@ describe('insertUserServiceCapability', () => {
     );
   });
 });
+
+describe('loadCapabilitiesByKeys', () => {
+  let subscriptionId: SubscriptionId | undefined;
+  let userServiceId: UserServiceId | undefined;
+
+  beforeEach(async () => {
+    const subscription = await TestHelper.subscription.create({
+      organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      service_instance_id: SERVICES.INSTANCES.VAULT.ID,
+      start_date: new Date(),
+    });
+    subscriptionId = subscription.id;
+
+    const userService = await TestHelper.user_Service.create({
+      user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+      subscription_id: subscriptionId,
+    });
+    userServiceId = userService?.id;
+
+    await TestHelper.user_ServiceCapability.create({
+      id: uuidv4() as UserServiceCapabilityId,
+      user_service_id: userServiceId,
+      generic_service_capability_id:
+        GenericServiceCapabilityIds.ManageAccessId as GenericServiceCapabilityId,
+      subscription_capability_id: null,
+    });
+  });
+
+  afterEach(async () => {
+    if (userServiceId) {
+      await TestHelper.user_ServiceCapability.delete({
+        user_service_id: userServiceId,
+      });
+      await TestHelper.user_Service.delete({ id: userServiceId });
+    }
+
+    if (subscriptionId) {
+      await TestHelper.subscription.delete({ id: subscriptionId });
+    }
+  });
+
+  it('should return capabilities matching each key and default to an empty array for missing keys, preserving input order', async () => {
+    const results = await UserServiceCapabilityHelper.loadCapabilitiesByKeys([
+      {
+        serviceInstanceId: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+        userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      },
+      {
+        serviceInstanceId: SERVICES.INSTANCES.VAULT.ID,
+        userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      },
+    ]);
+
+    expect(results).toEqual([[], ['MANAGE_ACCESS']]);
+  });
+});

--- a/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.ts
+++ b/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.ts
@@ -15,7 +15,9 @@ import UserServiceCapability, {
   UserServiceCapabilityId,
   UserServiceCapabilityInitializer,
 } from '../../../model/kanel/public/UserServiceCapability';
+import { buildTupleFilter } from '../../../utils/batch-query.util';
 import { ErrorCode, UnknownErrorCode } from '../../../utils/error/error.code';
+import { serviceInstanceUserOrganizationKey } from '../../service/instance/service-instance.keys';
 import { GenericServiceCapabilityHelper } from '../service-capability/generic-service-capability.helper';
 import { ServiceCapabilityDomain } from '../service-capability/service-capability.domain';
 import { SubscriptionCapabilityDomain } from '../subscription-capability/subscription-capability.domain';
@@ -125,13 +127,21 @@ export const UserServiceCapabilityHelper = {
       organizationId: OrganizationId;
     }[]
   ): Promise<string[][]> => {
-    const serviceInstanceIds = [
-      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
-    ];
-    const organizationIds = [
-      ...new Set(keys.map(({ organizationId }) => organizationId)),
-    ];
-    const userIds = [...new Set(keys.map(({ userId }) => userId))];
+    const { columns, tuples } = buildTupleFilter(keys, [
+      {
+        column: 'Subscription.service_instance_id',
+        value: (key) => key.serviceInstanceId,
+      },
+      {
+        column: 'Subscription.organization_id',
+        value: (key) => key.organizationId,
+      },
+      { column: 'User_Service.user_id', value: (key) => key.userId },
+    ]);
+
+    if (tuples.length === 0) {
+      return [];
+    }
 
     const rows: {
       service_instance_id: ServiceInstanceId;
@@ -139,15 +149,13 @@ export const UserServiceCapabilityHelper = {
       user_id: UserId;
       capability: string | null;
     }[] = await db<Subscription>('Subscription')
-      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
-      .whereIn('Subscription.organization_id', organizationIds)
       .join(
         'User_Service',
         'User_Service.subscription_id',
         '=',
         'Subscription.id'
       )
-      .whereIn('User_Service.user_id', userIds)
+      .whereIn(columns, tuples)
       .leftJoin(
         'UserService_Capability',
         'UserService_Capability.user_service_id',
@@ -186,7 +194,11 @@ export const UserServiceCapabilityHelper = {
       if (!row.capability) {
         continue;
       }
-      const key = `${row.service_instance_id}:${row.user_id}:${row.organization_id}`;
+      const key = serviceInstanceUserOrganizationKey.create({
+        serviceInstanceId: row.service_instance_id,
+        userId: row.user_id,
+        organizationId: row.organization_id,
+      });
       const capabilities = map.get(key) ?? [];
       capabilities.push(row.capability);
       map.set(key, capabilities);
@@ -194,7 +206,13 @@ export const UserServiceCapabilityHelper = {
 
     return keys.map(
       ({ serviceInstanceId, userId, organizationId }) =>
-        map.get(`${serviceInstanceId}:${userId}:${organizationId}`) ?? []
+        map.get(
+          serviceInstanceUserOrganizationKey.create({
+            serviceInstanceId,
+            userId,
+            organizationId,
+          })
+        ) ?? []
     );
   },
 

--- a/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.ts
+++ b/apps/backend/src/modules/security-management/user-service-capability/user-service-capability.helper.ts
@@ -118,21 +118,36 @@ export const UserServiceCapabilityHelper = {
       .returning('*');
   },
 
-  loadCapabilities: async (
-    serviceInstanceId: ServiceInstanceId,
-    userId: UserId,
-    orgaId: OrganizationId
-  ) => {
-    const [subscriptionWithCapabilities] = await db<Subscription>(
-      'Subscription'
-    )
-      .where('Subscription.service_instance_id', '=', serviceInstanceId)
-      .where('Subscription.organization_id', '=', orgaId)
-      .leftJoin('User_Service', function () {
-        this.on('User_Service.subscription_id', '=', 'Subscription.id')
+  loadCapabilitiesByKeys: async (
+    keys: readonly {
+      serviceInstanceId: ServiceInstanceId;
+      userId: UserId;
+      organizationId: OrganizationId;
+    }[]
+  ): Promise<string[][]> => {
+    const serviceInstanceIds = [
+      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
+    ];
+    const organizationIds = [
+      ...new Set(keys.map(({ organizationId }) => organizationId)),
+    ];
+    const userIds = [...new Set(keys.map(({ userId }) => userId))];
 
-          .andOnVal('User_Service.user_id', '=', userId);
-      })
+    const rows: {
+      service_instance_id: ServiceInstanceId;
+      organization_id: OrganizationId;
+      user_id: UserId;
+      capability: string | null;
+    }[] = await db<Subscription>('Subscription')
+      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
+      .whereIn('Subscription.organization_id', organizationIds)
+      .join(
+        'User_Service',
+        'User_Service.subscription_id',
+        '=',
+        'Subscription.id'
+      )
+      .whereIn('User_Service.user_id', userIds)
       .leftJoin(
         'UserService_Capability',
         'UserService_Capability.user_service_id',
@@ -158,14 +173,40 @@ export const UserServiceCapabilityHelper = {
         'Generic_Service_Capability.id'
       )
       .select(
+        'Subscription.service_instance_id',
+        'Subscription.organization_id',
+        'User_Service.user_id',
         dbRaw(
-          `COALESCE(
-          json_agg(
-            COALESCE("Generic_Service_Capability".name, "Service_Capability".name)
-          ), '[]'::json
-        ) AS capabilities`
+          `COALESCE("Generic_Service_Capability".name, "Service_Capability".name) AS capability`
         )
       );
-    return subscriptionWithCapabilities.capabilities;
+
+    const map = new Map<string, string[]>();
+    for (const row of rows) {
+      if (!row.capability) {
+        continue;
+      }
+      const key = `${row.service_instance_id}:${row.user_id}:${row.organization_id}`;
+      const capabilities = map.get(key) ?? [];
+      capabilities.push(row.capability);
+      map.set(key, capabilities);
+    }
+
+    return keys.map(
+      ({ serviceInstanceId, userId, organizationId }) =>
+        map.get(`${serviceInstanceId}:${userId}:${organizationId}`) ?? []
+    );
+  },
+
+  loadCapabilities: async (
+    serviceInstanceId: ServiceInstanceId,
+    userId: UserId,
+    orgaId: OrganizationId
+  ) => {
+    const [capabilities] =
+      await UserServiceCapabilityHelper.loadCapabilitiesByKeys([
+        { serviceInstanceId, userId, organizationId: orgaId },
+      ]);
+    return capabilities;
   },
 };

--- a/apps/backend/src/modules/service/instance/service-instance.app.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.app.test.ts
@@ -51,7 +51,7 @@ import { ServiceInstanceDomain } from './service-instance.domain';
 describe('service Instance app', () => {
   describe('loadServiceInstance', () => {
     let loadSubscriptionBySpy: MockInstance;
-    let loadUserServiceBySpy: MockInstance;
+    let doesUserServiceExistSpy: MockInstance;
     let loadServiceInstanceBySpy: MockInstance;
     let grantServiceAccessSpy: MockInstance;
 
@@ -68,13 +68,6 @@ describe('service Instance app', () => {
       end_date: null,
     };
 
-    const mockUserService = {
-      id: uuidv4(),
-      user_id: mockUserId,
-      subscription_id: mockSubscriptionId,
-      service_capability_id: GenericServiceCapabilityIds.AccessId,
-    };
-
     const mockServiceInstance = {
       id: mockServiceInstanceId,
       name: 'Service instance 1',
@@ -89,7 +82,10 @@ describe('service Instance app', () => {
         SubscriptionDomain,
         'loadSubscriptionBy'
       );
-      loadUserServiceBySpy = vi.spyOn(UserServiceDomain, 'loadUserServiceBy');
+      doesUserServiceExistSpy = vi.spyOn(
+        UserServiceDomain,
+        'doesUserServiceExist'
+      );
       loadServiceInstanceBySpy = vi.spyOn(
         ServiceInstanceDomain,
         'loadServiceInstanceBy'
@@ -104,7 +100,7 @@ describe('service Instance app', () => {
       // Given
       requestContext.set(requestContextSimpleUserSecondOrga);
       loadSubscriptionBySpy.mockResolvedValueOnce(mockSubscription);
-      loadUserServiceBySpy.mockResolvedValueOnce([mockUserService]);
+      doesUserServiceExistSpy.mockResolvedValueOnce(true);
       loadServiceInstanceBySpy.mockResolvedValueOnce(mockServiceInstance);
 
       // When
@@ -118,10 +114,10 @@ describe('service Instance app', () => {
         organization_id:
           contextSimpleUserSecondOrga.user.selected_organization_id,
       });
-      expect(loadUserServiceBySpy).toHaveBeenCalledWith({
-        subscription_id: mockSubscriptionId,
-        user_id: mockUserId,
-      });
+      expect(doesUserServiceExistSpy).toHaveBeenCalledWith(
+        mockUserId,
+        mockSubscriptionId
+      );
       expect(loadServiceInstanceBySpy).toHaveBeenCalledWith({
         id: mockServiceInstanceId,
       });
@@ -132,7 +128,7 @@ describe('service Instance app', () => {
       // Given
       requestContext.set(requestContextSimpleUserSecondOrga);
       loadSubscriptionBySpy.mockResolvedValue(mockSubscription);
-      loadUserServiceBySpy.mockResolvedValue([]);
+      doesUserServiceExistSpy.mockResolvedValue(false);
       loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
       grantServiceAccessSpy.mockResolvedValue(undefined);
 
@@ -143,8 +139,8 @@ describe('service Instance app', () => {
 
       // Then
       expect(grantServiceAccessSpy).toHaveBeenCalledWith(
-        [GenericServiceCapabilityIds.AccessId],
-        [mockUserId],
+        GenericServiceCapabilityIds.AccessId,
+        mockUserId,
         mockSubscriptionId
       );
     });
@@ -184,7 +180,7 @@ describe('service Instance app', () => {
         return Promise.resolve(otherOrgSubscription);
       });
 
-      loadUserServiceBySpy.mockResolvedValue([]);
+      doesUserServiceExistSpy.mockResolvedValue(false);
       loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
       grantServiceAccessSpy.mockResolvedValue(undefined);
 
@@ -200,8 +196,8 @@ describe('service Instance app', () => {
       });
 
       expect(grantServiceAccessSpy).toHaveBeenCalledWith(
-        [GenericServiceCapabilityIds.AccessId],
-        [mockUserId],
+        GenericServiceCapabilityIds.AccessId,
+        mockUserId,
         userOrgSubscriptionId
       );
       expect(loadServiceInstanceBySpy).toHaveBeenCalledBefore(
@@ -209,19 +205,11 @@ describe('service Instance app', () => {
       );
     });
 
-    it('should handle multiple user services', async () => {
+    it('should not grant access again when the user service already exists', async () => {
       // Given
       requestContext.set(requestContextSimpleUserSecondOrga);
-      const multipleUserServices = [
-        mockUserService,
-        {
-          ...mockUserService,
-          id: uuidv4(),
-          service_capability_id: uuidv4(),
-        },
-      ];
       loadSubscriptionBySpy.mockResolvedValue(mockSubscription);
-      loadUserServiceBySpy.mockResolvedValue(multipleUserServices);
+      doesUserServiceExistSpy.mockResolvedValue(true);
       loadServiceInstanceBySpy.mockResolvedValue(mockServiceInstance);
 
       // When
@@ -248,7 +236,7 @@ describe('service Instance app', () => {
       ).rejects.toThrow('Error');
 
       // Then
-      expect(loadUserServiceBySpy).not.toHaveBeenCalled();
+      expect(doesUserServiceExistSpy).not.toHaveBeenCalled();
       expect(grantServiceAccessSpy).not.toHaveBeenCalled();
     });
 
@@ -258,7 +246,7 @@ describe('service Instance app', () => {
       loadServiceInstanceBySpy.mockResolvedValueOnce(mockServiceInstance);
       const error = new Error('Other error');
       loadSubscriptionBySpy.mockResolvedValue(mockSubscription);
-      loadUserServiceBySpy.mockResolvedValue([]);
+      doesUserServiceExistSpy.mockResolvedValue(false);
       grantServiceAccessSpy.mockRejectedValue(error);
 
       // When

--- a/apps/backend/src/modules/service/instance/service-instance.app.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.app.ts
@@ -31,16 +31,17 @@ export const ServiceInstanceApp = {
   ): Promise<ServiceInstance> => {
     const user = requestContext.requireUser();
 
-    const service = await ServiceInstanceDomain.loadServiceInstanceBy({
-      id: serviceInstanceId,
-    });
+    const [service, existingSubscription] = await Promise.all([
+      ServiceInstanceDomain.loadServiceInstanceBy({ id: serviceInstanceId }),
+      SubscriptionDomain.loadSubscriptionBy({
+        service_instance_id: serviceInstanceId,
+        organization_id: user.selected_organization_id,
+      }),
+    ]);
     if (!service) {
       throw new Error(ErrorCode.ServiceInstanceNotFound);
     }
-    let subscription = await SubscriptionDomain.loadSubscriptionBy({
-      service_instance_id: serviceInstanceId,
-      organization_id: user.selected_organization_id,
-    });
+    let subscription = existingSubscription;
 
     if (!subscription) {
       const [createdSubscription] =
@@ -56,14 +57,14 @@ export const ServiceInstanceApp = {
       }
       subscription = createdSubscription;
     }
-    const userService = await UserServiceDomain.loadUserServiceBy({
-      subscription_id: subscription.id,
-      user_id: user.id,
-    });
-    if (userService.length === 0) {
+    const userService = await UserServiceDomain.doesUserServiceExist(
+      user.id,
+      subscription.id
+    );
+    if (!userService) {
       await ServiceInstanceDomain.grantServiceAccess(
-        [GenericServiceCapabilityIds.AccessId],
-        [user.id],
+        GenericServiceCapabilityIds.AccessId,
+        user.id,
         subscription.id
       );
     }

--- a/apps/backend/src/modules/service/instance/service-instance.dataloader.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.dataloader.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { TestHelper } from '../../../../tests/helper/test.helper';
+import {
+  // eslint-disable-next-line no-restricted-imports
+  requestContextAdminUser,
+  requestContextSimpleUserSecondOrga,
+  SERVICES,
+  TEST_ORGANIZATIONS,
+} from '../../../../tests/tests.const';
+import { requestContext } from '../../../context/request.context';
+import { ServiceInstanceDataLoader } from './service-instance.dataloader';
+import { organizationServiceInstanceKey } from './service-instance.keys';
+
+describe('batchLoadSubscriptions', () => {
+  afterEach(async () => {
+    await TestHelper.subscription.delete({});
+  });
+
+  const secondOrganizationKey = organizationServiceInstanceKey.create({
+    organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+    serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+  });
+
+  const createSubscriptions = async () => {
+    await TestHelper.subscription.create({
+      organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+    });
+    await TestHelper.subscription.create({
+      organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+      service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+    });
+  };
+
+  it('should return every organization subscription for a platform admin', async () => {
+    // Given
+    await createSubscriptions();
+    requestContext.set(requestContextAdminUser);
+
+    // When
+    const [subscriptions] =
+      await ServiceInstanceDataLoader.batchLoadSubscriptions([
+        secondOrganizationKey,
+      ]);
+
+    // Then
+    expect(subscriptions).toHaveLength(2);
+    expect(
+      subscriptions?.map((subscription) => subscription.organization_id).sort()
+    ).toEqual(
+      [
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        TEST_ORGANIZATIONS.FILIGRAN.ID,
+      ].sort()
+    );
+  });
+
+  it('should only return the subscriptions of the organization carried by the key for a regular user', async () => {
+    // Given
+    await createSubscriptions();
+    requestContext.set(requestContextSimpleUserSecondOrga);
+
+    // When
+    const [subscriptions] =
+      await ServiceInstanceDataLoader.batchLoadSubscriptions([
+        secondOrganizationKey,
+      ]);
+
+    // Then
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions?.[0]).toMatchObject({
+      organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+      service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+    });
+  });
+
+  it('should return an empty array when the key targets an organization without subscription', async () => {
+    // Given
+    await createSubscriptions();
+    requestContext.set(requestContextSimpleUserSecondOrga);
+
+    // When
+    const [subscriptions] =
+      await ServiceInstanceDataLoader.batchLoadSubscriptions([
+        organizationServiceInstanceKey.create({
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          serviceInstanceId: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+        }),
+      ]);
+
+    // Then
+    expect(subscriptions).toEqual([]);
+  });
+});

--- a/apps/backend/src/modules/service/instance/service-instance.dataloader.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.dataloader.ts
@@ -1,0 +1,201 @@
+import DataLoader from 'dataloader';
+import {
+  ServiceDefinition,
+  ServiceLink,
+  SubscriptionModel,
+} from '../../../__generated__/resolvers-types';
+import { OrganizationId } from '../../../model/kanel/public/Organization';
+import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
+import { UserId } from '../../../model/kanel/public/User';
+import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
+import { ServiceInstanceDomain } from './service-instance.domain';
+
+const KEY_SEPARATOR = ':';
+
+// `organization_subscribed` and `subscriptions` share the same key shape.
+type OrganizationServiceInstanceKey =
+  `${OrganizationId}${typeof KEY_SEPARATOR}${ServiceInstanceId}`;
+
+export const createOrganizationServiceInstanceKey = ({
+  organizationId,
+  serviceInstanceId,
+}: {
+  organizationId: OrganizationId;
+  serviceInstanceId: ServiceInstanceId;
+}): OrganizationServiceInstanceKey =>
+  `${organizationId}${KEY_SEPARATOR}${serviceInstanceId}`;
+
+const parseOrganizationServiceInstanceKey = (
+  key: OrganizationServiceInstanceKey
+): { organizationId: OrganizationId; serviceInstanceId: ServiceInstanceId } => {
+  const [organizationId, serviceInstanceId] = key.split(KEY_SEPARATOR) as [
+    OrganizationId,
+    ServiceInstanceId,
+  ];
+  return { organizationId, serviceInstanceId };
+};
+
+// `capabilities` and `user_joined` share the same key shape.
+type ServiceInstanceUserOrganizationKey =
+  `${ServiceInstanceId}${typeof KEY_SEPARATOR}${UserId}${typeof KEY_SEPARATOR}${OrganizationId}`;
+
+export const createServiceInstanceUserOrganizationKey = ({
+  serviceInstanceId,
+  userId,
+  organizationId,
+}: {
+  serviceInstanceId: ServiceInstanceId;
+  userId: UserId;
+  organizationId: OrganizationId;
+}): ServiceInstanceUserOrganizationKey =>
+  `${serviceInstanceId}${KEY_SEPARATOR}${userId}${KEY_SEPARATOR}${organizationId}`;
+
+const parseServiceInstanceUserOrganizationKey = (
+  key: ServiceInstanceUserOrganizationKey
+): {
+  serviceInstanceId: ServiceInstanceId;
+  userId: UserId;
+  organizationId: OrganizationId;
+} => {
+  const [serviceInstanceId, userId, organizationId] = key.split(
+    KEY_SEPARATOR
+  ) as [ServiceInstanceId, UserId, OrganizationId];
+  return { serviceInstanceId, userId, organizationId };
+};
+
+export interface ServiceInstanceDataLoaders {
+  linksByServiceInstanceLoader: DataLoader<ServiceInstanceId, ServiceLink[]>;
+  serviceDefinitionByServiceInstanceLoader: DataLoader<
+    ServiceInstanceId,
+    ServiceDefinition | undefined
+  >;
+  organizationSubscribedLoader: DataLoader<
+    OrganizationServiceInstanceKey,
+    boolean
+  >;
+  capabilitiesLoader: DataLoader<ServiceInstanceUserOrganizationKey, string[]>;
+  userJoinedLoader: DataLoader<ServiceInstanceUserOrganizationKey, boolean>;
+  subscriptionsByServiceInstanceLoader: DataLoader<
+    OrganizationServiceInstanceKey,
+    SubscriptionModel[]
+  >;
+}
+
+export const ServiceInstanceDataLoader = {
+  batchLoadLinks: async (
+    ids: readonly ServiceInstanceId[]
+  ): Promise<ServiceLink[][]> => {
+    const rows = await ServiceInstanceDomain.loadLinksByServiceInstanceIds(ids);
+
+    const map = new Map<string, ServiceLink[]>();
+    for (const row of rows) {
+      const serviceInstanceId = row.service_instance_id as ServiceInstanceId;
+      const existing = map.get(serviceInstanceId) ?? [];
+      existing.push(row);
+      map.set(serviceInstanceId, existing);
+    }
+    return ids.map((id) => map.get(id) ?? []);
+  },
+
+  batchLoadServiceDefinitions: async (
+    ids: readonly ServiceInstanceId[]
+  ): Promise<(ServiceDefinition | undefined)[]> => {
+    const rows =
+      await ServiceInstanceDomain.loadServiceDefinitionsByServiceInstanceIds(
+        ids
+      );
+
+    const map = new Map<string, ServiceDefinition>(
+      rows.map((row) => [row.service_instance_id, row])
+    );
+    return ids.map((id) => map.get(id));
+  },
+
+  batchLoadOrganizationSubscribed: async (
+    keys: readonly OrganizationServiceInstanceKey[]
+  ): Promise<boolean[]> => {
+    const parsedKeys = keys.map(parseOrganizationServiceInstanceKey);
+    const rows = await ServiceInstanceDomain.loadIsSubscribedByKeys(parsedKeys);
+
+    const subscribedKeys = new Set(
+      rows.map((row) =>
+        createOrganizationServiceInstanceKey({
+          organizationId: row.organization_id,
+          serviceInstanceId: row.service_instance_id,
+        })
+      )
+    );
+    return keys.map((key) => subscribedKeys.has(key));
+  },
+
+  batchLoadCapabilities: async (
+    keys: readonly ServiceInstanceUserOrganizationKey[]
+  ): Promise<string[][]> => {
+    const parsedKeys = keys.map(parseServiceInstanceUserOrganizationKey);
+    return UserServiceCapabilityHelper.loadCapabilitiesByKeys(parsedKeys);
+  },
+
+  batchLoadUserJoined: async (
+    keys: readonly ServiceInstanceUserOrganizationKey[]
+  ): Promise<boolean[]> => {
+    const parsedKeys = keys.map(parseServiceInstanceUserOrganizationKey);
+    const rows =
+      await ServiceInstanceDomain.loadJoinedUserServiceKeys(parsedKeys);
+
+    const joinedKeys = new Set(
+      rows.map((row) =>
+        createServiceInstanceUserOrganizationKey({
+          serviceInstanceId: row.service_instance_id,
+          userId: row.user_id,
+          organizationId: row.organization_id,
+        })
+      )
+    );
+    return keys.map((key) => joinedKeys.has(key));
+  },
+
+  batchLoadSubscriptions: async (
+    keys: readonly OrganizationServiceInstanceKey[]
+  ): Promise<SubscriptionModel[][]> => {
+    const parsedKeys = keys.map(parseOrganizationServiceInstanceKey);
+    const serviceInstanceIds = [
+      ...new Set(parsedKeys.map(({ serviceInstanceId }) => serviceInstanceId)),
+    ];
+    const rows =
+      await ServiceInstanceDomain.loadServiceInstanceSubscriptionsByIds(
+        serviceInstanceIds
+      );
+
+    const map = new Map<string, SubscriptionModel[]>();
+    for (const row of rows) {
+      const existing = map.get(row.service_instance_id) ?? [];
+      existing.push(row as unknown as SubscriptionModel);
+      map.set(row.service_instance_id, existing);
+    }
+
+    return parsedKeys.map(
+      ({ serviceInstanceId }) => map.get(serviceInstanceId) ?? []
+    );
+  },
+
+  create: (): ServiceInstanceDataLoaders => ({
+    linksByServiceInstanceLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadLinks
+    ),
+    serviceDefinitionByServiceInstanceLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadServiceDefinitions
+    ),
+    organizationSubscribedLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadOrganizationSubscribed
+    ),
+    capabilitiesLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadCapabilities
+    ),
+    userJoinedLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadUserJoined
+    ),
+    subscriptionsByServiceInstanceLoader: new DataLoader(
+      ServiceInstanceDataLoader.batchLoadSubscriptions
+    ),
+  }),
+};

--- a/apps/backend/src/modules/service/instance/service-instance.dataloader.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.dataloader.ts
@@ -4,64 +4,17 @@ import {
   ServiceLink,
   SubscriptionModel,
 } from '../../../__generated__/resolvers-types';
-import { OrganizationId } from '../../../model/kanel/public/Organization';
+import { requestContext } from '../../../context/request.context';
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
-import { UserId } from '../../../model/kanel/public/User';
+import { isUserAdminPlatform } from '../../../security/access';
 import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
 import { ServiceInstanceDomain } from './service-instance.domain';
-
-const KEY_SEPARATOR = ':';
-
-// `organization_subscribed` and `subscriptions` share the same key shape.
-type OrganizationServiceInstanceKey =
-  `${OrganizationId}${typeof KEY_SEPARATOR}${ServiceInstanceId}`;
-
-export const createOrganizationServiceInstanceKey = ({
-  organizationId,
-  serviceInstanceId,
-}: {
-  organizationId: OrganizationId;
-  serviceInstanceId: ServiceInstanceId;
-}): OrganizationServiceInstanceKey =>
-  `${organizationId}${KEY_SEPARATOR}${serviceInstanceId}`;
-
-const parseOrganizationServiceInstanceKey = (
-  key: OrganizationServiceInstanceKey
-): { organizationId: OrganizationId; serviceInstanceId: ServiceInstanceId } => {
-  const [organizationId, serviceInstanceId] = key.split(KEY_SEPARATOR) as [
-    OrganizationId,
-    ServiceInstanceId,
-  ];
-  return { organizationId, serviceInstanceId };
-};
-
-// `capabilities` and `user_joined` share the same key shape.
-type ServiceInstanceUserOrganizationKey =
-  `${ServiceInstanceId}${typeof KEY_SEPARATOR}${UserId}${typeof KEY_SEPARATOR}${OrganizationId}`;
-
-export const createServiceInstanceUserOrganizationKey = ({
-  serviceInstanceId,
-  userId,
-  organizationId,
-}: {
-  serviceInstanceId: ServiceInstanceId;
-  userId: UserId;
-  organizationId: OrganizationId;
-}): ServiceInstanceUserOrganizationKey =>
-  `${serviceInstanceId}${KEY_SEPARATOR}${userId}${KEY_SEPARATOR}${organizationId}`;
-
-const parseServiceInstanceUserOrganizationKey = (
-  key: ServiceInstanceUserOrganizationKey
-): {
-  serviceInstanceId: ServiceInstanceId;
-  userId: UserId;
-  organizationId: OrganizationId;
-} => {
-  const [serviceInstanceId, userId, organizationId] = key.split(
-    KEY_SEPARATOR
-  ) as [ServiceInstanceId, UserId, OrganizationId];
-  return { serviceInstanceId, userId, organizationId };
-};
+import {
+  OrganizationServiceInstanceKey,
+  organizationServiceInstanceKey,
+  ServiceInstanceUserOrganizationKey,
+  serviceInstanceUserOrganizationKey,
+} from './service-instance.keys';
 
 export interface ServiceInstanceDataLoaders {
   linksByServiceInstanceLoader: DataLoader<ServiceInstanceId, ServiceLink[]>;
@@ -114,12 +67,12 @@ export const ServiceInstanceDataLoader = {
   batchLoadOrganizationSubscribed: async (
     keys: readonly OrganizationServiceInstanceKey[]
   ): Promise<boolean[]> => {
-    const parsedKeys = keys.map(parseOrganizationServiceInstanceKey);
+    const parsedKeys = keys.map(organizationServiceInstanceKey.parse);
     const rows = await ServiceInstanceDomain.loadIsSubscribedByKeys(parsedKeys);
 
     const subscribedKeys = new Set(
       rows.map((row) =>
-        createOrganizationServiceInstanceKey({
+        organizationServiceInstanceKey.create({
           organizationId: row.organization_id,
           serviceInstanceId: row.service_instance_id,
         })
@@ -131,20 +84,20 @@ export const ServiceInstanceDataLoader = {
   batchLoadCapabilities: async (
     keys: readonly ServiceInstanceUserOrganizationKey[]
   ): Promise<string[][]> => {
-    const parsedKeys = keys.map(parseServiceInstanceUserOrganizationKey);
+    const parsedKeys = keys.map(serviceInstanceUserOrganizationKey.parse);
     return UserServiceCapabilityHelper.loadCapabilitiesByKeys(parsedKeys);
   },
 
   batchLoadUserJoined: async (
     keys: readonly ServiceInstanceUserOrganizationKey[]
   ): Promise<boolean[]> => {
-    const parsedKeys = keys.map(parseServiceInstanceUserOrganizationKey);
+    const parsedKeys = keys.map(serviceInstanceUserOrganizationKey.parse);
     const rows =
       await ServiceInstanceDomain.loadJoinedUserServiceKeys(parsedKeys);
 
     const joinedKeys = new Set(
       rows.map((row) =>
-        createServiceInstanceUserOrganizationKey({
+        serviceInstanceUserOrganizationKey.create({
           serviceInstanceId: row.service_instance_id,
           userId: row.user_id,
           organizationId: row.organization_id,
@@ -157,7 +110,7 @@ export const ServiceInstanceDataLoader = {
   batchLoadSubscriptions: async (
     keys: readonly OrganizationServiceInstanceKey[]
   ): Promise<SubscriptionModel[][]> => {
-    const parsedKeys = keys.map(parseOrganizationServiceInstanceKey);
+    const parsedKeys = keys.map(organizationServiceInstanceKey.parse);
     const serviceInstanceIds = [
       ...new Set(parsedKeys.map(({ serviceInstanceId }) => serviceInstanceId)),
     ];
@@ -166,16 +119,34 @@ export const ServiceInstanceDataLoader = {
         serviceInstanceIds
       );
 
+    // A platform admin is allowed to see every organization subscribed to a
+    // service instance, so the `organizationId` part of the key is not a filter
+    // for them and rows are grouped by service instance only. Every other user
+    // only gets the subscriptions of the organization carried by the key.
+    const isAdmin = isUserAdminPlatform(requestContext.requireUser());
+
     const map = new Map<string, SubscriptionModel[]>();
     for (const row of rows) {
-      const existing = map.get(row.service_instance_id) ?? [];
+      const groupKey = isAdmin
+        ? row.service_instance_id
+        : organizationServiceInstanceKey.create({
+            organizationId: row.organization_id,
+            serviceInstanceId: row.service_instance_id,
+          });
+      const existing = map.get(groupKey) ?? [];
       existing.push(row as unknown as SubscriptionModel);
-      map.set(row.service_instance_id, existing);
+      map.set(groupKey, existing);
     }
 
-    return parsedKeys.map(
-      ({ serviceInstanceId }) => map.get(serviceInstanceId) ?? []
-    );
+    return parsedKeys.map(({ organizationId, serviceInstanceId }) => {
+      const groupKey = isAdmin
+        ? serviceInstanceId
+        : organizationServiceInstanceKey.create({
+            organizationId,
+            serviceInstanceId,
+          });
+      return map.get(groupKey) ?? [];
+    });
   },
 
   create: (): ServiceInstanceDataLoaders => ({

--- a/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
@@ -527,8 +527,8 @@ describe('service instance domain', () => {
     it('should create user_service linked to the correct subscription', async () => {
       // When
       const result = await grantServiceAccess(
-        [GenericServiceCapabilityIds.AccessId],
-        [TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID],
+        GenericServiceCapabilityIds.AccessId,
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
         secondOrgaSubscriptionId
       );
 
@@ -552,8 +552,8 @@ describe('service instance domain', () => {
     it('should not link user_service to a different organization subscription', async () => {
       // When
       const result = await grantServiceAccess(
-        [GenericServiceCapabilityIds.AccessId],
-        [TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID],
+        GenericServiceCapabilityIds.AccessId,
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
         secondOrgaSubscriptionId
       );
 
@@ -574,8 +574,8 @@ describe('service instance domain', () => {
       const sendMailSpy = vi.spyOn(mailService, 'sendMail').mockResolvedValue();
       // When
       await grantServiceAccess(
-        [GenericServiceCapabilityIds.AccessId],
-        [TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID],
+        GenericServiceCapabilityIds.AccessId,
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
         secondOrgaSubscriptionId
       );
 
@@ -607,8 +607,8 @@ describe('service instance domain', () => {
 
       // When
       await grantServiceAccess(
-        [GenericServiceCapabilityIds.AccessId],
-        [TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID],
+        GenericServiceCapabilityIds.AccessId,
+        TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
         subscription!.id
       );
       // Then

--- a/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
@@ -662,6 +662,9 @@ describe('service instance domain', () => {
       await TestHelper.user_Service.delete({
         user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
       });
+      await TestHelper.user_Service.delete({
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+      });
     });
 
     it('should only return keys for which the user actually joined the service', async () => {
@@ -697,6 +700,52 @@ describe('service instance domain', () => {
         service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
       });
     });
+
+    it('should not match a key built from the cross product of the requested keys', async () => {
+      // Given
+      const integrationsSubscription = await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+      await TestHelper.user_Service.create({
+        user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        subscription_id: integrationsSubscription!.id,
+      });
+
+      const scenariosSubscription = await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+      });
+      await TestHelper.user_Service.create({
+        user_id: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+        subscription_id: scenariosSubscription!.id,
+      });
+
+      // When
+      const result = await loadJoinedUserServiceKeys([
+        {
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          serviceInstanceId: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+        },
+        {
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+      ]);
+
+      // Then
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when no key is provided', async () => {
+      // When
+      const result = await loadJoinedUserServiceKeys([]);
+
+      // Then
+      expect(result).toEqual([]);
+    });
   });
 
   describe('loadIsSubscribedByKeys', () => {
@@ -725,6 +774,33 @@ describe('service instance domain', () => {
         organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
         service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
       });
+    });
+
+    it('should not match a key built from the cross product of the requested keys', async () => {
+      // Given
+      await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+      await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+      });
+
+      // When
+      const result = await loadIsSubscribedByKeys([
+        {
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          serviceInstanceId: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+        },
+        {
+          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+      ]);
+
+      // Then
+      expect(result).toEqual([]);
     });
 
     it('should return an empty array when no organization or service instance ids are provided', async () => {

--- a/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.test.ts
@@ -40,9 +40,14 @@ const {
   getUserJoined,
   grantServiceAccess,
   loadLinks,
+  loadLinksByServiceInstanceIds,
+  loadIsSubscribedByKeys,
+  loadJoinedUserServiceKeys,
   loadPlatformConfigurationByServiceInstanceId,
   loadPlatformServiceInstance,
+  loadServiceDefinitionsByServiceInstanceIds,
   loadServiceInstanceSubscriptions,
+  loadServiceInstanceSubscriptionsByIds,
   loadServiceInstancesByIds,
   loadSubscribedServiceInstancesByIdentifier,
   loadSubscriptionByServiceInstanceAndOrganization,
@@ -166,6 +171,46 @@ describe('service instance domain', () => {
       const links = await loadLinks(generateId);
       // Then
       expect(links).toHaveLength(0);
+    });
+  });
+
+  describe('loadLinksByServiceInstanceIds', () => {
+    it('should return one row per link tagged with its service instance id and nothing for instances without links', async () => {
+      // When
+      const results = await loadLinksByServiceInstanceIds([
+        SERVICES.INSTANCES.EPIC.ID,
+        SERVICES.INSTANCES.VAULT.ID,
+      ]);
+
+      // Then
+      const epicLinks = results.filter(
+        (link) => link.service_instance_id === SERVICES.INSTANCES.EPIC.ID
+      );
+      const vaultLinks = results.filter(
+        (link) => link.service_instance_id === SERVICES.INSTANCES.VAULT.ID
+      );
+      expect(epicLinks).toHaveLength(0);
+      expect(vaultLinks).toHaveLength(1);
+      expect(vaultLinks[0]?.service_instance_id).toBe(
+        SERVICES.INSTANCES.VAULT.ID
+      );
+    });
+  });
+
+  describe('loadServiceDefinitionsByServiceInstanceIds', () => {
+    it('should return one row per requested service instance id, tagged accordingly', async () => {
+      // When
+      const results = await loadServiceDefinitionsByServiceInstanceIds([
+        SERVICES.INSTANCES.VAULT.ID,
+        SERVICES.INSTANCES.EPIC.ID,
+      ]);
+
+      // Then
+      expect(results).toHaveLength(2);
+      const vaultRow = results.find(
+        (row) => row.service_instance_id === SERVICES.INSTANCES.VAULT.ID
+      );
+      expect(vaultRow?.id).toBe(SERVICES.DEFINITIONS.VAULT.ID);
     });
   });
 
@@ -609,6 +654,121 @@ describe('service instance domain', () => {
 
       // Then
       expect(result).toBe(false);
+    });
+  });
+
+  describe('loadJoinedUserServiceKeys', () => {
+    afterAll(async () => {
+      await TestHelper.user_Service.delete({
+        user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+      });
+    });
+
+    it('should only return keys for which the user actually joined the service', async () => {
+      // Given
+      const subscription = await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+      await TestHelper.user_Service.create({
+        user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        subscription_id: subscription!.id,
+      });
+
+      // When
+      const result = await loadJoinedUserServiceKeys([
+        {
+          userId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+        {
+          userId: TEST_ORGANIZATIONS.FILIGRAN.USERS.SIMPLE.ID,
+          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+      ]);
+
+      // Then
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        user_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.SIMPLE.ID,
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+    });
+  });
+
+  describe('loadIsSubscribedByKeys', () => {
+    it('should only return keys with an actual subscription', async () => {
+      // Given
+      await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+
+      // When
+      const result = await loadIsSubscribedByKeys([
+        {
+          organizationId: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+        {
+          organizationId: TEST_ORGANIZATIONS.FILIGRAN.ID,
+          serviceInstanceId: SERVICES.INSTANCES.INTEGRATIONS.ID,
+        },
+      ]);
+
+      // Then
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        organization_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+    });
+
+    it('should return an empty array when no organization or service instance ids are provided', async () => {
+      // When
+      const result = await loadIsSubscribedByKeys([]);
+
+      // Then
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('loadServiceInstanceSubscriptionsByIds', () => {
+    it('should group subscriptions per requested service instance id', async () => {
+      // Given
+      await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.INTEGRATIONS.ID,
+      });
+      await TestHelper.subscription.create({
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+      });
+
+      requestContext.set(requestContextAdminUser);
+
+      // When
+      const result = await loadServiceInstanceSubscriptionsByIds([
+        SERVICES.INSTANCES.INTEGRATIONS.ID,
+        SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID,
+      ]);
+
+      // Then
+      const integrationSubscriptions = result.filter(
+        (subscription) =>
+          subscription.service_instance_id ===
+          SERVICES.INSTANCES.INTEGRATIONS.ID
+      );
+      const scenarioSubscriptions = result.filter(
+        (subscription) =>
+          subscription.service_instance_id ===
+          SERVICES.INSTANCES.OPENAEV_SCENARIOS.ID
+      );
+      expect(integrationSubscriptions).toHaveLength(1);
+      expect(scenarioSubscriptions).toHaveLength(1);
     });
   });
 

--- a/apps/backend/src/modules/service/instance/service-instance.domain.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.ts
@@ -27,9 +27,8 @@ import ServiceInstance, {
 } from '../../../model/kanel/public/ServiceInstance';
 import Subscription, {
   SubscriptionId,
-  SubscriptionMutator,
 } from '../../../model/kanel/public/Subscription';
-import { UserId, UserMutator } from '../../../model/kanel/public/User';
+import { UserId } from '../../../model/kanel/public/User';
 import { UserServiceId } from '../../../model/kanel/public/UserService';
 import { UserServiceCapabilityId } from '../../../model/kanel/public/UserServiceCapability';
 import { isUserAdminPlatform } from '../../../security/access';
@@ -395,27 +394,23 @@ export const ServiceInstanceDomain = {
   },
 
   grantServiceAccess: async (
-    capabilitiesIds: string[],
-    usersId: UserId[],
+    capabilityId: string,
+    userId: UserId,
     subscriptionId: SubscriptionId
   ) => {
-    const dataUserServices = usersId.map((userId) => ({
+    const dataUserService = {
       id: uuidv4() as UserServiceId,
       user_id: userId,
       subscription_id: subscriptionId,
-    }));
-    const insertedUserServices =
-      await UserServiceDomain.insertUserService(dataUserServices);
+    };
+    const [insertedUserService] =
+      await UserServiceDomain.insertUserService(dataUserService);
+    if (!insertedUserService) {
+      throw new Error(UnknownErrorCode.AddUserServiceError);
+    }
 
-    const [subscription] =
-      await SubscriptionDomain.loadSubscriptionWithOrganizationAndCapabilitiesBy(
-        {
-          'Subscription.id': subscriptionId,
-        } as SubscriptionMutator
-      );
-    const serviceInstance = await ServiceInstanceDomain.loadServiceInstanceBy({
-      id: subscription.service_instance_id,
-    });
+    const serviceInstance =
+      await loadServiceInstanceBySubscriptionId(subscriptionId);
     if (!serviceInstance) {
       throw new Error(NotFoundErrorCode.ServiceInstanceNotFound);
     }
@@ -428,49 +423,21 @@ export const ServiceInstanceDomain = {
       throw new Error(NotFoundErrorCode.ServiceDefinitionNotFound);
     }
 
-    for (const userId of usersId) {
-      const user = await UserDomain.loadUserBy({
-        'User.id': userId,
-      } as UserMutator);
+    await notifyUserServiceAccessGranted(
+      userId,
+      serviceInstance,
+      service_definition.identifier
+    );
 
-      if (!user) {
-        logApp.warn(`User ${userId} not found, skipping mail notification`);
-        continue;
-      }
-
-      const mailTemplate = ServiceIdentifierToMailTemplate.get(
-        service_definition.identifier
-      );
-      if (mailTemplate) {
-        await sendMail({
-          to: user.email,
-          template: mailTemplate,
-          params: {
-            name: user.email,
-            serviceLink: buildServiceLink({
-              serviceDefinitionIdentifier: service_definition.identifier,
-              serviceInstanceId: serviceInstance.id,
-            }),
-            serviceName: serviceInstance.name,
-          },
-        });
-      }
-    }
-
-    for (const capabilityId of capabilitiesIds) {
-      const dataServiceCapabilities = insertedUserServices.map(
-        (insertedUserService) => ({
-          id: uuidv4() as UserServiceCapabilityId,
-          user_service_id: insertedUserService.id,
-          generic_service_capability_id:
-            capabilityId as GenericServiceCapabilityId,
-        })
-      );
-      await ServiceCapabilityHelper.insertServiceCapability(
-        dataServiceCapabilities
-      );
-    }
-    return insertedUserServices;
+    await ServiceCapabilityHelper.insertServiceCapability([
+      {
+        id: uuidv4() as UserServiceCapabilityId,
+        user_service_id: insertedUserService.id,
+        generic_service_capability_id:
+          capabilityId as GenericServiceCapabilityId,
+      },
+    ]);
+    return [insertedUserService];
   },
 
   loadLinksByServiceInstanceIds: async (
@@ -685,4 +652,56 @@ export const ServiceInstanceDomain = {
       .delete('*');
     return deletedServiceInstance;
   },
+};
+
+const loadServiceInstanceBySubscriptionId = async (
+  subscriptionId: SubscriptionId
+): Promise<ServiceInstance | undefined> => {
+  const subscription = await SubscriptionDomain.loadSubscriptionBy({
+    id: subscriptionId,
+  });
+  if (!subscription) {
+    return undefined;
+  }
+  return ServiceInstanceDomain.loadServiceInstanceBy({
+    id: subscription.service_instance_id,
+  });
+};
+
+const notifyUserServiceAccessGranted = async (
+  userId: UserId,
+  serviceInstance: ServiceInstance,
+  serviceDefinitionIdentifier: ServiceDefinitionIdentifier
+): Promise<void> => {
+  const mailTemplate = ServiceIdentifierToMailTemplate.get(
+    serviceDefinitionIdentifier
+  );
+  if (!mailTemplate) {
+    return;
+  }
+
+  const [user] = await UserDomain.loadUser({ id: userId });
+  if (!user) {
+    logApp.warn(`User ${userId} not found, skipping mail notification`);
+    return;
+  }
+
+  const serviceLink = buildServiceLink({
+    serviceDefinitionIdentifier,
+    serviceInstanceId: serviceInstance.id,
+  });
+
+  // Mails are best effort: a slow or failing SMTP/queue must never delay or fail
+  // the access grant, so they are dispatched without awaiting the send.
+  sendMail({
+    to: user.email,
+    template: mailTemplate,
+    params: {
+      name: user.email,
+      serviceLink,
+      serviceName: serviceInstance.name,
+    },
+  }).catch((error) => {
+    logApp.error('Failed to send service access granted mail', { error });
+  });
 };

--- a/apps/backend/src/modules/service/instance/service-instance.domain.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.ts
@@ -12,7 +12,9 @@ import {
 } from '../../../__generated__/resolvers-types';
 import { requestContext } from '../../../context/request.context';
 import { GenericServiceCapabilityId } from '../../../model/kanel/public/GenericServiceCapability';
-import { OrganizationId } from '../../../model/kanel/public/Organization';
+import Organization, {
+  OrganizationId,
+} from '../../../model/kanel/public/Organization';
 import {
   default as PlatformConfigurationModel,
   PlatformConfigurationMutator,
@@ -34,6 +36,7 @@ import { isUserAdminPlatform } from '../../../security/access';
 import { buildServiceLink, sendMail } from '../../../server/mail-service';
 import { ServiceIdentifierToMailTemplate } from '../../../server/mail-template/mail';
 import { logApp } from '../../../utils/app-logger.util';
+import { buildTupleFilter } from '../../../utils/batch-query.util';
 import {
   NotFoundErrorCode,
   UnknownErrorCode,
@@ -209,20 +212,23 @@ export const ServiceInstanceDomain = {
   ): Promise<
     Pick<Subscription, 'organization_id' | 'service_instance_id'>[]
   > => {
-    const organizationIds = [
-      ...new Set(keys.map(({ organizationId }) => organizationId)),
-    ];
-    const serviceInstanceIds = [
-      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
-    ];
+    const { columns, tuples } = buildTupleFilter(keys, [
+      {
+        column: 'Subscription.organization_id',
+        value: (key) => key.organizationId,
+      },
+      {
+        column: 'Subscription.service_instance_id',
+        value: (key) => key.serviceInstanceId,
+      },
+    ]);
 
-    if (organizationIds.length === 0 || serviceInstanceIds.length === 0) {
+    if (tuples.length === 0) {
       return [];
     }
 
     return db<Subscription>('Subscription')
-      .whereIn('Subscription.organization_id', organizationIds)
-      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
+      .whereIn(columns, tuples)
       .select(
         'Subscription.organization_id',
         'Subscription.service_instance_id'
@@ -241,7 +247,7 @@ export const ServiceInstanceDomain = {
 
   loadServiceInstanceSubscriptionsByIds: async (
     ids: readonly ServiceInstanceId[]
-  ) => {
+  ): Promise<(Subscription & { organization: Organization | null })[]> => {
     if (ids.length === 0) {
       return [];
     }
@@ -318,32 +324,30 @@ export const ServiceInstanceDomain = {
       user_id: UserId;
     }[]
   > => {
-    const userIds = [...new Set(keys.map(({ userId }) => userId))];
-    const organizationIds = [
-      ...new Set(keys.map(({ organizationId }) => organizationId)),
-    ];
-    const serviceInstanceIds = [
-      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
-    ];
+    const { columns, tuples } = buildTupleFilter(keys, [
+      {
+        column: 'Subscription.service_instance_id',
+        value: (key) => key.serviceInstanceId,
+      },
+      {
+        column: 'Subscription.organization_id',
+        value: (key) => key.organizationId,
+      },
+      { column: 'User_Service.user_id', value: (key) => key.userId },
+    ]);
 
-    if (
-      userIds.length === 0 ||
-      organizationIds.length === 0 ||
-      serviceInstanceIds.length === 0
-    ) {
+    if (tuples.length === 0) {
       return [];
     }
 
     return db<Subscription>('Subscription')
-      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
-      .whereIn('Subscription.organization_id', organizationIds)
       .join(
         'User_Service',
         'User_Service.subscription_id',
         '=',
         'Subscription.id'
       )
-      .whereIn('User_Service.user_id', userIds)
+      .whereIn(columns, tuples)
       .select(
         'Subscription.service_instance_id',
         'Subscription.organization_id',

--- a/apps/backend/src/modules/service/instance/service-instance.domain.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.ts
@@ -201,31 +201,32 @@ export const ServiceInstanceDomain = {
     }));
   },
 
-  loadIsSubscribed: async (
-    organizationId: OrganizationId,
-    id: ServiceInstanceId
-  ) => {
-    const serviceInstance = await db<{
-      organization_subscribed: boolean;
-    }>('ServiceInstance')
-      .where('ServiceInstance.id', '=', id)
-      .leftJoin('Subscription as subscription', function () {
-        this.on(
-          'subscription.service_instance_id',
-          '=',
-          'ServiceInstance.id'
-        ).andOnVal('subscription.organization_id', '=', organizationId);
-      })
+  loadIsSubscribedByKeys: async (
+    keys: readonly {
+      organizationId: OrganizationId;
+      serviceInstanceId: ServiceInstanceId;
+    }[]
+  ): Promise<
+    Pick<Subscription, 'organization_id' | 'service_instance_id'>[]
+  > => {
+    const organizationIds = [
+      ...new Set(keys.map(({ organizationId }) => organizationId)),
+    ];
+    const serviceInstanceIds = [
+      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
+    ];
+
+    if (organizationIds.length === 0 || serviceInstanceIds.length === 0) {
+      return [];
+    }
+
+    return db<Subscription>('Subscription')
+      .whereIn('Subscription.organization_id', organizationIds)
+      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
       .select(
-        dbRaw(`
-          CASE
-            WHEN "subscription"."id" IS NOT NULL THEN true
-            ELSE false
-          END AS organization_subscribed
-          `)
-      )
-      .first();
-    return serviceInstance?.organization_subscribed ?? false;
+        'Subscription.organization_id',
+        'Subscription.service_instance_id'
+      );
   },
 
   loadServiceInstances: async (opts: QueryOpts) => {
@@ -238,11 +239,17 @@ export const ServiceInstanceDomain = {
     });
   },
 
-  loadServiceInstanceSubscriptions: async (id: ServiceInstanceId) => {
+  loadServiceInstanceSubscriptionsByIds: async (
+    ids: readonly ServiceInstanceId[]
+  ) => {
+    if (ids.length === 0) {
+      return [];
+    }
+
     const user = requestContext.requireUser();
 
     const queryBuilder = db<Subscription>('Subscription')
-      .where('Subscription.service_instance_id', '=', id)
+      .whereIn('Subscription.service_instance_id', ids)
       .leftJoin(
         'Organization',
         'Organization.id',
@@ -267,6 +274,10 @@ export const ServiceInstanceDomain = {
         })
       ),
     ]);
+  },
+
+  loadServiceInstanceSubscriptions: async (id: ServiceInstanceId) => {
+    return ServiceInstanceDomain.loadServiceInstanceSubscriptionsByIds([id]);
   },
 
   loadSubscriptionByServiceInstanceAndOrganization: async (
@@ -294,30 +305,61 @@ export const ServiceInstanceDomain = {
       .first();
   },
 
+  loadJoinedUserServiceKeys: async (
+    keys: readonly {
+      userId: UserId;
+      organizationId: OrganizationId;
+      serviceInstanceId: ServiceInstanceId;
+    }[]
+  ): Promise<
+    {
+      service_instance_id: ServiceInstanceId;
+      organization_id: OrganizationId;
+      user_id: UserId;
+    }[]
+  > => {
+    const userIds = [...new Set(keys.map(({ userId }) => userId))];
+    const organizationIds = [
+      ...new Set(keys.map(({ organizationId }) => organizationId)),
+    ];
+    const serviceInstanceIds = [
+      ...new Set(keys.map(({ serviceInstanceId }) => serviceInstanceId)),
+    ];
+
+    if (
+      userIds.length === 0 ||
+      organizationIds.length === 0 ||
+      serviceInstanceIds.length === 0
+    ) {
+      return [];
+    }
+
+    return db<Subscription>('Subscription')
+      .whereIn('Subscription.service_instance_id', serviceInstanceIds)
+      .whereIn('Subscription.organization_id', organizationIds)
+      .join(
+        'User_Service',
+        'User_Service.subscription_id',
+        '=',
+        'Subscription.id'
+      )
+      .whereIn('User_Service.user_id', userIds)
+      .select(
+        'Subscription.service_instance_id',
+        'Subscription.organization_id',
+        'User_Service.user_id'
+      );
+  },
+
   getUserJoined: async (
     userId: UserId,
     organizationId: OrganizationId,
     id: ServiceInstanceId
   ) => {
-    const result = await db<{ user_joined: boolean }>('ServiceInstance')
-      .where('ServiceInstance.id', '=', id)
-      .leftJoin(
-        'Subscription',
-        'ServiceInstance.id',
-        'Subscription.service_instance_id'
-      )
-      .leftJoin('User_Service', function () {
-        this.on('Subscription.id', 'User_Service.subscription_id').andOnVal(
-          'User_Service.user_id',
-          '=',
-          userId
-        );
-      })
-      .select(dbRaw(`"User_Service".id IS NOT NULL AS user_joined`))
-      .where('Subscription.organization_id', '=', organizationId)
-      .first();
-
-    return result?.user_joined === true;
+    const joined = await ServiceInstanceDomain.loadJoinedUserServiceKeys([
+      { userId, organizationId, serviceInstanceId: id },
+    ]);
+    return joined.length > 0;
   },
 
   loadServiceInstanceBy: async (
@@ -427,25 +469,50 @@ export const ServiceInstanceDomain = {
     return insertedUserServices;
   },
 
-  loadLinks: (id: ServiceInstanceId) => {
-    return db<ServiceLink[]>('Service_Link')
-      .where('Service_Link.service_instance_id', '=', id)
-      .select('*');
+  loadLinksByServiceInstanceIds: async (
+    ids: readonly ServiceInstanceId[]
+  ): Promise<ServiceLink[]> => {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    return db<ServiceLink>('Service_Link')
+      .whereIn('Service_Link.service_instance_id', ids)
+      .select(['*']);
   },
 
-  loadServiceDefinitionByServiceInstance: async (
-    service_instance_id: ServiceInstanceId
-  ): Promise<ServiceDefinition | undefined> => {
+  loadLinks: async (id: ServiceInstanceId) => {
+    return ServiceInstanceDomain.loadLinksByServiceInstanceIds([id]);
+  },
+
+  loadServiceDefinitionsByServiceInstanceIds: async (
+    ids: readonly ServiceInstanceId[]
+  ): Promise<
+    (ServiceDefinition & { service_instance_id: ServiceInstanceId })[]
+  > => {
+    if (ids.length === 0) {
+      return [];
+    }
+
     return db<ServiceDefinition>('ServiceInstance')
-      .where('ServiceInstance.id', '=', service_instance_id)
+      .whereIn('ServiceInstance.id', ids)
       .leftJoin(
         'ServiceDefinition as service_def',
         'service_def.id',
         '=',
         'ServiceInstance.service_definition_id'
       )
-      .select('service_def.*')
-      .first();
+      .select('service_def.*', 'ServiceInstance.id as service_instance_id');
+  },
+
+  loadServiceDefinitionByServiceInstance: async (
+    service_instance_id: ServiceInstanceId
+  ): Promise<ServiceDefinition | undefined> => {
+    const [serviceDefinition] =
+      await ServiceInstanceDomain.loadServiceDefinitionsByServiceInstanceIds([
+        service_instance_id,
+      ]);
+    return serviceDefinition;
   },
 
   loadSeoServiceInstances: async (): Promise<SeoServiceInstance[]> => {
@@ -525,12 +592,6 @@ export const ServiceInstanceDomain = {
       )
       .where('ServiceInstance.slug', '=', slug)
       .groupBy('ServiceInstance.id', 'ServiceDefinition.id')
-      .first();
-  },
-
-  getServiceInstance: async (id: ServiceInstanceId) => {
-    return db<ServiceInstance>('ServiceInstance')
-      .where('ServiceInstance.id', '=', id)
       .first();
   },
 

--- a/apps/backend/src/modules/service/instance/service-instance.domain.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.domain.ts
@@ -691,17 +691,17 @@ const notifyUserServiceAccessGranted = async (
     serviceInstanceId: serviceInstance.id,
   });
 
-  // Mails are best effort: a slow or failing SMTP/queue must never delay or fail
-  // the access grant, so they are dispatched without awaiting the send.
-  sendMail({
-    to: user.email,
-    template: mailTemplate,
-    params: {
-      name: user.email,
-      serviceLink,
-      serviceName: serviceInstance.name,
-    },
-  }).catch((error) => {
+  try {
+    await sendMail({
+      to: user.email,
+      template: mailTemplate,
+      params: {
+        name: user.email,
+        serviceLink,
+        serviceName: serviceInstance.name,
+      },
+    });
+  } catch (error) {
     logApp.error('Failed to send service access granted mail', { error });
-  });
+  }
 };

--- a/apps/backend/src/modules/service/instance/service-instance.keys.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.keys.ts
@@ -1,0 +1,39 @@
+import { OrganizationId } from '../../../model/kanel/public/Organization';
+import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
+import { UserId } from '../../../model/kanel/public/User';
+import {
+  CompositeKey,
+  defineCompositeKey,
+} from '../../../utils/dataloader-key.util';
+
+// `organization_subscribed` and `subscriptions` share the same key shape.
+interface OrganizationServiceInstanceFields extends Record<string, string> {
+  organizationId: OrganizationId;
+  serviceInstanceId: ServiceInstanceId;
+}
+
+export type OrganizationServiceInstanceKey =
+  CompositeKey<OrganizationServiceInstanceFields>;
+
+export const organizationServiceInstanceKey =
+  defineCompositeKey<OrganizationServiceInstanceFields>([
+    'organizationId',
+    'serviceInstanceId',
+  ]);
+
+// `capabilities` and `user_joined` share the same key shape.
+interface ServiceInstanceUserOrganizationFields extends Record<string, string> {
+  serviceInstanceId: ServiceInstanceId;
+  userId: UserId;
+  organizationId: OrganizationId;
+}
+
+export type ServiceInstanceUserOrganizationKey =
+  CompositeKey<ServiceInstanceUserOrganizationFields>;
+
+export const serviceInstanceUserOrganizationKey =
+  defineCompositeKey<ServiceInstanceUserOrganizationFields>([
+    'serviceInstanceId',
+    'userId',
+    'organizationId',
+  ]);

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
@@ -16,9 +16,9 @@ import { ErrorCode } from '../../../utils/error/error.code';
 import { ErrorType } from '../../../utils/error/error.type';
 import { ServiceInstanceApp } from './service-instance.app';
 import {
-  createOrganizationServiceInstanceKey,
-  createServiceInstanceUserOrganizationKey,
-} from './service-instance.dataloader';
+  organizationServiceInstanceKey,
+  serviceInstanceUserOrganizationKey,
+} from './service-instance.keys';
 import serviceInstanceResolver from './service-instance.resolver';
 
 describe('serviceInstance field resolvers', () => {
@@ -98,7 +98,7 @@ describe('serviceInstance field resolvers', () => {
     );
 
     expect(load).toHaveBeenCalledWith(
-      createOrganizationServiceInstanceKey({
+      organizationServiceInstanceKey.create({
         organizationId:
           contextSimpleUserFiligran2.user.selected_organization_id,
         serviceInstanceId: id,
@@ -128,7 +128,7 @@ describe('serviceInstance field resolvers', () => {
     );
 
     expect(load).toHaveBeenCalledWith(
-      createServiceInstanceUserOrganizationKey({
+      serviceInstanceUserOrganizationKey.create({
         serviceInstanceId: id,
         userId: contextSimpleUserFiligran2.user.id,
         organizationId:
@@ -157,7 +157,7 @@ describe('serviceInstance field resolvers', () => {
     );
 
     expect(load).toHaveBeenCalledWith(
-      createServiceInstanceUserOrganizationKey({
+      serviceInstanceUserOrganizationKey.create({
         serviceInstanceId: id,
         userId: contextSimpleUserFiligran2.user.id,
         organizationId:
@@ -188,7 +188,7 @@ describe('serviceInstance field resolvers', () => {
     );
 
     expect(load).toHaveBeenCalledWith(
-      createOrganizationServiceInstanceKey({
+      organizationServiceInstanceKey.create({
         organizationId:
           contextSimpleUserFiligran2.user.selected_organization_id,
         serviceInstanceId: id,

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
@@ -6,7 +6,6 @@ import {
   SERVICES,
 } from '../../../../tests/tests.const';
 import {
-  IntegrationType,
   MutationAddServicePictureArgs,
   MutationUpdatePlatformServiceMetadataArgs,
   ServiceInstance,
@@ -17,32 +16,9 @@ import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { ErrorType } from '../../../utils/error/error.type';
 import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
-import { OPENAEV_SCENARIO_DOCUMENT_TYPE } from '../../shareable-resource/openaev/scenario/scenario.model';
-import { OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE } from '../../shareable-resource/opencti/custom-dashboard/custom-dashboard.model';
-import { OPENCTI_INTEGRATION_DOCUMENT_TYPE } from '../../shareable-resource/opencti/integration/integration.model';
 import { ServiceInstanceApp } from './service-instance.app';
 import { ServiceInstanceDomain } from './service-instance.domain';
 import serviceInstanceResolver from './service-instance.resolver';
-
-describe('serviceInstance.__resolveType', () => {
-  it.each`
-    type                                      | integration_type             | expected
-    ${OPENAEV_SCENARIO_DOCUMENT_TYPE}         | ${undefined}                 | ${'OpenAEVScenario'}
-    ${OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE} | ${undefined}                 | ${'OpenCTICustomDashboard'}
-    ${OPENCTI_INTEGRATION_DOCUMENT_TYPE}      | ${IntegrationType.Connector} | ${'Connector'}
-    ${OPENCTI_INTEGRATION_DOCUMENT_TYPE}      | ${IntegrationType.CsvFeed}   | ${'CsvFeed'}
-    ${OPENCTI_INTEGRATION_DOCUMENT_TYPE}      | ${undefined}                 | ${'OpenCTIIntegration'}
-    ${'unknown_type'}                         | ${undefined}                 | ${'SeoServiceInstance'}
-  `(
-    'should resolve type=$type integration_type=$integration_type to $expected',
-    ({ type, integration_type, expected }) => {
-      const result = (
-        serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
-      ).__resolveType({ type, integration_type });
-      expect(result).toBe(expected);
-    }
-  );
-});
 
 describe('serviceInstance field resolvers', () => {
   it('links should load links by service instance id', async () => {

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.test.ts
@@ -12,21 +12,30 @@ import {
   ServiceInstanceResolvers,
   ServiceInstanceTag,
 } from '../../../__generated__/resolvers-types';
-import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { ErrorCode } from '../../../utils/error/error.code';
 import { ErrorType } from '../../../utils/error/error.type';
-import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
 import { ServiceInstanceApp } from './service-instance.app';
-import { ServiceInstanceDomain } from './service-instance.domain';
+import {
+  createOrganizationServiceInstanceKey,
+  createServiceInstanceUserOrganizationKey,
+} from './service-instance.dataloader';
 import serviceInstanceResolver from './service-instance.resolver';
 
 describe('serviceInstance field resolvers', () => {
-  it('links should load links by service instance id', async () => {
+  it('links should load links via linksByServiceInstanceLoader', async () => {
     const id = SERVICES.INSTANCES.EPIC.ID;
     const expected = [] as unknown as Awaited<
-      ReturnType<typeof ServiceInstanceDomain.loadLinks>
+      ReturnType<
+        (typeof contextSimpleUserFiligran2.dataLoaders.serviceInstance.linksByServiceInstanceLoader)['load']
+      >
     >;
-    vi.spyOn(ServiceInstanceDomain, 'loadLinks').mockResolvedValue(expected);
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance
+          .linksByServiceInstanceLoader,
+        'load'
+      )
+      .mockResolvedValue(expected);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -37,21 +46,24 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(ServiceInstanceDomain.loadLinks).toHaveBeenCalledWith(id);
+    expect(load).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
 
-  it('service_definition should load service definition by service instance id', async () => {
+  it('service_definition should load via serviceDefinitionByServiceInstanceLoader', async () => {
     const id = SERVICES.INSTANCES.EPIC.ID;
     const expected = { id: uuidv4() } as unknown as Awaited<
       ReturnType<
-        typeof ServiceInstanceDomain.loadServiceDefinitionByServiceInstance
+        (typeof contextSimpleUserFiligran2.dataLoaders.serviceInstance.serviceDefinitionByServiceInstanceLoader)['load']
       >
     >;
-    vi.spyOn(
-      ServiceInstanceDomain,
-      'loadServiceDefinitionByServiceInstance'
-    ).mockResolvedValue(expected);
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance
+          .serviceDefinitionByServiceInstanceLoader,
+        'load'
+      )
+      .mockResolvedValue(expected);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -62,12 +74,19 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
+    expect(load).toHaveBeenCalledWith(id);
     expect(result).toEqual(expected);
   });
 
-  it('organization_subscribed should call loadIsSubscribed with org id and instance id', async () => {
-    const id = SERVICES.INSTANCES.EPIC.ID as ServiceInstanceId;
-    vi.spyOn(ServiceInstanceDomain, 'loadIsSubscribed').mockResolvedValue(true);
+  it('organization_subscribed should load via organizationSubscribedLoader with composite key', async () => {
+    const id = SERVICES.INSTANCES.EPIC.ID;
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance
+          .organizationSubscribedLoader,
+        'load'
+      )
+      .mockResolvedValue(true);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -78,21 +97,26 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(ServiceInstanceDomain.loadIsSubscribed).toHaveBeenCalledWith(
-      contextSimpleUserFiligran2.user.selected_organization_id,
-      id
+    expect(load).toHaveBeenCalledWith(
+      createOrganizationServiceInstanceKey({
+        organizationId:
+          contextSimpleUserFiligran2.user.selected_organization_id,
+        serviceInstanceId: id,
+      })
     );
     expect(result).toBe(true);
   });
 
-  it('capabilities should load capabilities for user and instance', async () => {
+  it('capabilities should load via capabilitiesLoader with composite key', async () => {
     const id = SERVICES.INSTANCES.EPIC.ID;
-    const expected = [] as unknown as Awaited<
-      ReturnType<typeof UserServiceCapabilityHelper.loadCapabilities>
-    >;
-    vi.spyOn(UserServiceCapabilityHelper, 'loadCapabilities').mockResolvedValue(
-      expected
-    );
+    const expected: string[] = [];
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance
+          .capabilitiesLoader,
+        'load'
+      )
+      .mockResolvedValue(expected);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -103,17 +127,25 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(UserServiceCapabilityHelper.loadCapabilities).toHaveBeenCalledWith(
-      id,
-      contextSimpleUserFiligran2.user.id,
-      contextSimpleUserFiligran2.user.selected_organization_id
+    expect(load).toHaveBeenCalledWith(
+      createServiceInstanceUserOrganizationKey({
+        serviceInstanceId: id,
+        userId: contextSimpleUserFiligran2.user.id,
+        organizationId:
+          contextSimpleUserFiligran2.user.selected_organization_id,
+      })
     );
     expect(result).toEqual(expected);
   });
 
-  it('user_joined should call getUserJoined with user, org, and instance id', async () => {
-    const id = SERVICES.INSTANCES.EPIC.ID as ServiceInstanceId;
-    vi.spyOn(ServiceInstanceDomain, 'getUserJoined').mockResolvedValue(false);
+  it('user_joined should load via userJoinedLoader with composite key', async () => {
+    const id = SERVICES.INSTANCES.EPIC.ID;
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance.userJoinedLoader,
+        'load'
+      )
+      .mockResolvedValue(false);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -124,23 +156,27 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(ServiceInstanceDomain.getUserJoined).toHaveBeenCalledWith(
-      contextSimpleUserFiligran2.user.id,
-      contextSimpleUserFiligran2.user.selected_organization_id,
-      id
+    expect(load).toHaveBeenCalledWith(
+      createServiceInstanceUserOrganizationKey({
+        serviceInstanceId: id,
+        userId: contextSimpleUserFiligran2.user.id,
+        organizationId:
+          contextSimpleUserFiligran2.user.selected_organization_id,
+      })
     );
     expect(result).toBe(false);
   });
 
-  it('subscriptions should load subscriptions by service instance id', async () => {
-    const id = SERVICES.INSTANCES.EPIC.ID as ServiceInstanceId;
-    const expected = [] as unknown as Awaited<
-      ReturnType<typeof ServiceInstanceDomain.loadServiceInstanceSubscriptions>
-    >;
-    vi.spyOn(
-      ServiceInstanceDomain,
-      'loadServiceInstanceSubscriptions'
-    ).mockResolvedValue(expected);
+  it('subscriptions should load via subscriptionsByServiceInstanceLoader with composite key', async () => {
+    const id = SERVICES.INSTANCES.EPIC.ID;
+    const expected: [] = [];
+    const load = vi
+      .spyOn(
+        contextSimpleUserFiligran2.dataLoaders.serviceInstance
+          .subscriptionsByServiceInstanceLoader,
+        'load'
+      )
+      .mockResolvedValue(expected);
 
     const result = await (
       serviceInstanceResolver.ServiceInstance as unknown as ServiceInstanceResolvers
@@ -151,9 +187,13 @@ describe('serviceInstance field resolvers', () => {
       GRAPHQL_RESOLVE_INFO
     );
 
-    expect(
-      ServiceInstanceDomain.loadServiceInstanceSubscriptions
-    ).toHaveBeenCalledWith(id);
+    expect(load).toHaveBeenCalledWith(
+      createOrganizationServiceInstanceKey({
+        organizationId:
+          contextSimpleUserFiligran2.user.selected_organization_id,
+        serviceInstanceId: id,
+      })
+    );
     expect(result).toEqual(expected);
   });
 });

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.ts
@@ -7,11 +7,11 @@ import { mapToGraphQLError } from '../../../utils/error/error.mapping';
 import { NotFoundError } from '../../../utils/error/error.util';
 import { createRelayIdScalar } from '../../../utils/scalar.util';
 import { ServiceInstanceApp } from './service-instance.app';
-import {
-  createOrganizationServiceInstanceKey,
-  createServiceInstanceUserOrganizationKey,
-} from './service-instance.dataloader';
 import { ServiceInstanceDomain } from './service-instance.domain';
+import {
+  organizationServiceInstanceKey,
+  serviceInstanceUserOrganizationKey,
+} from './service-instance.keys';
 
 const resolvers: Resolvers = {
   ServiceInstanceId: createRelayIdScalar<ServiceInstanceId>('ServiceInstance'),
@@ -26,14 +26,14 @@ const resolvers: Resolvers = {
       ),
     organization_subscribed: ({ id }, _, context) =>
       context.dataLoaders.serviceInstance.organizationSubscribedLoader.load(
-        createOrganizationServiceInstanceKey({
+        organizationServiceInstanceKey.create({
           organizationId: context.user.selected_organization_id,
           serviceInstanceId: id as ServiceInstanceId,
         })
       ),
     capabilities: ({ id }, _, context) =>
       context.dataLoaders.serviceInstance.capabilitiesLoader.load(
-        createServiceInstanceUserOrganizationKey({
+        serviceInstanceUserOrganizationKey.create({
           serviceInstanceId: id as ServiceInstanceId,
           userId: context.user.id,
           organizationId: context.user.selected_organization_id,
@@ -41,7 +41,7 @@ const resolvers: Resolvers = {
       ),
     user_joined: ({ id }, _, context) =>
       context.dataLoaders.serviceInstance.userJoinedLoader.load(
-        createServiceInstanceUserOrganizationKey({
+        serviceInstanceUserOrganizationKey.create({
           serviceInstanceId: id as ServiceInstanceId,
           userId: context.user.id,
           organizationId: context.user.selected_organization_id,
@@ -49,7 +49,7 @@ const resolvers: Resolvers = {
       ),
     subscriptions: ({ id }, _, context) =>
       context.dataLoaders.serviceInstance.subscriptionsByServiceInstanceLoader.load(
-        createOrganizationServiceInstanceKey({
+        organizationServiceInstanceKey.create({
           organizationId: context.user.selected_organization_id,
           serviceInstanceId: id as ServiceInstanceId,
         })

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.ts
@@ -1,7 +1,4 @@
-import {
-  IntegrationType,
-  Resolvers,
-} from '../../../__generated__/resolvers-types';
+import { Resolvers } from '../../../__generated__/resolvers-types';
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import { listen } from '../../../pub';
 import { getErrorMessage } from '../../../utils/error/error-guard.util';
@@ -10,48 +7,12 @@ import { mapToGraphQLError } from '../../../utils/error/error.mapping';
 import { NotFoundError } from '../../../utils/error/error.util';
 import { createRelayIdScalar } from '../../../utils/scalar.util';
 import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
-import { OPENAEV_SCENARIO_DOCUMENT_TYPE } from '../../shareable-resource/openaev/scenario/scenario.model';
-import { OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE } from '../../shareable-resource/opencti/custom-dashboard/custom-dashboard.model';
-import { OPENCTI_INTEGRATION_DOCUMENT_TYPE } from '../../shareable-resource/opencti/integration/integration.model';
-import { OPENCTI_PLAYBOOK_DOCUMENT_TYPE } from '../../shareable-resource/opencti/playbook/playbook.model';
 import { ServiceInstanceApp } from './service-instance.app';
 import { ServiceInstanceDomain } from './service-instance.domain';
 
 const resolvers: Resolvers = {
   ServiceInstanceId: createRelayIdScalar<ServiceInstanceId>('ServiceInstance'),
   ServiceInstance: {
-    __resolveType(service_instance: {
-      type?: string;
-      integration_type?: string;
-    }) {
-      const integrationMapping: Record<string, string> = {
-        [IntegrationType.Connector]: 'Connector',
-        [IntegrationType.CsvFeed]: 'CsvFeed',
-      };
-      const typeMapping: Record<string, string> = {
-        [OPENAEV_SCENARIO_DOCUMENT_TYPE]: 'OpenAEVScenario',
-        [OPENCTI_CUSTOM_DASHBOARD_DOCUMENT_TYPE]: 'OpenCTICustomDashboard',
-        [OPENCTI_INTEGRATION_DOCUMENT_TYPE]: 'OpenCTIIntegration',
-        [OPENCTI_PLAYBOOK_DOCUMENT_TYPE]: 'OpenCTIPlaybook',
-      };
-
-      const serviceType = service_instance.type;
-      if (!serviceType) {
-        return 'SeoServiceInstance';
-      }
-
-      if (serviceType === OPENCTI_INTEGRATION_DOCUMENT_TYPE) {
-        const integrationType = service_instance.integration_type;
-
-        if (integrationType) {
-          return (
-            integrationMapping[integrationType] ?? typeMapping[serviceType]
-          );
-        }
-        return typeMapping[serviceType];
-      }
-      return typeMapping[serviceType] ?? 'SeoServiceInstance';
-    },
     links: ({ id }, _) =>
       ServiceInstanceDomain.loadLinks(id as ServiceInstanceId),
     service_definition: ({ id }, _) =>

--- a/apps/backend/src/modules/service/instance/service-instance.resolver.ts
+++ b/apps/backend/src/modules/service/instance/service-instance.resolver.ts
@@ -6,39 +6,53 @@ import { ErrorCode, UnknownErrorCode } from '../../../utils/error/error.code';
 import { mapToGraphQLError } from '../../../utils/error/error.mapping';
 import { NotFoundError } from '../../../utils/error/error.util';
 import { createRelayIdScalar } from '../../../utils/scalar.util';
-import { UserServiceCapabilityHelper } from '../../security-management/user-service-capability/user-service-capability.helper';
 import { ServiceInstanceApp } from './service-instance.app';
+import {
+  createOrganizationServiceInstanceKey,
+  createServiceInstanceUserOrganizationKey,
+} from './service-instance.dataloader';
 import { ServiceInstanceDomain } from './service-instance.domain';
 
 const resolvers: Resolvers = {
   ServiceInstanceId: createRelayIdScalar<ServiceInstanceId>('ServiceInstance'),
   ServiceInstance: {
-    links: ({ id }, _) =>
-      ServiceInstanceDomain.loadLinks(id as ServiceInstanceId),
-    service_definition: ({ id }, _) =>
-      ServiceInstanceDomain.loadServiceDefinitionByServiceInstance(
+    links: ({ id }, _, context) =>
+      context.dataLoaders.serviceInstance.linksByServiceInstanceLoader.load(
+        id as ServiceInstanceId
+      ),
+    service_definition: ({ id }, _, context) =>
+      context.dataLoaders.serviceInstance.serviceDefinitionByServiceInstanceLoader.load(
         id as ServiceInstanceId
       ),
     organization_subscribed: ({ id }, _, context) =>
-      ServiceInstanceDomain.loadIsSubscribed(
-        context.user.selected_organization_id,
-        id as ServiceInstanceId
+      context.dataLoaders.serviceInstance.organizationSubscribedLoader.load(
+        createOrganizationServiceInstanceKey({
+          organizationId: context.user.selected_organization_id,
+          serviceInstanceId: id as ServiceInstanceId,
+        })
       ),
     capabilities: ({ id }, _, context) =>
-      UserServiceCapabilityHelper.loadCapabilities(
-        id as ServiceInstanceId,
-        context.user.id,
-        context.user.selected_organization_id
+      context.dataLoaders.serviceInstance.capabilitiesLoader.load(
+        createServiceInstanceUserOrganizationKey({
+          serviceInstanceId: id as ServiceInstanceId,
+          userId: context.user.id,
+          organizationId: context.user.selected_organization_id,
+        })
       ),
     user_joined: ({ id }, _, context) =>
-      ServiceInstanceDomain.getUserJoined(
-        context.user.id,
-        context.user.selected_organization_id,
-        id as ServiceInstanceId
+      context.dataLoaders.serviceInstance.userJoinedLoader.load(
+        createServiceInstanceUserOrganizationKey({
+          serviceInstanceId: id as ServiceInstanceId,
+          userId: context.user.id,
+          organizationId: context.user.selected_organization_id,
+        })
       ),
-    subscriptions: ({ id }, _) =>
-      ServiceInstanceDomain.loadServiceInstanceSubscriptions(
-        id as ServiceInstanceId
+    subscriptions: ({ id }, _, context) =>
+      context.dataLoaders.serviceInstance.subscriptionsByServiceInstanceLoader.load(
+        createOrganizationServiceInstanceKey({
+          organizationId: context.user.selected_organization_id,
+          serviceInstanceId: id as ServiceInstanceId,
+        })
       ),
   },
   Query: {

--- a/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.test.ts
@@ -14,12 +14,13 @@ describe('openAEVScenario field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        contextSimpleUserFiligran2.dataLoaders.document
+          .imagesByDocumentIdLoader,
         'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
           ReturnType<
-            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+            typeof contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader.load
           >
         >
       );
@@ -35,7 +36,8 @@ describe('openAEVScenario field resolvers', () => {
 
       // Then
       expect(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+        contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader
+          .load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });

--- a/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/openaev/scenario/scenario.resolver.ts
@@ -6,7 +6,7 @@ import {
 const resolvers: Resolvers = {
   OpenAEVScenario: {
     children_documents: async ({ id }, _, context) =>
-      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+      (await context.dataLoaders.document.imagesByDocumentIdLoader.load(
         id
       )) as unknown as ShareableResource[],
   },

--- a/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.test.ts
@@ -14,12 +14,13 @@ describe('customDashboard field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        contextSimpleUserFiligran2.dataLoaders.document
+          .imagesByDocumentIdLoader,
         'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
           ReturnType<
-            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+            typeof contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader.load
           >
         >
       );
@@ -35,7 +36,8 @@ describe('customDashboard field resolvers', () => {
 
       // Then
       expect(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+        contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader
+          .load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });

--- a/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/custom-dashboard/custom-dashboard.resolver.ts
@@ -6,7 +6,7 @@ import {
 const resolvers: Resolvers = {
   CustomDashboard: {
     children_documents: async ({ id }, _, context) =>
-      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+      (await context.dataLoaders.document.imagesByDocumentIdLoader.load(
         id
       )) as unknown as ShareableResource[],
   },

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
@@ -69,12 +69,13 @@ describe('integration field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        contextSimpleUserFiligran2.dataLoaders.document
+          .imagesByDocumentIdLoader,
         'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
           ReturnType<
-            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+            typeof contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader.load
           >
         >
       );
@@ -87,7 +88,8 @@ describe('integration field resolvers', () => {
       );
 
       expect(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+        contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader
+          .load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.test.ts
@@ -99,7 +99,7 @@ describe('integration field resolvers', () => {
         const documentId = uuidv4();
         const expected = { id: uuidv4(), name: 'Case Management', product: [] };
         vi.spyOn(
-          contextSimpleUserFiligran2.dataLoaders
+          contextSimpleUserFiligran2.dataLoaders.document
             .solutionCategoryByDocumentIdLoader,
           'load'
         ).mockResolvedValue(expected as unknown as SolutionCategory | null);
@@ -113,7 +113,7 @@ describe('integration field resolvers', () => {
         );
 
         expect(
-          contextSimpleUserFiligran2.dataLoaders
+          contextSimpleUserFiligran2.dataLoaders.document
             .solutionCategoryByDocumentIdLoader.load
         ).toHaveBeenCalledWith(documentId);
         expect(result).toEqual(expected);

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
@@ -28,7 +28,7 @@ const resolvers: Resolvers = {
       return resolvedType;
     },
     solution_category: ({ id }, _, context) =>
-      context.dataLoaders.solutionCategoryByDocumentIdLoader.load(id),
+      context.dataLoaders.document.solutionCategoryByDocumentIdLoader.load(id),
     children_documents: async ({ id }, _, context) =>
       (await context.dataLoaders.document.imagesByDocumentIdLoader.load(
         id

--- a/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/integration/integration.resolver.ts
@@ -30,7 +30,7 @@ const resolvers: Resolvers = {
     solution_category: ({ id }, _, context) =>
       context.dataLoaders.solutionCategoryByDocumentIdLoader.load(id),
     children_documents: async ({ id }, _, context) =>
-      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+      (await context.dataLoaders.document.imagesByDocumentIdLoader.load(
         id
       )) as unknown as ShareableResource[],
   },

--- a/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.test.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.test.ts
@@ -13,12 +13,13 @@ describe('openCTIPlaybook field resolvers', () => {
       const documentId = uuidv4();
       const expected = [{ id: uuidv4() }];
       vi.spyOn(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader,
+        contextSimpleUserFiligran2.dataLoaders.document
+          .imagesByDocumentIdLoader,
         'load'
       ).mockResolvedValue(
         expected as unknown as Awaited<
           ReturnType<
-            typeof contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+            typeof contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader.load
           >
         >
       );
@@ -32,7 +33,8 @@ describe('openCTIPlaybook field resolvers', () => {
       );
 
       expect(
-        contextSimpleUserFiligran2.dataLoaders.imagesByDocumentIdLoader.load
+        contextSimpleUserFiligran2.dataLoaders.document.imagesByDocumentIdLoader
+          .load
       ).toHaveBeenCalledWith(documentId);
       expect(result).toEqual(expected);
     });

--- a/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.ts
+++ b/apps/backend/src/modules/shareable-resource/opencti/playbook/playbook.resolver.ts
@@ -6,7 +6,7 @@ import {
 const resolvers: Resolvers = {
   OpenCTIPlaybook: {
     children_documents: async ({ id }, _, context) =>
-      (await context.dataLoaders.imagesByDocumentIdLoader.load(
+      (await context.dataLoaders.document.imagesByDocumentIdLoader.load(
         id
       )) as unknown as ShareableResource[],
   },

--- a/apps/backend/src/modules/user-service/user-service.domain.test.ts
+++ b/apps/backend/src/modules/user-service/user-service.domain.test.ts
@@ -660,4 +660,48 @@ describe('userServiceDomain', () => {
       );
     });
   });
+
+  describe('doesUserServiceExist', () => {
+    const sub = useSubscription();
+
+    it('should return true when the user already has access to the subscription', async () => {
+      await insertUserService(SIMPLE.ID, sub.id);
+
+      const result = await UserServiceDomain.doesUserServiceExist(
+        SIMPLE.ID,
+        sub.id
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the user has no access to the subscription', async () => {
+      const result = await UserServiceDomain.doesUserServiceExist(
+        SIMPLE.ID,
+        sub.id
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should not match a user service belonging to another subscription', async () => {
+      const otherSubscriptionId = await createTestSubscription({
+        organization_id: TEST_ORGANIZATIONS.FILIGRAN.ID,
+        service_instance_id: SERVICES.INSTANCES.VAULT.ID,
+        start_date: new Date(),
+        end_date: undefined,
+      });
+      await insertUserService(SIMPLE.ID, otherSubscriptionId);
+
+      const result = await UserServiceDomain.doesUserServiceExist(
+        SIMPLE.ID,
+        sub.id
+      );
+
+      await cleanupUserServices(otherSubscriptionId);
+      await TestHelper.subscription.delete({ id: otherSubscriptionId });
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/apps/backend/src/modules/user-service/user-service.domain.ts
+++ b/apps/backend/src/modules/user-service/user-service.domain.ts
@@ -37,7 +37,6 @@ import { UserDomain } from '../organization-management/user/user-domain/user.dom
 import { UserOrganizationDomain } from '../organization-management/user/user-organization/user-organization.domain';
 import { UserHelper } from '../organization-management/user/user.helper';
 import { GenericServiceCapabilityIds } from '../security-management/service-capability/generic-service-capability.const';
-import { ServiceCapabilityHelper } from '../security-management/service-capability/service-capability.helper';
 import { UserServiceCapabilityHelper } from '../security-management/user-service-capability/user-service-capability.helper';
 import { ServiceInstanceDomain } from '../service/instance/service-instance.domain';
 import { SubscriptionDomain } from '../subscription/subscription.domain';
@@ -74,37 +73,6 @@ export const UserServiceDomain = {
       }
       return userServices;
     });
-  },
-
-  addAdminAccess: async (
-    adminId: UserId,
-    subscriptionId: SubscriptionId,
-    isPersonalSpace: boolean = false
-  ) => {
-    const dataUserService = {
-      id: uuidv4() as UserServiceId,
-      user_id: adminId,
-      subscription_id: subscriptionId,
-    };
-    const [userService] =
-      await UserServiceDomain.insertUserService(dataUserService);
-
-    if (!userService) {
-      throw new Error(UnknownErrorCode.AddUserServiceError);
-    }
-
-    const capabilitiesId = isPersonalSpace
-      ? [GenericServiceCapabilityIds.AccessId]
-      : [
-          GenericServiceCapabilityIds.AccessId,
-          GenericServiceCapabilityIds.ManageAccessId,
-        ];
-    const dataCapabilities = capabilitiesId.map((capabilityId) => ({
-      id: uuidv4() as UserServiceCapabilityId,
-      user_service_id: userService.id,
-      generic_service_capability_id: capabilityId as GenericServiceCapabilityId,
-    }));
-    await ServiceCapabilityHelper.insertServiceCapability(dataCapabilities);
   },
 
   createUserServiceAccess: async ({
@@ -569,12 +537,11 @@ export const UserServiceDomain = {
   doesUserServiceExist: async (
     user_id: UserId,
     subscription_id: SubscriptionId
-  ) => {
-    const [existingUserService] =
-      await UserServiceDomain.loadUserServiceWithCapabilitiesBy({
-        user_id,
-        subscription_id,
-      });
+  ): Promise<boolean> => {
+    const existingUserService = await db<UserService>('User_Service')
+      .where({ user_id, subscription_id })
+      .select('User_Service.id')
+      .first();
     return !!existingUserService;
   },
 };

--- a/apps/backend/src/utils/batch-query.util.test.ts
+++ b/apps/backend/src/utils/batch-query.util.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { buildTupleFilter, uniqueTuples } from './batch-query.util';
+
+describe('uniqueTuples', () => {
+  it('should remove duplicated tuples while preserving the first occurrence order', () => {
+    const result = uniqueTuples([
+      ['a', 'b'],
+      ['c', 'd'],
+      ['a', 'b'],
+      ['b', 'a'],
+    ]);
+
+    expect(result).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+      ['b', 'a'],
+    ]);
+  });
+
+  it('should not merge tuples whose concatenation would collide', () => {
+    const result = uniqueTuples([
+      ['ab', 'c'],
+      ['a', 'bc'],
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('should return an empty array when no tuple is given', () => {
+    expect(uniqueTuples([])).toEqual([]);
+  });
+});
+
+describe('buildTupleFilter', () => {
+  interface Key {
+    organizationId: string;
+    serviceInstanceId: string;
+  }
+
+  const columns = [
+    {
+      column: 'Subscription.organization_id',
+      value: (key: Key) => key.organizationId,
+    },
+    {
+      column: 'Subscription.service_instance_id',
+      value: (key: Key) => key.serviceInstanceId,
+    },
+  ];
+
+  it('should pair each declared column with the value extracted from the keys, in declaration order', () => {
+    const result = buildTupleFilter<Key>(
+      [{ organizationId: 'org', serviceInstanceId: 'instance' }],
+      columns
+    );
+
+    expect(result.columns).toEqual([
+      'Subscription.organization_id',
+      'Subscription.service_instance_id',
+    ]);
+    expect(result.tuples).toEqual([['org', 'instance']]);
+  });
+
+  it('should deduplicate tuples built from the keys', () => {
+    const result = buildTupleFilter<Key>(
+      [
+        { organizationId: 'org', serviceInstanceId: 'instance' },
+        { organizationId: 'org', serviceInstanceId: 'instance' },
+      ],
+      columns
+    );
+
+    expect(result.tuples).toEqual([['org', 'instance']]);
+  });
+
+  it('should return an empty tuples array when no key is given', () => {
+    const result = buildTupleFilter<Key>([], columns);
+
+    expect(result.columns).toEqual([
+      'Subscription.organization_id',
+      'Subscription.service_instance_id',
+    ]);
+    expect(result.tuples).toEqual([]);
+  });
+});

--- a/apps/backend/src/utils/batch-query.util.ts
+++ b/apps/backend/src/utils/batch-query.util.ts
@@ -1,0 +1,44 @@
+const TUPLE_SEPARATOR = '\u0000';
+
+// Batch queries match on tuples (`WHERE (a, b) IN ((..), (..))`) to keep the
+// correlation between columns; duplicated tuples would only bloat the query.
+export const uniqueTuples = <Value extends string>(
+  tuples: readonly Value[][]
+): Value[][] => {
+  const seen = new Set<string>();
+
+  return tuples.filter((tuple) => {
+    const identifier = tuple.join(TUPLE_SEPARATOR);
+    if (seen.has(identifier)) {
+      return false;
+    }
+
+    seen.add(identifier);
+    return true;
+  });
+};
+
+export interface TupleColumn<Key> {
+  // Column reference passed to knex's `whereIn`, e.g. `Subscription.organization_id`.
+  column: string;
+  // Extracts the value matching this column from a batch key.
+  value: (key: Key) => string;
+}
+
+export interface TupleFilter {
+  columns: string[];
+  tuples: string[][];
+}
+
+// Pairs each column with its value extractor so the columns array passed to
+// `whereIn` and the tuples built from the keys can never drift out of order,
+// which would otherwise silently match the cross product of the columns.
+export const buildTupleFilter = <Key>(
+  keys: readonly Key[],
+  columns: readonly TupleColumn<Key>[]
+): TupleFilter => ({
+  columns: columns.map(({ column }) => column),
+  tuples: uniqueTuples(
+    keys.map((key) => columns.map(({ value }) => value(key)))
+  ),
+});

--- a/apps/backend/src/utils/dataloader-key.util.test.ts
+++ b/apps/backend/src/utils/dataloader-key.util.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { defineCompositeKey } from './dataloader-key.util';
+
+interface TestFields extends Record<string, string> {
+  organizationId: string;
+  serviceInstanceId: string;
+  userId: string;
+}
+
+const compositeKey = defineCompositeKey<TestFields>([
+  'organizationId',
+  'serviceInstanceId',
+  'userId',
+]);
+
+describe('defineCompositeKey', () => {
+  describe('create', () => {
+    it('should join values following the declared field order', () => {
+      const key = compositeKey.create({
+        userId: 'user',
+        organizationId: 'organization',
+        serviceInstanceId: 'instance',
+      });
+
+      expect(key).toBe('organization:instance:user');
+    });
+  });
+
+  describe('parse', () => {
+    it('should rebuild the fields from a key created by the same codec', () => {
+      const fields = {
+        organizationId: 'organization',
+        serviceInstanceId: 'instance',
+        userId: 'user',
+      };
+
+      expect(compositeKey.parse(compositeKey.create(fields))).toEqual(fields);
+    });
+
+    it.each`
+      key                         | description
+      ${'organization:instance'}  | ${'too few segments'}
+      ${'a:b:c:d'}                | ${'too many segments'}
+      ${':instance:user'}         | ${'empty leading segment'}
+      ${'organization::user'}     | ${'empty middle segment'}
+      ${'organization:instance:'} | ${'empty trailing segment'}
+      ${''}                       | ${'empty key'}
+    `('should throw for "$key" ($description)', ({ key }) => {
+      expect(() => compositeKey.parse(key)).toThrow(
+        `Invalid composite key: ${key}`
+      );
+    });
+  });
+});

--- a/apps/backend/src/utils/dataloader-key.util.ts
+++ b/apps/backend/src/utils/dataloader-key.util.ts
@@ -1,0 +1,37 @@
+const KEY_SEPARATOR = ':';
+
+declare const compositeKeyBrand: unique symbol;
+
+export type CompositeKey<Fields extends Record<string, string>> = string & {
+  readonly [compositeKeyBrand]: Fields;
+};
+
+export interface CompositeKeyCodec<Fields extends Record<string, string>> {
+  create: (values: Fields) => CompositeKey<Fields>;
+  parse: (key: CompositeKey<Fields>) => Fields;
+}
+
+// DataLoader keys must be primitives, so composite keys are encoded as
+// `value1:value2:...` following the declared `fieldNames` order.
+export const defineCompositeKey = <Fields extends Record<string, string>>(
+  fieldNames: readonly (keyof Fields & string)[]
+): CompositeKeyCodec<Fields> => ({
+  create: (values) =>
+    fieldNames
+      .map((fieldName) => values[fieldName])
+      .join(KEY_SEPARATOR) as CompositeKey<Fields>,
+
+  parse: (key) => {
+    const values = key.split(KEY_SEPARATOR);
+    if (
+      values.length !== fieldNames.length ||
+      values.some((value) => value === '')
+    ) {
+      throw new Error(`Invalid composite key: ${key}`);
+    }
+
+    return Object.fromEntries(
+      fieldNames.map((fieldName, index) => [fieldName, values[index]])
+    ) as Fields;
+  },
+});

--- a/apps/backend/tests/tests.const.ts
+++ b/apps/backend/tests/tests.const.ts
@@ -19,6 +19,7 @@ import { ServiceInstanceId } from '../src/model/kanel/public/ServiceInstance';
 import { UserId } from '../src/model/kanel/public/User';
 import { PortalContext } from '../src/model/portal-context';
 import type { DocumentDataLoaders } from '../src/modules/document/document.dataloader';
+import type { ServiceInstanceDataLoaders } from '../src/modules/service/instance/service-instance.dataloader';
 import {
   CAPABILITY_BYPASS,
   PLATFORM_ORGANIZATION_UUID,
@@ -365,16 +366,32 @@ export const contextSimpleUserFiligran2: PortalContext = {
     roles_portal: [],
   },
   dataLoaders: {
-    uploaderLoader: { load: () => Promise.resolve(null) },
-    uploaderOrganizationLoader: { load: () => Promise.resolve(null) },
-    childrenDocumentsLoader: { load: () => Promise.resolve([]) },
-    imagesByDocumentIdLoader: { load: () => Promise.resolve([]) },
-    useCasesByDocumentIdLoader: { load: () => Promise.resolve([]) },
-    solutionCategoryByDocumentIdLoader: { load: () => Promise.resolve(null) },
-    integrationTypeLoader: { load: () => Promise.resolve(null) },
-    serviceInstanceByIdLoader: { load: () => Promise.resolve(undefined) },
-    subscriptionByServiceInstanceLoader: { load: () => Promise.resolve(null) },
-  } as unknown as DocumentDataLoaders,
+    document: {
+      uploaderLoader: { load: () => Promise.resolve(null) },
+      uploaderOrganizationLoader: { load: () => Promise.resolve(null) },
+      childrenDocumentsLoader: { load: () => Promise.resolve([]) },
+      imagesByDocumentIdLoader: { load: () => Promise.resolve([]) },
+      useCasesByDocumentIdLoader: { load: () => Promise.resolve([]) },
+      solutionCategoryByDocumentIdLoader: { load: () => Promise.resolve(null) },
+      integrationTypeLoader: { load: () => Promise.resolve(null) },
+      serviceInstanceByIdLoader: { load: () => Promise.resolve(undefined) },
+      subscriptionByServiceInstanceLoader: {
+        load: () => Promise.resolve(null),
+      },
+    } as unknown as DocumentDataLoaders,
+    serviceInstance: {
+      linksByServiceInstanceLoader: { load: () => Promise.resolve([]) },
+      serviceDefinitionByServiceInstanceLoader: {
+        load: () => Promise.resolve(undefined),
+      },
+      organizationSubscribedLoader: { load: () => Promise.resolve(false) },
+      capabilitiesLoader: { load: () => Promise.resolve([]) },
+      userJoinedLoader: { load: () => Promise.resolve(false) },
+      subscriptionsByServiceInstanceLoader: {
+        load: () => Promise.resolve([]),
+      },
+    } as unknown as ServiceInstanceDataLoaders,
+  },
 } as unknown as PortalContext;
 
 export const requestContextSimpleUserFiligran2 = {


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

This PR refactors the backend `ServiceInstance` GraphQL resolvers to reduce N+1 database patterns by introducing request-scoped DataLoaders and batch-oriented domain/helper methods, aligning with the performance goal in #2880.

**Changes:**

- Introduces `ServiceInstanceDataLoader` and updates `PortalContext.dataLoaders` to be namespaced (`document`, `serviceInstance`).
- Refactors `ServiceInstance` field resolvers to use DataLoaders for links, service definition, subscription status, capabilities, join status, and subscriptions.
- Updates affected resolvers/tests to the new `context.dataLoaders.document.*` access pattern and adds batch-query unit tests.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- go to private service pages
- check that everything is alright (no regression)

## Related issues

- Related to #2880 

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.