### PR TITLE
feat(ci): enhance parallel test execution and artifact management (#3069)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github/CODEOWNERS
+.idea
+.vscode
+.copilot
+
+**/node_modules
+**/.next
+**/dist
+**/coverage
+**/test-results
+**/.turbo
+**/.cache
+**/.DS_Store
+
+xtm-hub-dev/docker-compose*.yml
+logs

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .idea
 .vscode
 .copilot
+.husky
 
 **/node_modules
 **/.next
@@ -15,3 +16,4 @@
 
 xtm-hub-dev/docker-compose*.yml
 logs
+bruno

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -290,37 +290,6 @@ jobs:
           path: logs/
           retention-days: 30
 
-  publish-e2e-test-report:
-    needs: run-e2e-tests-shards
-    if: always() && needs.run-e2e-tests-shards.result != 'skipped'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Download CTRF artifacts
-        uses: actions/download-artifact@v5
-        with:
-          pattern: ctrf-shard-*
-          path: ctrf
-          merge-multiple: false
-
-      - name: Publish Test Report
-        if: always()
-        uses: ctrf-io/github-test-reporter@v1
-        with:
-          report-path: "./ctrf/**/*.json"
-          pull-request: true
-          summary-report: true
-          failed-report: true
-          flaky-report: true
-          insights-report: true
-          suite-folded-report: true
-          overwrite-comment: true
-          report-order: "summary-report,failed-report,flaky-report,insights-report,test-report"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   run-front-unit-tests-shards:
     needs: build-images-tests
     runs-on: ubuntu-latest
@@ -423,9 +392,11 @@ jobs:
   run-e2e-tests:
     needs:
       - run-e2e-tests-shards
-      - publish-e2e-test-report
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Finalize e2e shards
         run: |
@@ -433,10 +404,30 @@ jobs:
             echo "E2E shard job failed with result: ${{ needs.run-e2e-tests-shards.result }}"
             exit 1
           fi
-          if [ "${{ needs.publish-e2e-test-report.result }}" != "success" ] && [ "${{ needs.publish-e2e-test-report.result }}" != "skipped" ]; then
-            echo "E2E report publishing failed with result: ${{ needs.publish-e2e-test-report.result }}"
-            exit 1
-          fi
+
+      - name: Download CTRF artifacts
+        if: always() && needs.run-e2e-tests-shards.result != 'skipped'
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ctrf-shard-*
+          path: ctrf
+          merge-multiple: false
+
+      - name: Publish Test Report
+        if: always() && needs.run-e2e-tests-shards.result != 'skipped'
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: "./ctrf/**/*.json"
+          pull-request: true
+          summary-report: true
+          failed-report: true
+          flaky-report: true
+          insights-report: true
+          suite-folded-report: true
+          overwrite-comment: true
+          report-order: "summary-report,failed-report,flaky-report,insights-report,test-report"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-front-unit-tests:
     needs: run-front-unit-tests-shards

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -183,7 +183,7 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  run-e2e-tests:
+  run-e2e-tests-shards:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -290,8 +290,8 @@ jobs:
           retention-days: 30
 
   publish-e2e-test-report:
-    needs: run-e2e-tests
-    if: always() && needs.run-e2e-tests.result != 'skipped'
+    needs: run-e2e-tests-shards
+    if: always() && needs.run-e2e-tests-shards.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -320,7 +320,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  run-front-unit-tests:
+  run-front-unit-tests-shards:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -367,7 +367,7 @@ jobs:
           name: frontend-shard-${{ matrix.shard }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  run-api-unit-tests:
+  run-api-unit-tests-shards:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -418,6 +418,48 @@ jobs:
           flags: backend-shard-${{ matrix.shard }}
           name: backend-shard-${{ matrix.shard }}
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  run-e2e-tests:
+    needs:
+      - run-e2e-tests-shards
+      - publish-e2e-test-report
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize e2e shards
+        run: |
+          if [ "${{ needs.run-e2e-tests-shards.result }}" != "success" ]; then
+            echo "E2E shard job failed with result: ${{ needs.run-e2e-tests-shards.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.publish-e2e-test-report.result }}" != "success" ] && [ "${{ needs.publish-e2e-test-report.result }}" != "skipped" ]; then
+            echo "E2E report publishing failed with result: ${{ needs.publish-e2e-test-report.result }}"
+            exit 1
+          fi
+
+  run-front-unit-tests:
+    needs: run-front-unit-tests-shards
+    if: always() && contains(github.ref , 'refs/tags/') == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize frontend shards
+        run: |
+          if [ "${{ needs.run-front-unit-tests-shards.result }}" != "success" ]; then
+            echo "Frontend shard job failed with result: ${{ needs.run-front-unit-tests-shards.result }}"
+            exit 1
+          fi
+
+  run-api-unit-tests:
+    needs: run-api-unit-tests-shards
+    if: always() && contains(github.ref , 'refs/tags/') == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize backend shards
+        run: |
+          if [ "${{ needs.run-api-unit-tests-shards.result }}" != "success" ]; then
+            echo "Backend shard job failed with result: ${{ needs.run-api-unit-tests-shards.result }}"
+            exit 1
+          fi
 
   deploy-feature-branch:
     needs: build-images-tests

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -225,6 +225,7 @@ jobs:
            GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}" \
            GITHUB_RUN_ID="${{ github.run_id }}" \
            PLAYWRIGHT_SHARD="${{ matrix.shard }}/8"
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml pull --include-deps e2e
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
            -e PLAYWRIGHT_SHARD \
            e2e sh -lc "yarn test:e2e --shard=${PLAYWRIGHT_SHARD}" || TEST_EXIT_CODE=$?

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -187,10 +187,13 @@ jobs:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     permissions:
       contents: read
       packages: write
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -220,27 +223,22 @@ jobs:
            TEAMS_WEBHOOK_E2E="${{ secrets.TEAMS_WEBHOOK_E2E }}" \
            GITHUB_PR_TITLE="${{ github.event.pull_request.title }}" \
            GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}" \
-           GITHUB_RUN_ID="${{ github.run_id }}"
-          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run e2e || TEST_EXIT_CODE=$?
+           GITHUB_RUN_ID="${{ github.run_id }}" \
+           PLAYWRIGHT_SHARD="${{ matrix.shard }}/8"
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
+           -e PLAYWRIGHT_SHARD \
+           e2e sh -lc "yarn test:e2e --shard=${PLAYWRIGHT_SHARD}" || TEST_EXIT_CODE=$?
           CONTAINER_ID=$(docker ps -a --filter "name=e2e-run" --format "{{.ID}}" | head -1)
           docker cp $CONTAINER_ID:/app/apps/e2e/ctrf/. ./ctrf/
           exit ${TEST_EXIT_CODE:-0}
 
