### PR TITLE
fix(public-menu): use initializeWithValue to get rid of hydration error (#3018)

### DIFF
--- a/apps/frontend/src/components/menu/PublicMenu.tsx
+++ b/apps/frontend/src/components/menu/PublicMenu.tsx
@@ -9,7 +9,11 @@ import { useLocalStorage } from 'usehooks-ts';
 
 const PublicMenu = () => {
   const locale = useLocale();
-  const [open, setOpen] = useLocalStorage<boolean>('is-public-menu-open', true);
+  const [open, setOpen] = useLocalStorage<boolean>(
+    'is-public-menu-open',
+    true,
+    { initializeWithValue: false }
+  );
   const handleOpenMenu = useCallback(() => setOpen((prev) => !prev), [setOpen]);
 
   return (


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

This PR updates the frontend `PublicMenu` component to avoid a Next.js hydration mismatch by preventing `useLocalStorage` from reading `localStorage` during the initial render, while still keeping the default “open” behavior.

**Changes:**
- Update `useLocalStorage` usage in `PublicMenu` to pass `{ initializeWithValue: false }` to avoid hydration errors when the stored value differs from the server-rendered default.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

Local only, can't be tested (errors not shown on development or production environments)

## Related issues

- Related to #3018

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.