### PR TITLE
fix: disable prefetch for side effect links and add agent instructions (#3035)

### DIFF
--- a/.github/agents/frontend-code-writer.agent.md
+++ b/.github/agents/frontend-code-writer.agent.md
@@ -33,4 +33,8 @@ performance bottlenecks and security weaknesses before delivering it.
 - When touching a component that still uses Relay, only migrate it to `@tanstack/react-query` when the task scope explicitly includes migration or the change is small and low-risk.
 - After removing a component's last Relay usage, confirm no other files still depend on its generated Relay artifacts before deleting them.
 
+## Routing & Links
+- **Disable prefetch on side-effecting links** — Next.js `<Link>` prefetches its `href` in the background as soon as it enters the viewport (or on hover). Any `href` that resolves to a route with real side effects — e.g. paths under `/auth/*`, `/document/*`, `/user/picture`, or App Router `route.ts` handlers that authenticate, mutate data, or trigger redirects with business logic (like `app/redirect/[identifier]/route.ts`) — must use `<Link href="..." prefetch={false}>`. Plain `<a href="...">` tags are unaffected and don't need this.
+- When adding or reviewing any `<Link>`, check whether its target is a passive page/RSC route or a side-effecting endpoint before deciding on `prefetch`.
+
 Default posture: implement like a maintainer of this codebase, not a generic generator.

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/openaev-free-trial/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/openaev-free-trial/page.tsx
@@ -79,7 +79,9 @@ const Page = async ({
           platformIdentifier={PlatformIdentifier.Openaev}
           actions={
             <GradientButton className="bg-background dark:bg-none">
-              <Link href="/redirect/create-openaev-free-trial">
+              <Link
+                href="/redirect/create-openaev-free-trial"
+                prefetch={false}>
                 {t('Service.Trials.StartTrial')}
               </Link>
             </GradientButton>

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/opencti-free-trial/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/opencti-free-trial/page.tsx
@@ -79,7 +79,9 @@ const Page = async ({
           platformIdentifier={PlatformIdentifier.Opencti}
           actions={
             <GradientButton className="bg-background dark:bg-none">
-              <Link href="/redirect/create-free-trial">
+              <Link
+                href="/redirect/create-free-trial"
+                prefetch={false}>
                 {t('Service.Trials.StartTrial')}
               </Link>
             </GradientButton>

--- a/apps/frontend/src/components/layout/PublicHeaderContent.tsx
+++ b/apps/frontend/src/components/layout/PublicHeaderContent.tsx
@@ -23,7 +23,11 @@ export const PublicHeaderContent = async ({
       </Link>
       <div className="flex items-center gap-s ml-auto">
         <Button variant="secondary">
-          <Link href="/auth/oidc">{t('PublicLayout.Login')}</Link>
+          <Link
+            href="/auth/oidc"
+            prefetch={false}>
+            {t('PublicLayout.Login')}
+          </Link>
         </Button>
         <Button
           asChild

--- a/apps/frontend/src/components/signup/SignUp.tsx
+++ b/apps/frontend/src/components/signup/SignUp.tsx
@@ -102,6 +102,7 @@ const SignUp = ({ showLocalLogin = false }: { showLocalLogin?: boolean }) => {
             {t('AlreadyHaveAccount')}
             <Link
               href={oidcHref}
+              prefetch={false}
               className="text-primary underline">
               {t('LogIn')}
             </Link>


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


This PR addresses unwanted background requests to side-effecting routes (notably `/auth/oidc`) when navigating public pages by disabling Next.js `<Link>` prefetching for those targets, reducing unnecessary auth redirects and potential rate limiting.

**Changes:**

- Disabled Next.js `<Link>` prefetch for `/auth/oidc` login links on public-facing UI.
- Disabled prefetch for free-trial “redirect” links that hit `app/redirect/[identifier]/route.ts` handlers.
- Added agent guidance documenting when to disable prefetch for side-effecting links.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- navigate on public pages
- check that there is no `/auth/oidc` requests anymore

https://github.com/user-attachments/assets/bfaea98c-7a89-4c80-8a26-c2e6746ea130

## Related issues

- Related to #3035

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.