-      - name: Publish Test Report
+      - name: Upload CTRF artifact
         if: always()
-        uses: ctrf-io/github-test-reporter@v1
+        uses: actions/upload-artifact@v7
         with:
-          report-path: "./ctrf/*.json"
-          pull-request: true
-          summary-report: true
-          failed-report: true
-          flaky-report: true
-          insights-report: true
-          suite-folded-report: true
-          overwrite-comment: true
-          report-order: "summary-report,failed-report,flaky-report,insights-report,test-report"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: ctrf-shard-${{ matrix.shard }}
+          path: ctrf/
+          retention-days: 30
 
       - name: Collect service logs on failure
         if: failure()
@@ -287,9 +285,40 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: service-logs-${{ github.run_id }}
+          name: service-logs-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: logs/
           retention-days: 30
+
+  publish-e2e-test-report:
+    needs: run-e2e-tests
+    if: always() && needs.run-e2e-tests.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download CTRF artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ctrf-shard-*
+          path: ctrf
+          merge-multiple: false
+
+      - name: Publish Test Report
+        if: always()
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: "./ctrf/**/*.json"
+          pull-request: true
+          summary-report: true
+          failed-report: true
+          flaky-report: true
+          insights-report: true
+          suite-folded-report: true
+          overwrite-comment: true
+          report-order: "summary-report,failed-report,flaky-report,insights-report,test-report"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-front-unit-tests:
     needs: build-images-tests
@@ -333,6 +362,10 @@ jobs:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     permissions:
       contents: read
       packages: write
@@ -353,16 +386,28 @@ jobs:
       - name: Install docker
         uses: docker/setup-docker-action@v5
 
+      - name: Run backend type-check
+        if: matrix.shard == 1
+        run: |
+          export IMAGE_TAGS=${{ needs.build-images-tests.outputs.docker-tags }}
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
+            backend-test sh -lc "yarn check-ts"
+
       - name: Launch docker compose
         run: |
           mkdir -p coverage
