### PR TITLE
fix(sse): sse singleConnectio, Header NotificationButton single mount (#3063)

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -366,12 +366,12 @@ const handler = createHandler({
 
   onConnect: async (req) => {
     sseActiveConnectionsGauge.inc({
-      subscription: req.context.res.req.body.operationName ?? 'Unknown',
+      subscription: req.context.res.req.body?.operationName ?? 'Unknown',
     });
   },
   onComplete: async (_ctx, msg) => {
     sseActiveConnectionsGauge.dec({
-      subscription: msg.context.res.req.body.operationName ?? 'Unknown',
+      subscription: msg.context.res.req.body?.operationName ?? 'Unknown',
     });
   },
   onSubscribe: async (_ctx, msg) => {
@@ -381,7 +381,7 @@ const handler = createHandler({
   },
   onNext: async (_ctx, req) => {
     sseMessageCounter.inc({
-      subscription: req.context.res.req.body.operationName ?? 'Unknown',
+      subscription: req.context.res.req.body?.operationName ?? 'Unknown',
     });
   },
 });

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -26,7 +26,7 @@ import Link from 'next/link';
 
 import { OrganizationCapability } from '@graphql/generated';
 import { usePathname, useRouter } from 'next/navigation';
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useMutation } from 'react-relay';
 
 // Component interface
@@ -52,6 +52,19 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
     ) ||
       hasOrganizationCapability(OrganizationCapability.ManageAccess));
 
+  const handleLogout = useCallback(() => {
+    commitLogoutMutation({
+      variables: {},
+      updater: (store) => {
+        store.invalidateStore();
+      },
+      onCompleted() {
+        router.push('/');
+        router.refresh();
+      },
+    });
+  }, [commitLogoutMutation, router]);
+
   const headerContent = (
     <>
       <div className="mobile:hidden flex items-center gap-s">
@@ -66,99 +79,79 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
 
       <DisplayLogo className="text-primary mr-2 h-full py-l sm:hidden" />
 
-      <div className="mobile:hidden flex items-center gap-s">
-        <ConnectedProductsDropdown />
+      <div className="flex items-center gap-s">
+        <div className="mobile:hidden flex items-center gap-s">
+          <ConnectedProductsDropdown />
+        </div>
         {canManageUser && <NotificationButton />}
-        <IconActions
-          className="rounded-full"
-          icon={
-            <>
-              <div className="my-auto [&_img]:object-cover size-6 text-primary [&_span]:bg-transparent">
-                <Avatar src={me?.picture || undefined} />
-              </div>
-              <span className="sr-only">{t('MenuUser.ToggleUser')}</span>
-            </>
-          }>
-          <IconActionsItem asChild>
-            <Link href={`/${APP_PATH}/profile`}>{t('MenuUser.Profile')}</Link>
-          </IconActionsItem>
-          <IconActionsItem
-            onClick={() => {
-              commitLogoutMutation({
-                variables: {},
-                updater: (store) => {
-                  store.invalidateStore();
-                },
-                onCompleted() {
-                  router.push('/');
-                  router.refresh();
-                },
-              });
-            }}>
-            {t('LoginPage.Logout')}
-          </IconActionsItem>
-        </IconActions>
-      </div>
-      <div className="flex gap-xs items-center sm:hidden">
-        {canManageUser && <NotificationButton />}
-        <Sheet
-          open={open}
-          onOpenChange={setOpen}>
-          <SheetTrigger>
-            <span className="sr-only">
-              {open ? t('Header.CloseMenu') : t('Header.OpenMenu')}
-            </span>
-            <MenuIcon
-              aria-hidden={true}
-              focusable={false}
-              className="h-6 w-6"
-            />
-          </SheetTrigger>
-          <SheetContent
-            side="left"
-            className="bg-gradient-layer-0-white">
-            <SheetHeader className="flex flex-row justify-between pl-l bg-gradient-layer-0-white">
-              <div className="flex items-center gap-s">
-                <DisplayLogo className="text-primary h-8" />
-                <SheetTitle className="sr-only">
-                  {t('Header.BrandName')}
-                </SheetTitle>
-              </div>
-            </SheetHeader>
-            <div className="flex flex-col h-full">
-              <div>
-                <PrivateNavigation open={true} />
-                <Separator className="my-s" />
-                <div className="flex flex-col gap-m pl-5">
-                  <HeaderOrganizationSwitcher fitContainer />
+        <div className="mobile:hidden flex items-center">
+          <IconActions
+            className="rounded-full"
+            icon={
+              <>
+                <div className="my-auto [&_img]:object-cover size-6 text-primary [&_span]:bg-transparent">
+                  <Avatar src={me?.picture || undefined} />
                 </div>
-              </div>
-              <div className="mt-auto pt-l pb-xl flex flex-col text-center">
-                <Link href={`/${APP_PATH}/profile`}>
-                  <div className="w-full p-2 hover:bg-hover rounded">
-                    {t('MenuUser.Profile')}
+                <span className="sr-only">{t('MenuUser.ToggleUser')}</span>
+              </>
+            }>
+            <IconActionsItem asChild>
+              <Link href={`/${APP_PATH}/profile`}>{t('MenuUser.Profile')}</Link>
+            </IconActionsItem>
+            <IconActionsItem onClick={handleLogout}>
+              {t('LoginPage.Logout')}
+            </IconActionsItem>
+          </IconActions>
+        </div>
+        <div className="flex gap-xs items-center sm:hidden">
+          <Sheet
+            open={open}
+            onOpenChange={setOpen}>
+            <SheetTrigger>
+              <span className="sr-only">
+                {open ? t('Header.CloseMenu') : t('Header.OpenMenu')}
+              </span>
+              <MenuIcon
+                aria-hidden={true}
+                focusable={false}
+                className="h-6 w-6"
+              />
+            </SheetTrigger>
+            <SheetContent
+              side="left"
+              className="bg-gradient-layer-0-white">
+              <SheetHeader className="flex flex-row justify-between pl-l bg-gradient-layer-0-white">
+                <div className="flex items-center gap-s">
+                  <DisplayLogo className="text-primary h-8" />
+                  <SheetTitle className="sr-only">
+                    {t('Header.BrandName')}
+                  </SheetTitle>
+                </div>
+              </SheetHeader>
+              <div className="flex flex-col h-full">
+                <div>
+                  <PrivateNavigation open={true} />
+                  <Separator className="my-s" />
+                  <div className="flex flex-col gap-m pl-5">
+                    <HeaderOrganizationSwitcher fitContainer />
                   </div>
-                </Link>
-                <div
-                  className="p-2 hover:bg-hover rounded cursor-pointer"
-                  onClick={() => {
-                    commitLogoutMutation({
-                      variables: {},
-                      updater: (store) => {
-                        store.invalidateStore();
-                      },
-                      onCompleted() {
-                        router.push('/');
-                        router.refresh();
-                      },
-                    });
-                  }}>
-                  {t('LoginPage.Logout')}
+                </div>
+                <div className="mt-auto pt-l pb-xl flex flex-col text-center">
+                  <Link href={`/${APP_PATH}/profile`}>
+                    <div className="w-full p-2 hover:bg-hover rounded">
+                      {t('MenuUser.Profile')}
+                    </div>
+                  </Link>
+                  <div
+                    className="p-2 hover:bg-hover rounded cursor-pointer"
+                    onClick={handleLogout}>
+                    {t('LoginPage.Logout')}
+                  </div>
                 </div>
               </div>
-            </div>
-          </SheetContent>
-        </Sheet>
+            </SheetContent>
+          </Sheet>
+        </div>
       </div>
     </>
   );

