### PR TITLE
ci(project-automation): point workflow to the XTM-Hub organization project (#3022)

### DIFF
--- a/.github/workflows/pr-issue-automation.yml
+++ b/.github/workflows/pr-issue-automation.yml
@@ -12,8 +12,8 @@ on:
     workflows: ["Run XTM Hub CI/CD"]
     types: [completed]
 env:
-  ORGANIZATION: "FiligranHQ"
-  PROJECT_NUMBER: 17
+  ORGANIZATION: "XTM-Hub"
+  PROJECT_NUMBER: 1
 jobs:
   manage-pr-and-issues:
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
               console.error(`Failed to assign PR to ${prCreator}:`, error);
             }
 
-      - name: Check if creator is in FiligranHQ organization
+      - name: Check if creator is in the organization
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         id: check_org_membership
         uses: actions/github-script@v9
@@ -81,8 +81,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-              const { data: membership } = await github.rest.orgs.checkMembershipForUser({
-                org: 'FiligranHQ',
+              await github.rest.orgs.checkMembershipForUser({
+                org: process.env.ORGANIZATION,
                 username: context.payload.pull_request.user.login
               });
               return true;


### PR DESCRIPTION
Closes #3022

## Context

The repository was migrated from `FiligranHQ` to `XTM-Hub`, but the automation workflow still targeted `FiligranHQ/17`. All 1306 items were migrated to `XTM-Hub/1`, and the old project was emptied and closed.

As a result the workflow was reporting success while doing nothing:

```
Issue #2451 is not in project #17, skipping...
```

## Changes

- `ORGANIZATION`: `FiligranHQ` → `XTM-Hub`
- `PROJECT_NUMBER`: `17` → `1`
- The organization membership check now resolves `process.env.ORGANIZATION` instead of a hardcoded `FiligranHQ`
- Removed an unused `membership` variable

## Post-merge verification

A run should log `Issue #XXXX found in project #1` instead of `not in project #17`.