### PR TITLE
fix(bundletrial): parent_id should not be base64 encoded for platform (#3074)

### DIFF
--- a/apps/backend/src/__generated__/resolvers-types.ts
+++ b/apps/backend/src/__generated__/resolvers-types.ts
@@ -1595,7 +1595,7 @@ export type PlatformDeploymentRequest = {
   ordering: Scalars['Int']['output'];
   organization_domains?: Maybe<Array<Scalars['String']['output']>>;
   organization_name: Scalars['String']['output'];
-  parent_id?: Maybe<Scalars['DeploymentRequestId']['output']>;
+  parent_id?: Maybe<Scalars['String']['output']>;
   platform_id?: Maybe<Scalars['String']['output']>;
   platform_identifier?: Maybe<PlatformIdentifier>;
   platform_token: Scalars['String']['output'];
@@ -3979,7 +3979,7 @@ export type PlatformDeploymentRequestResolvers<ContextType = PortalContext, Pare
   ordering?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   organization_domains?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   organization_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  parent_id?: Resolver<Maybe<ResolversTypes['DeploymentRequestId']>, ParentType, ContextType>;
+  parent_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_identifier?: Resolver<Maybe<ResolversTypes['PlatformIdentifier']>, ParentType, ContextType>;
   platform_token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/apps/backend/src/modules/deployment/deployment.graphql
+++ b/apps/backend/src/modules/deployment/deployment.graphql
@@ -167,7 +167,8 @@ type PlatformDeploymentRequest {
   platform_id: String
   platform_url: String
   failure_reason: String
-  parent_id: DeploymentRequestId
+  #  parent_id should not be base64 encoded, so let's keep it as a String instead of DeploymentRequestId
+  parent_id: String
   url: String
 }
 

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -1603,7 +1603,7 @@ export type PlatformDeploymentRequest = {
   ordering: Scalars['Int']['output'];
   organization_domains: Maybe<Array<Scalars['String']['output']>>;
   organization_name: Scalars['String']['output'];
-  parent_id: Maybe<Scalars['DeploymentRequestId']['output']>;
+  parent_id: Maybe<Scalars['String']['output']>;
   platform_id: Maybe<Scalars['String']['output']>;
   platform_identifier: Maybe<PlatformIdentifier>;
   platform_token: Scalars['String']['output'];

--- a/apps/frontend/schema.graphql
+++ b/apps/frontend/schema.graphql
@@ -396,7 +396,7 @@ type PlatformDeploymentRequest {
   platform_id: String
   platform_url: String
   failure_reason: String
-  parent_id: DeploymentRequestId
+  parent_id: String
   url: String
 }
 


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

parent_id for platform should not be base 64 encoded

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

create a bundle, retrieve the list of trials, with `deploymentRequests` query, and check the parent_id is not base64 encoded

## Related issues

- Related to #3074

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.