--- a/apps/frontend/src/relay/environment/fetch-fn.test.ts
+++ b/apps/frontend/src/relay/environment/fetch-fn.test.ts
@@ -3,6 +3,10 @@ import { RequestParameters } from 'relay-runtime';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { networkFetch } from './fetch-fn';
 
+vi.mock('graphql-sse', () => ({
+  createClient: vi.fn(() => ({ subscribe: vi.fn() })),
+}));
+
 const mockRequest: RequestParameters = {
   id: null,
   name: 'TestQuery',
@@ -71,5 +75,20 @@ describe('networkFetch', () => {
     const result = await networkFetch({ request: mockRequest, variables: {} });
 
     expect(result).toEqual(mockData);
+  });
+});
+
+describe('subscriptionsClient', () => {
+  it('should create the graphql-sse client with singleConnection enabled to multiplex all subscriptions over one SSE connection', async () => {
+    vi.resetModules();
+    const { createClient } = await import('graphql-sse');
+    await import('./fetch-fn');
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/graphql-sse',
+        singleConnection: true,
+      })
+    );
   });
 });

--- a/apps/frontend/src/relay/environment/fetch-fn.ts
+++ b/apps/frontend/src/relay/environment/fetch-fn.ts
@@ -76,6 +76,7 @@ export async function networkFetch({
 
 const subscriptionsClient = createClient({
   url: '/graphql-sse',
+  singleConnection: true,
 });
 
 export function fetchOrSubscribe(


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

SSE subsription is limited to 6 per browser.  

bug: NotificationButton  (pending-user badge) is mounted twice in  Header.tsx  (desktop  mobile:hidden  block + mobile  sm:hidden  block, both always in the DOM), each independently subscribing to the same  pendingUserList  subscription. -> duplicate subscription for pending users

What has been done : 
- Set `singleConnection` so that a tab would only have one connection and not multiple ones
- Refactor `NotificationButton` to only call it once

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

before changes : a single page could do multiple SSE connections, resulting in reaching the 6 connection limit early and therefore opening new tabs would load indefinitely/not load everything
- Open a tab logged in in an organization with AdministrateOrganization or ManageAccess rights
- Open other tabs the same way
- Limit will reach early, page will not fully load / not at all (for me at some point on one tab, XTM Platform Roadmap on the Left Menu does not appear, opening a new tab will result in an indefinite loading)


after changes : only 1 connection per tab, limit is still to 6 but that means we can open up to 6 tabs before reaching the limit
- Open as many tabs the same way, limit will always reach at the 6th one and not early

## Related issues

- Related to #3063

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.