-          export IMAGE_TAGS=${{ needs.build-images-tests.outputs.docker-tags }}
-          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run backend-test
+          export IMAGE_TAGS="${{ needs.build-images-tests.outputs.docker-tags }}" \
+            VITEST_SHARD="${{ matrix.shard }}/8"
+          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
+            -e VITEST_SHARD \
+            backend-test sh -lc "VITEST_MODE=true yarn vitest run --shard=${VITEST_SHARD} --coverage --coverage.clean=false"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
+          flags: backend-shard-${{ matrix.shard }}
+          name: backend-shard-${{ matrix.shard }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy-feature-branch:

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -324,6 +324,10 @@ jobs:
     needs: build-images-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     permissions:
       contents: read
       packages: write
@@ -346,16 +350,21 @@ jobs:
 
       - name: Run front unit tests
         run: |
-          export IMAGE_TAGS=${{ needs.build-images-tests.outputs.docker-tags }}
+          export IMAGE_TAGS="${{ needs.build-images-tests.outputs.docker-tags }}" \
+            VITEST_SHARD="${{ matrix.shard }}/8"
           mkdir -p coverage
           docker run --rm \
+            -e VITEST_SHARD \
             -v $(pwd)/coverage:/app/apps/frontend/coverage \
-            filigran/portal-front-test:${IMAGE_TAGS}
+            filigran/portal-front-test:${IMAGE_TAGS} \
+            sh -lc "yarn vitest run --shard=${VITEST_SHARD} --coverage --coverage.clean=false"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
+          flags: frontend-shard-${{ matrix.shard }}
+          name: frontend-shard-${{ matrix.shard }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   run-api-unit-tests:

--- a/apps/frontend/src/components/ui/DisplayLogo.test.tsx
+++ b/apps/frontend/src/components/ui/DisplayLogo.test.tsx
@@ -1,0 +1,61 @@
+import testRender from '@/utils/test/test-render';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DisplayLogo } from './DisplayLogo';
+
+const mocks = vi.hoisted(() => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: mocks.useTheme,
+}));
+
+vi.mock('@public/logo_xtm_hub_light.svg', () => ({
+  default: ({ className }: { className?: string }) => (
+    <svg
+      data-testid="logo-light"
+      className={className}
+    />
+  ),
+}));
+
+vi.mock('@public/logo_xtm_hub_dark.svg', () => ({
+  default: ({ className }: { className?: string }) => (
+    <svg
+      data-testid="logo-dark"
+      className={className}
+    />
+  ),
+}));
+
+describe('DisplayLogo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each`
+    resolvedTheme | expectedVisible | expectedHidden
+    ${'light'}    | ${'logo-light'} | ${'logo-dark'}
+    ${'dark'}     | ${'logo-dark'}  | ${'logo-light'}
+    ${undefined}  | ${'logo-dark'}  | ${'logo-light'}
+  `(
+    'renders $expectedVisible when resolvedTheme is $resolvedTheme',
+    ({ resolvedTheme, expectedVisible, expectedHidden }) => {
+      mocks.useTheme.mockReturnValue({ resolvedTheme });
+
+      testRender(<DisplayLogo />);
+
+      expect(screen.getByTestId(expectedVisible)).toBeInTheDocument();
+      expect(screen.queryByTestId(expectedHidden)).not.toBeInTheDocument();
+    }
+  );
+
+  it('forwards className to the rendered logo', () => {
+    mocks.useTheme.mockReturnValue({ resolvedTheme: 'light' });
+
+    testRender(<DisplayLogo className="h-8 w-8" />);
+
+    expect(screen.getByTestId('logo-light')).toHaveClass('h-8 w-8');
+  });
+});

--- a/xtm-hub-dev/docker-compose-ci.yml
+++ b/xtm-hub-dev/docker-compose-ci.yml
@@ -113,7 +113,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:17.2
+    image: postgres:17.2-alpine
     environment:
       - POSTGRES_USER=portal
       - POSTGRES_PASSWORD=portal-password


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

This PR updates the GitHub Actions CI workflow to run E2E and unit tests in 8-way parallel shards, while changing how test reports and artifacts are collected and published to improve total pipeline time and reporting.

**Changes:**
- Shard Playwright E2E runs into an 8-job matrix and aggregate CTRF JSON reports into a single PR comment/reporting step.
- Shard frontend and backend Vitest runs into an 8-job matrix and upload per-shard coverage to Codecov with shard-specific flags.
- Add a `.dockerignore` to reduce Docker build context size by excluding common build/test artifacts and local tooling directories.

Github action time reduction: `~10min -> ~6m = ~40% gain`

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

CI changes only, nothing to test (feature env - image building are working as expected)

## Related issues

- Related to #3069

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.