### PR TITLE
feat(proxy): add redirect for trailing backslash on cybersecurity slug path (#3077)

### DIFF
--- a/apps/frontend/app/proxy.test.ts
+++ b/apps/frontend/app/proxy.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { proxy } from '../proxy';
+
+const proxyMocks = vi.hoisted(() => ({
+  manageRequestMock: vi.fn(),
+  intlMiddlewareMock: vi.fn(),
+}));
+
+vi.mock('@/utils/middleware/graphql-request.util', () => ({
+  manageRequest: proxyMocks.manageRequestMock,
+}));
+
+vi.mock('next-intl/middleware', () => ({
+  default: vi.fn(() => proxyMocks.intlMiddlewareMock),
+}));
+
+const BASE_URL = 'http://localhost:3002';
+
+describe('proxy', () => {
+  beforeEach(() => {
+    proxyMocks.manageRequestMock.mockResolvedValue(null);
+    proxyMocks.intlMiddlewareMock.mockReturnValue(NextResponse.next());
+  });
+
+  it('should redirect trailing encoded backslash on public cybersecurity slug path', async () => {
+    const request = new NextRequest(
+      `${BASE_URL}/en/cybersecurity-solutions/my-slug%5C?foo=bar`
+    );
+
+    const response = await proxy(request, {} as never);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('location')).toBe(
+      `${BASE_URL}/en/cybersecurity-solutions/my-slug?foo=bar`
+    );
+    expect(proxyMocks.intlMiddlewareMock).not.toHaveBeenCalled();
+  });
+
+  it('should redirect trailing encoded backslash on public cybersecurity docSlug path', async () => {
+    const request = new NextRequest(
+      `${BASE_URL}/en/cybersecurity-solutions/my-slug/my-doc%5C?foo=bar`
+    );
+
+    const response = await proxy(request, {} as never);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('location')).toBe(
+      `${BASE_URL}/en/cybersecurity-solutions/my-slug/my-doc?foo=bar`
+    );
+    expect(proxyMocks.intlMiddlewareMock).not.toHaveBeenCalled();
+  });
+
+  it('should not redirect when another backslash marker exists in the same public slug path', async () => {
+    const request = new NextRequest(
+      `${BASE_URL}/en/cybersecurity-solutions/my%5Cslug%5C`
+    );
+
+    await proxy(request, {} as never);
+
+    expect(proxyMocks.intlMiddlewareMock).toHaveBeenCalledOnce();
+  });
+
+  it('should not redirect trailing encoded backslash outside public cybersecurity slug path', async () => {
+    const request = new NextRequest(`${BASE_URL}/en/other-path%5C`);
+
+    await proxy(request, {} as never);
+
+    expect(proxyMocks.intlMiddlewareMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/proxy.ts
+++ b/apps/frontend/proxy.ts
@@ -1,5 +1,6 @@
 import { defaultLocale, publicLocales } from '@/i18n/config';
 import { manageRequest } from '@/utils/middleware/graphql-request.util';
+import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
 import createMiddleware from 'next-intl/middleware';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
@@ -12,6 +13,10 @@ const intlMiddleware = createMiddleware({
 const PUBLIC_LOCALE_PATH = new RegExp(
   `^/(${publicLocales.join('|')})(/|$)|^/$`
 );
+const PUBLIC_CYBERSECURITY_SOLUTION_ROUTE_PATH = new RegExp(
+  `^/(${publicLocales.join('|')})/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/[^/]+(?:/[^/]+)?$`,
+  'i'
+);
 
 export async function proxy(request: NextRequest, _: NextFetchEvent) {
   const proxyResponse = await manageRequest(request);
@@ -20,6 +25,24 @@ export async function proxy(request: NextRequest, _: NextFetchEvent) {
   }
 
   const { pathname } = request.nextUrl;
+
+  const trailingBackslashMatch = pathname.match(/(?:\\|%5c)$/i);
+  if (trailingBackslashMatch) {
+    const pathnameWithoutTrailingBackslash = pathname.slice(
+      0,
+      -trailingBackslashMatch[0].length
+    );
+    if (
+      PUBLIC_CYBERSECURITY_SOLUTION_ROUTE_PATH.test(
+        pathnameWithoutTrailingBackslash
+      ) &&
+      !/(\\|%5c)/i.test(pathnameWithoutTrailingBackslash)
+    ) {
+      const redirectUrl = request.nextUrl.clone();
+      redirectUrl.pathname = pathnameWithoutTrailingBackslash;
+      return NextResponse.redirect(redirectUrl, 308);
+    }
+  }
 
   if (PUBLIC_LOCALE_PATH.test(pathname) || !pathname.startsWith('/app')) {
     return intlMiddleware(request);


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- go to a resource route with a trailing `%5C` character
- resource detail page must be displayed

## Related issues

- Related to #3077

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [x] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.